### PR TITLE
Change default operation to multiplication

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -130,7 +130,7 @@ export default function App() {
     currentTask: 1,
     totalTasks: TOTAL_TASKS,
     gameMode: GameMode.NORMAL,
-    operation: Operation.ADDITION,
+    operation: Operation.MULTIPLICATION,
     questionPart: 2,
     showResult: false,
     lastAnswerCorrect: null,


### PR DESCRIPTION
## Summary
- Set initial operation to MULTIPLICATION instead of ADDITION
- Users can still switch to addition via settings menu

## Test plan
- [ ] Verify app starts with multiplication mode active
- [ ] Verify users can still switch to addition via settings
- [ ] Test that the game works correctly with multiplication tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)