### PR TITLE
fix: CI/CD Android build compatibility

### DIFF
--- a/Android/gradle.properties
+++ b/Android/gradle.properties
@@ -23,4 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Use Java 23 toolchain (Kotlin 2.2.21 doesn't support Java 25 yet)
-org.gradle.java.home=/Users/svenstrohkark/Library/Java/JavaVirtualMachines/valhalla-ea-23-valhalla+1-90/Contents/Home
+# org.gradle.java.home=/Users/svenstrohkark/Library/Java/JavaVirtualMachines/valhalla-ea-23-valhalla+1-90/Contents/Home
+# Note: Commented out for CI/CD compatibility - GitHub Actions provides its own Java


### PR DESCRIPTION
## Problem
CI/CD Android build failed with:
```
Value '/Users/svenstrohkark/Library/Java/JavaVirtualMachines/valhalla-ea-23-valhalla+1-90/Contents/Home' 
given for org.gradle.java.home Gradle property is invalid
```

## Solution
Removed hardcoded local Java home path from `Android/gradle.properties`.
GitHub Actions provides its own Java environment (Java 17).

## Changes
- `Android/gradle.properties`: Commented out `org.gradle.java.home`
- Added note explaining CI/CD compatibility

## Testing
- [ ] CI/CD pipeline runs successfully
- [ ] Android build completes without errors
- [ ] Web build still works
- [ ] All quality checks pass

## Impact
This fix allows the Android build to work in CI/CD while maintaining local development flexibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>