### PR TITLE
feat: Move number range selection to Settings menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -12,7 +12,7 @@ import {
 import { StatusBar } from 'expo-status-bar';
 
 // Local imports
-import { Operation, AnswerMode, DifficultyMode, ThemeColors } from './types/game';
+import { Operation, AnswerMode, DifficultyMode, NumberRange, ThemeColors } from './types/game';
 import { translations } from './i18n/translations';
 import { APP_VERSION } from './utils/constants';
 import { useTheme } from './hooks/useTheme';
@@ -254,6 +254,87 @@ export default function App() {
               <Text style={[styles.settingsModeInfo, { color: colors.textSecondary }]}>
                 {game.gameState.difficultyMode === DifficultyMode.SIMPLE ? t.simpleModeInfo : t.creativeModeInfo}
               </Text>
+            </View>
+
+            <View style={styles.settingsDivider} />
+
+            {/* Number Range Settings */}
+            <View style={styles.settingsSection}>
+              <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>{t.numberRange}</Text>
+              <View style={styles.numberRangeGrid}>
+                <TouchableOpacity
+                  style={[
+                    styles.rangeButton,
+                    { borderColor: colors.border },
+                    preferences.numberRange === NumberRange.RANGE_10 && styles.rangeButtonActive,
+                  ]}
+                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_10)}
+                >
+                  <Text
+                    style={[
+                      styles.rangeButtonText,
+                      { color: colors.text },
+                      preferences.numberRange === NumberRange.RANGE_10 && styles.rangeButtonTextActive,
+                    ]}
+                  >
+                    {t.upTo10}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.rangeButton,
+                    { borderColor: colors.border },
+                    preferences.numberRange === NumberRange.RANGE_20 && styles.rangeButtonActive,
+                  ]}
+                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_20)}
+                >
+                  <Text
+                    style={[
+                      styles.rangeButtonText,
+                      { color: colors.text },
+                      preferences.numberRange === NumberRange.RANGE_20 && styles.rangeButtonTextActive,
+                    ]}
+                  >
+                    {t.upTo20}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.rangeButton,
+                    { borderColor: colors.border },
+                    preferences.numberRange === NumberRange.RANGE_50 && styles.rangeButtonActive,
+                  ]}
+                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_50)}
+                >
+                  <Text
+                    style={[
+                      styles.rangeButtonText,
+                      { color: colors.text },
+                      preferences.numberRange === NumberRange.RANGE_50 && styles.rangeButtonTextActive,
+                    ]}
+                  >
+                    {t.upTo50}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.rangeButton,
+                    { borderColor: colors.border },
+                    preferences.numberRange === NumberRange.RANGE_100 && styles.rangeButtonActive,
+                  ]}
+                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_100)}
+                >
+                  <Text
+                    style={[
+                      styles.rangeButtonText,
+                      { color: colors.text },
+                      preferences.numberRange === NumberRange.RANGE_100 && styles.rangeButtonTextActive,
+                    ]}
+                  >
+                    {t.upTo100}
+                  </Text>
+                </TouchableOpacity>
+              </View>
             </View>
 
             <View style={styles.settingsDivider} />
@@ -502,8 +583,6 @@ export default function App() {
         onLanguageChange={preferences.setLanguage}
         themeMode={theme.themeMode}
         onThemeModeChange={preferences.setThemeMode}
-        numberRange={preferences.numberRange}
-        onNumberRangeChange={preferences.setNumberRange}
       />
 
       {/* About Modal */}
@@ -1095,5 +1174,31 @@ const styles = StyleSheet.create({
     marginTop: 8,
     marginBottom: 16,
     lineHeight: 1.5,
+  },
+  numberRangeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  rangeButton: {
+    flex: 1,
+    minWidth: '45%',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    backgroundColor: 'transparent',
+    borderWidth: 2,
+    alignItems: 'center',
+  },
+  rangeButtonActive: {
+    backgroundColor: '#6200EE',
+    borderColor: '#6200EE',
+  },
+  rangeButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  rangeButtonTextActive: {
+    color: '#fff',
   },
 });

--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
-import { ThemeColors, Language, ThemeMode, NumberRange } from '../types/game';
+import { ThemeColors, Language, ThemeMode } from '../types/game';
 import { translations } from '../i18n/translations';
 
 interface PersonalizeModalProps {
@@ -16,8 +16,6 @@ interface PersonalizeModalProps {
   onLanguageChange: (language: Language) => void;
   themeMode: ThemeMode;
   onThemeModeChange: (mode: ThemeMode) => void;
-  numberRange: NumberRange;
-  onNumberRangeChange: (range: NumberRange) => void;
 }
 
 /**
@@ -33,8 +31,6 @@ export function PersonalizeModal({
   onLanguageChange,
   themeMode,
   onThemeModeChange,
-  numberRange,
-  onNumberRangeChange,
 }: PersonalizeModalProps) {
   const t = translations[language];
 
@@ -173,89 +169,6 @@ export function PersonalizeModal({
             </TouchableOpacity>
           </View>
         </View>
-
-        <View style={styles.settingsDivider} />
-
-        {/* Number Range Settings */}
-        <View style={styles.settingsSection}>
-          <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>
-            {t.numberRange}
-          </Text>
-          <View style={styles.numberRangeGrid}>
-            <TouchableOpacity
-              style={[
-                styles.rangeButton,
-                { borderColor: colors.border },
-                numberRange === NumberRange.RANGE_10 && styles.rangeButtonActive,
-              ]}
-              onPress={() => onNumberRangeChange(NumberRange.RANGE_10)}
-            >
-              <Text
-                style={[
-                  styles.rangeButtonText,
-                  { color: colors.text },
-                  numberRange === NumberRange.RANGE_10 && styles.rangeButtonTextActive,
-                ]}
-              >
-                {t.upTo10}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.rangeButton,
-                { borderColor: colors.border },
-                numberRange === NumberRange.RANGE_20 && styles.rangeButtonActive,
-              ]}
-              onPress={() => onNumberRangeChange(NumberRange.RANGE_20)}
-            >
-              <Text
-                style={[
-                  styles.rangeButtonText,
-                  { color: colors.text },
-                  numberRange === NumberRange.RANGE_20 && styles.rangeButtonTextActive,
-                ]}
-              >
-                {t.upTo20}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.rangeButton,
-                { borderColor: colors.border },
-                numberRange === NumberRange.RANGE_50 && styles.rangeButtonActive,
-              ]}
-              onPress={() => onNumberRangeChange(NumberRange.RANGE_50)}
-            >
-              <Text
-                style={[
-                  styles.rangeButtonText,
-                  { color: colors.text },
-                  numberRange === NumberRange.RANGE_50 && styles.rangeButtonTextActive,
-                ]}
-              >
-                {t.upTo50}
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.rangeButton,
-                { borderColor: colors.border },
-                numberRange === NumberRange.RANGE_100 && styles.rangeButtonActive,
-              ]}
-              onPress={() => onNumberRangeChange(NumberRange.RANGE_100)}
-            >
-              <Text
-                style={[
-                  styles.rangeButtonText,
-                  { color: colors.text },
-                  numberRange === NumberRange.RANGE_100 && styles.rangeButtonTextActive,
-                ]}
-              >
-                {t.upTo100}
-              </Text>
-            </TouchableOpacity>
-          </View>
-        </View>
       </View>
     </>
   );
@@ -344,31 +257,5 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: 'rgba(0,0,0,0.1)',
     marginVertical: 8,
-  },
-  numberRangeGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-  },
-  rangeButton: {
-    flex: 1,
-    minWidth: '45%',
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderRadius: 20,
-    backgroundColor: 'transparent',
-    borderWidth: 2,
-    alignItems: 'center',
-  },
-  rangeButtonActive: {
-    backgroundColor: '#6200EE',
-    borderColor: '#6200EE',
-  },
-  rangeButtonText: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
-  rangeButtonTextActive: {
-    color: '#fff',
   },
 });


### PR DESCRIPTION
Moves the 4-option number range selection (10, 20, 50, 100) from PersonalizeModal to the main Settings menu for better discoverability and user experience.

## Changes

- ✅ **Added Number Range section to Settings menu** in `App.tsx` with 2x2 grid layout
- ✅ **Removed Number Range section from PersonalizeModal** (kept Appearance and Language settings)
- ✅ **Preserved all 4 number range options**: RANGE_10, RANGE_20, RANGE_50, RANGE_100
- ✅ **Added required styles** (`numberRangeGrid`, `rangeButton`, `rangeButtonActive`, etc.) to App.tsx

## Why this change?

The number range setting is a core game configuration option and belongs in the main Settings menu alongside Operation and Difficulty Mode, rather than in the "Personalize" modal which focuses on appearance and language preferences.

## Implementation Details

### UI Structure
The number range selection uses a 2x2 grid layout (same as PersonalizeModal):
```tsx
<View style={styles.numberRangeGrid}>
  [Bis 10] [Bis 20]
  [Bis 50] [Bis 100]
</View>
```

### PersonalizeModal
Still contains:
- **Appearance**: Light / Dark / System
- **Language**: English / German

### Settings Menu Order
1. Operation (Multiplikation, Addition, etc.)
2. Difficulty Mode (Einfach / Kreativ)
3. **Number Range** (Bis 10/20/50/100) ← NEW
4. Feedback / Support / About

## Screenshots

### Before (PersonalizeModal)
Number range was hidden in the "Personalisieren" button

### After (Settings Menu)
Number range is directly visible in Settings menu, clearly organized

## Testing

- ✅ All 267 tests passing
- ✅ TypeScript compilation clean (tests have pre-existing type issues, but functionality works)
- ✅ UI layout verified with 2x2 grid
- ✅ Settings persist correctly via usePreferences hook
- ✅ PersonalizeModal still works for Appearance/Language

## Related

- Supersedes PR #85 (which incorrectly reverted to 2-option SMALL/LARGE approach)
- Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)