### PR TITLE
Fix layout spacing between question and input field

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -937,6 +937,7 @@ const styles = StyleSheet.create({
     borderRadius: 24,
     padding: 24,
     alignItems: 'center',
+    justifyContent: 'space-between',
     // Multi-layer shadow for depth
     elevation: 8,
     shadowColor: '#000',
@@ -947,7 +948,7 @@ const styles = StyleSheet.create({
   questionRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 24,
+    marginBottom: 16,
   },
   questionText: {
     fontSize: 48,
@@ -969,8 +970,7 @@ const styles = StyleSheet.create({
   },
   answerArea: {
     width: '100%',
-    flex: 1,
-    justifyContent: 'flex-end',
+    flexShrink: 0,
   },
   numpad: {
     width: '100%',


### PR DESCRIPTION
## Summary
Fixes #58 - Improves layout spacing on Android devices by reducing excessive gaps.

## Problem
On older Android devices, there was too much spacing between the question and the input field, creating an unbalanced appearance with the keypad at the bottom and a large gap above it.

## Solution
- Add `justifyContent: 'space-between'` to questionCard for better space distribution
- Reduce `marginBottom` on questionRow from 24px to 16px
- Change answerArea from `flex: 1` to `flexShrink: 0` to prevent excessive stretching

## Changes
**App.tsx:**
- `questionCard`: Added `justifyContent: 'space-between'`
- `questionRow`: Reduced `marginBottom` from 24 to 16
- `answerArea`: Changed from `flex: 1, justifyContent: 'flex-end'` to `flexShrink: 0`

## Test plan
- [x] All 300 tests pass
- [x] Layout changes don't break existing functionality
- [ ] Manual testing on Android devices (old and new)
- [ ] Manual testing on iOS devices
- [ ] Web PWA testing in different viewport sizes

## Visual Impact
The new layout distributes vertical space more evenly, creating a balanced appearance across different screen sizes while maintaining proper spacing for usability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)