### PR TITLE
Add comprehensive iOS PWA icon support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,13 +16,23 @@
     <link rel="manifest" href="/1x1_Trainer/manifest.json" />
     <link rel="icon" type="image/png" sizes="128x128" href="/1x1_Trainer/icon-128.png" />
     <link rel="icon" type="image/png" sizes="96x96" href="/1x1_Trainer/icon-96.png" />
-    <link rel="apple-touch-icon" href="/1x1_Trainer/icon.png" />
-    <meta name="theme-color" content="#6200EE" />
+
+    <!-- iOS PWA Icons -->
+    <link rel="apple-touch-icon" href="/1x1_Trainer/icon-180.png?v=2" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/1x1_Trainer/icon-180.png?v=2" />
+    <link rel="apple-touch-icon" sizes="192x192" href="/1x1_Trainer/icon-192.png?v=2" />
+    <link rel="apple-touch-icon" sizes="512x512" href="/1x1_Trainer/icon-512.png?v=2" />
+
+    <!-- iOS PWA Configuration -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="1x1 Trainer" />
-    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-touch-fullscreen" content="yes" />
+
+    <!-- PWA Theme -->
+    <meta name="theme-color" content="#6200EE" />
+    <meta name="mobile-web-app-capable" content="yes" />
+
     <link rel="shortcut icon" href="/1x1_Trainer/icon-192.png" />
     <style>
       #root,

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,8 @@
     {
       "src": "/icon-180.png",
       "type": "image/png",
-      "sizes": "180x180"
+      "sizes": "180x180",
+      "purpose": "any maskable"
     },
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
## Summary
Fixes #37 - Implements iOS-specific meta tags and icon configuration for proper PWA home screen support.

## Problem
iOS requires specific meta tags and icon configurations for PWAs to display correctly when added to the home screen. Without proper configuration, the wrong icon may be used or cached incorrectly.

## Solution
Based on the successful implementation in [Energy_Price_Germany PR #113](https://github.com/S540d/Energy_Price_Germany/pull/113).

### Changes to `public/index.html`:
- ✅ Add multiple `apple-touch-icon` links with different sizes (180x180, 192x192, 512x512)
- ✅ Add cache-busting query strings (`?v=2`) to force iOS to recognize icon updates
- ✅ Change `apple-mobile-web-app-status-bar-style` to `black-translucent` for native-like appearance
- ✅ Reorganize meta tags with clear comments for better maintainability
- ✅ Use `icon-180.png` as primary iOS icon (standard iOS size)

### Changes to `public/manifest.json`:
- ✅ Add `purpose: any maskable` to icon-180.png for better iOS compatibility

## Benefits
- ✅ Correct icon display when adding to iOS home screen
- ✅ Cache-busting ensures icon updates are recognized by iOS
- ✅ Black-translucent status bar provides native-like appearance
- ✅ Follows iOS PWA best practices
- ✅ Better user experience on iOS devices

## Test plan
- [x] All 300 tests pass
- [ ] Test on iOS Safari: Add to home screen
- [ ] Verify correct icon appears on home screen
- [ ] Verify cache-busting works for icon updates
- [ ] Test status bar appearance (black-translucent)
- [ ] Test on different iOS versions (iOS 14+)
- [ ] Verify Android/Web remain unaffected

## Reference
- [Energy_Price_Germany PR #113](https://github.com/S540d/Energy_Price_Germany/pull/113)
- [iOS PWA Best Practices](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)