### PR TITLE
Improve Personalize button visibility in settings menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -117,15 +117,17 @@ export default function App() {
             </View>
 
             {/* Personalize Button */}
-            <TouchableOpacity
-              style={styles.settingsMenuLink}
-              onPress={() => {
-                setPersonalizeVisible(true);
-                setMenuVisible(false);
-              }}
-            >
-              <Text style={styles.settingsMenuLinkText}>{t.personalize}</Text>
-            </TouchableOpacity>
+            <View style={styles.settingsSection}>
+              <TouchableOpacity
+                style={[styles.personalizeButton, { borderColor: colors.border }]}
+                onPress={() => {
+                  setPersonalizeVisible(true);
+                  setMenuVisible(false);
+                }}
+              >
+                <Text style={[styles.personalizeButtonText, { color: colors.text }]}>{t.personalize}</Text>
+              </TouchableOpacity>
+            </View>
 
             <View style={styles.settingsDivider} />
 
@@ -818,6 +820,19 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#6200EE',
+  },
+  personalizeButton: {
+    width: '100%',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    backgroundColor: 'transparent',
+    borderWidth: 2,
+    alignItems: 'center',
+  },
+  personalizeButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
   settingsSection: {
     paddingHorizontal: 16,


### PR DESCRIPTION
## Summary
Fixes #93 - Makes the Personalize button more recognizable in the settings menu.

## Problem
The Personalize button was difficult to recognize as it used a simple link style with only a top border, making it blend in with other menu items.

## Solution
Updated the Personalize button to match the visual style of unselected operation buttons (Addition, Subtraction, etc.):
- Oval gray border (`borderRadius: 20`, `borderWidth: 2`)
- Transparent background with theme-aware border color
- Increased padding for better touch target and visual prominence
- Consistent spacing with other settings sections

## Changes
**App.tsx:**
- Wrapped Personalize button in `settingsSection` container
- Applied new `personalizeButton` style with oval border
- Added `personalizeButtonText` style
- Border color adapts to theme (light/dark mode)

## Visual Impact
**Before:** Simple link-style button with minimal visual weight  
**After:** Prominent oval button matching operation button style

## Test plan
- [x] All 300 tests pass
- [x] Button renders correctly in settings menu
- [ ] Manual testing: Check button visibility in light mode
- [ ] Manual testing: Check button visibility in dark mode
- [ ] Manual testing: Verify touch target is adequate
- [ ] Manual testing: Button opens PersonalizeModal correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)