### PR TITLE
fix: Challenge-Modus Verbesserungen (#110)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -268,78 +268,38 @@ export default function App() {
             <View style={styles.settingsSection}>
               <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>{t.numberRange}</Text>
               <View style={styles.numberRangeGrid}>
-                <TouchableOpacity
-                  style={[
-                    styles.rangeButton,
-                    { borderColor: colors.border },
-                    preferences.numberRange === NumberRange.RANGE_10 && styles.rangeButtonActive,
-                  ]}
-                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_10)}
-                >
-                  <Text
-                    style={[
-                      styles.rangeButtonText,
-                      { color: colors.text },
-                      preferences.numberRange === NumberRange.RANGE_10 && styles.rangeButtonTextActive,
-                    ]}
-                  >
-                    {t.upTo10}
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[
-                    styles.rangeButton,
-                    { borderColor: colors.border },
-                    preferences.numberRange === NumberRange.RANGE_20 && styles.rangeButtonActive,
-                  ]}
-                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_20)}
-                >
-                  <Text
-                    style={[
-                      styles.rangeButtonText,
-                      { color: colors.text },
-                      preferences.numberRange === NumberRange.RANGE_20 && styles.rangeButtonTextActive,
-                    ]}
-                  >
-                    {t.upTo20}
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[
-                    styles.rangeButton,
-                    { borderColor: colors.border },
-                    preferences.numberRange === NumberRange.RANGE_50 && styles.rangeButtonActive,
-                  ]}
-                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_50)}
-                >
-                  <Text
-                    style={[
-                      styles.rangeButtonText,
-                      { color: colors.text },
-                      preferences.numberRange === NumberRange.RANGE_50 && styles.rangeButtonTextActive,
-                    ]}
-                  >
-                    {t.upTo50}
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[
-                    styles.rangeButton,
-                    { borderColor: colors.border },
-                    preferences.numberRange === NumberRange.RANGE_100 && styles.rangeButtonActive,
-                  ]}
-                  onPress={() => preferences.setNumberRange(NumberRange.RANGE_100)}
-                >
-                  <Text
-                    style={[
-                      styles.rangeButtonText,
-                      { color: colors.text },
-                      preferences.numberRange === NumberRange.RANGE_100 && styles.rangeButtonTextActive,
-                    ]}
-                  >
-                    {t.upTo100}
-                  </Text>
-                </TouchableOpacity>
+                {([
+                  { range: NumberRange.RANGE_10, label: t.upTo10 },
+                  { range: NumberRange.RANGE_20, label: t.upTo20 },
+                  { range: NumberRange.RANGE_50, label: t.upTo50 },
+                  { range: NumberRange.RANGE_100, label: t.upTo100 },
+                ] as const).map(({ range, label }) => {
+                  const isChallengeMode = game.gameState.difficultyMode === DifficultyMode.CHALLENGE;
+                  const isActive = isChallengeMode ? range === NumberRange.RANGE_100 : preferences.numberRange === range;
+                  return (
+                    <TouchableOpacity
+                      key={range}
+                      style={[
+                        styles.rangeButton,
+                        { borderColor: colors.border },
+                        isActive && styles.rangeButtonActive,
+                        isChallengeMode && { opacity: 0.6 },
+                      ]}
+                      onPress={() => preferences.setNumberRange(range)}
+                      disabled={isChallengeMode}
+                    >
+                      <Text
+                        style={[
+                          styles.rangeButtonText,
+                          { color: colors.text },
+                          isActive && styles.rangeButtonTextActive,
+                        ]}
+                      >
+                        {label}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
               </View>
             </View>
 

--- a/hooks/useGameLogic.test.tsx
+++ b/hooks/useGameLogic.test.tsx
@@ -637,10 +637,31 @@ describe('useGameLogic Hook', () => {
 
   // Helper to enter answer digit by digit
   const enterAnswer = (result: any, answer: number) => {
-    const answerStr = answer.toString();
-    for (const digit of answerStr) {
+    if (result.current.gameState.answerMode === AnswerMode.INPUT) {
+      const answerStr = answer.toString();
+      for (const digit of answerStr) {
+        act(() => {
+          result.current.handleNumberClick(parseInt(digit));
+        });
+      }
+    } else {
+      // MULTIPLE_CHOICE or NUMBER_SEQUENCE: select the correct value
       act(() => {
-        result.current.handleNumberClick(parseInt(digit));
+        result.current.handleChoiceClick(answer);
+      });
+    }
+  };
+
+  const enterWrongAnswer = (result: any) => {
+    const correctAnswer = result.current.getCorrectAnswer();
+    if (result.current.gameState.answerMode === AnswerMode.INPUT) {
+      act(() => {
+        result.current.handleNumberClick(0);
+      });
+    } else {
+      // Pick a wrong value (correctAnswer + 1 is never correct)
+      act(() => {
+        result.current.handleChoiceClick(correctAnswer + 1000);
       });
     }
   };
@@ -1942,9 +1963,7 @@ describe('useGameLogic Hook', () => {
       jest.runAllTimers();
 
       // Enter a deliberately wrong answer
-      act(() => {
-        result.current.handleNumberClick(0);
-      });
+      enterWrongAnswer(result);
       act(() => {
         result.current.checkAnswer();
       });
@@ -1968,9 +1987,7 @@ describe('useGameLogic Hook', () => {
         });
         jest.runAllTimers();
 
-        act(() => {
-          result.current.handleNumberClick(0);
-        });
+        enterWrongAnswer(result);
         act(() => {
           result.current.checkAnswer();
         });
@@ -2049,9 +2066,7 @@ describe('useGameLogic Hook', () => {
       });
       jest.runAllTimers();
 
-      act(() => {
-        result.current.handleNumberClick(0);
-      });
+      enterWrongAnswer(result);
       act(() => {
         result.current.checkAnswer();
       });
@@ -2128,9 +2143,7 @@ describe('useGameLogic Hook', () => {
         });
         jest.runAllTimers();
 
-        act(() => {
-          result.current.handleNumberClick(0);
-        });
+        enterWrongAnswer(result);
         act(() => {
           result.current.checkAnswer();
         });


### PR DESCRIPTION
## Summary
- Zahlenraum im Challenge-Modus gesperrt und auf "bis 100" vorausgewählt (analog zu Rechenarten)
- Aufgabenverteilung bei Multiplikation/Division: Alle gültigen Faktorpaare werden gleichmäßig gesampelt (statt sequentiell, was kleine Faktoren bevorzugte)
- Antwortmodus wechselt nun auch im Challenge-Modus zwischen INPUT, MULTIPLE_CHOICE und NUMBER_SEQUENCE

Closes #110

## Test plan
- [x] Alle 337 Tests bestehen (334 passed, 3 skipped)
- [x] Tests für falsche Antworten nutzen answerMode-aware Hilfsfunktion
- [ ] Manuell: Challenge starten → Zahlenraum-Buttons ausgegraut
- [ ] Manuell: Challenge spielen → Antwortmodus wechselt
- [ ] Manuell: Aufgabenverteilung beobachten → weniger 1×x Aufgaben

🤖 Generated with [Claude Code](https://claude.com/claude-code)