### PR TITLE
feat: Über-Dialog um Kontakt und Lizenzdetails erweitert (#105)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -640,7 +640,13 @@ export default function App() {
               {t.version} {APP_VERSION}
             </Text>
             <Text style={[styles.aboutModalInfoText, { color: colors.textSecondary }]}>
+              {t.copyright}
+            </Text>
+            <Text style={[styles.aboutModalInfoText, { color: colors.textSecondary }]}>
               {t.license}
+            </Text>
+            <Text style={[styles.aboutModalInfoText, { color: colors.textSecondary }]}>
+              {t.contact}
             </Text>
             <TouchableOpacity
               style={styles.restartButton}

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -41,6 +41,7 @@ export interface TranslationStrings {
   version: string;
   copyright: string;
   license: string;
+  contact: string;
   // Game UI
   task: string;
   points: string;
@@ -116,7 +117,8 @@ export const translations: Record<Language, TranslationStrings> = {
     about: 'ABOUT',
     version: 'Version',
     copyright: '© 2025 Sven Strohkark',
-    license: 'License: MIT',
+    license: 'License: MIT – Free for non-commercial use',
+    contact: 'Contact: devsven@posteo.de',
     // Game UI
     task: 'Task',
     points: 'Points',
@@ -190,7 +192,8 @@ export const translations: Record<Language, TranslationStrings> = {
     about: 'ÜBER',
     version: 'Version',
     copyright: '© 2025 Sven Strohkark',
-    license: 'Lizenz: MIT',
+    license: 'Lizenz: MIT – Frei für nicht-kommerzielle Nutzung',
+    contact: 'Kontakt: devsven@posteo.de',
     // Game UI
     task: 'Aufgabe',
     points: 'Punkte',


### PR DESCRIPTION
## Summary
- Copyright-Zeile (© 2025 Sven Strohkark) im Über-Dialog hinzugefügt
- Lizenzinfo um Nutzungshinweis ergänzt ("MIT – Frei für nicht-kommerzielle Nutzung")
- Kontakt-Mailadresse hinzugefügt
- Übersetzungen für DE und EN aktualisiert

Closes #105

## Test plan
- [x] Alle 337 Tests bestehen
- [ ] Manuell: Über-Dialog öffnen → Version, Copyright, Lizenz und Kontakt sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)