### PR TITLE
feat: extend pre-commit hook with sensitive data checks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,8 +55,19 @@ Validation rules enforced by Husky (`.husky/pre-commit`):
 1. **No console.log/debug** (except in scripts/)
 2. **Platform-safe Web API usage** (window.*, localStorage.*)
 3. **Version consistency** (package.json vs app.json)
+4. **Sensitive account identifiers** – prüft staged Diff (nur `+`-Zeilen):
+   - `app.json`: blockiert `projectId`, `owner`-Feld, `com.sven*` Package-Namen
+   - Workflow-Dateien: blockiert hardcodierte SHA1-Signing-Fingerabdrücke
+   - Interne Docs (`docs/ANDROID_BUILD.md`, `docs/RELEASE_CHECKLIST.md`, `scripts/setup-twa-step1.sh`, `.claude/CLAUDE.md`): **Warnung** (nicht blockierend)
 
 **Note:** grep pipes use `|| true` to prevent false failures under `set -e` when no TS/JS files are staged.
+
+### CI Privacy-Check (GitHub Actions)
+Der `security` Job in `.github/workflows/ci-cd.yml` enthält den Step **"Check for account-specific identifiers"**:
+- Prüft den **vollständigen Repo-Zustand** (nicht nur den Diff)
+- **Blockiert PRs** solange sensitive Daten im Repo vorhanden sind (Issue #150)
+- Geprüfte Patterns: `projectId`/`owner` in app.json, `com.sven*` Package-Namen, SHA1-Fingerabdrücke in Workflows, interne Docs, `.claude/` Verzeichnis
+- Wird grün, sobald Issue #150 vollständig umgesetzt ist
 
 #### Testing & Environments (3-Tier Workflow)
 | Environment | URL | Branch | Purpose |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -202,6 +202,64 @@ jobs:
 
           echo "✅ No obvious secrets found"
 
+      - name: Check for account-specific identifiers (Issue #150)
+        run: |
+          echo "Checking for account-specific identifiers..."
+          FOUND=0
+
+          # app.json: EAS projectId must not be committed
+          if grep -q '"projectId"' app.json 2>/dev/null; then
+            echo "❌ app.json enthält 'projectId' (EAS Account-Verknüpfung)"
+            echo "   → Lokal halten, zur Build-Zeit per Umgebungsvariable injizieren"
+            FOUND=1
+          fi
+
+          # app.json: owner field must not be committed
+          if grep -q '"owner"\s*:' app.json 2>/dev/null; then
+            echo "❌ app.json enthält 'owner' (persönlicher Expo-Account)"
+            echo "   → Lokal halten, zur Build-Zeit per Umgebungsvariable injizieren"
+            FOUND=1
+          fi
+
+          # app.json: personal package names must not be committed
+          if grep -qE '"(package|bundleIdentifier)"\s*:\s*"com\.sven' app.json 2>/dev/null; then
+            echo "❌ app.json enthält persönliche Store-Package-Namen (com.sven...)"
+            echo "   → Lokal halten, nicht im öffentlichen Repo"
+            FOUND=1
+          fi
+
+          # Workflow files: hardcoded SHA1 signing fingerprint
+          if grep -rqiE "EXPECTED_SHA1\s*=|SHA1\s*=\s*['\"][0-9A-F:]{2}" .github/workflows/ 2>/dev/null; then
+            echo "❌ Hardcoded SHA1-Signing-Fingerabdruck in Workflow-Datei gefunden"
+            echo "   → Als GitHub Secret auslagern (ANDROID_KEY_SHA1)"
+            FOUND=1
+          fi
+
+          # Internal docs must not be in the repo
+          for internal_doc in "docs/ANDROID_BUILD.md" "docs/RELEASE_CHECKLIST.md" "scripts/setup-twa-step1.sh"; do
+            if [ -f "$internal_doc" ]; then
+              echo "❌ Interne Datei im Repo: $internal_doc"
+              echo "   → Lokal halten, aus Repo entfernen und in .gitignore eintragen"
+              FOUND=1
+            fi
+          done
+
+          # .claude/ directory must not be in the repo
+          if [ -d ".claude" ]; then
+            echo "❌ .claude/ Verzeichnis ist im Repo (AI-Tool-Konfiguration)"
+            echo "   → Lokal halten, in .gitignore eintragen (Issue #150)"
+            FOUND=1
+          fi
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo ""
+            echo "Bereinigung erforderlich – siehe Issue #150:"
+            echo "https://github.com/S540d/1x1_Trainer/issues/150"
+            exit 1
+          fi
+
+          echo "✅ Keine account-spezifischen Identifier gefunden"
+
   # ============================================================================
   # JOB 5: Release Readiness Report
   # ============================================================================

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -51,7 +51,7 @@ STAGED_ALL=$(git diff --cached --name-only || true)
 # app.json: EAS projectId, owner, and personal package names must not be re-added
 if echo "$STAGED_ALL" | grep -q "app\.json"; then
   STAGED_APPJSON_NEW=$(git diff --cached app.json | grep "^+" | grep -v "^+++" || true)
-  if echo "$STAGED_APPJSON_NEW" | grep -qE '"projectId"|"owner"\s*:'; then
+  if echo "$STAGED_APPJSON_NEW" | grep -qE '"(projectId|owner)"\s*:'; then
     echo "❌ ERROR: app.json enthält account-spezifische EAS-Daten (projectId/owner)!"
     echo "Diese Felder lokal halten und zur Build-Zeit per Umgebungsvariable injizieren."
     echo "Siehe Issue #150."
@@ -67,7 +67,7 @@ fi
 # Workflow files: SHA1 signing fingerprint must not be hardcoded
 if echo "$STAGED_ALL" | grep -qE "\.github/workflows/"; then
   STAGED_WORKFLOW_NEW=$(git diff --cached -- .github/workflows/ | grep "^+" | grep -v "^+++" || true)
-  if echo "$STAGED_WORKFLOW_NEW" | grep -qiE "EXPECTED_SHA1\s*=|SHA1\s*=\s*['\"][0-9A-F:]{2}"; then
+  if echo "$STAGED_WORKFLOW_NEW" | grep -vE '\$\{\{|\$[A-Z_]+' | grep -qiE "([0-9A-Fa-f]{2}:){19}[0-9A-Fa-f]{2}"; then
     echo "❌ ERROR: Hardcoded SHA1-Signing-Fingerabdruck in Workflow-Datei!"
     echo "Als GitHub Secret auslagern (z.B. ANDROID_KEY_SHA1). Siehe Issue #150."
     exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -44,4 +44,42 @@ if git diff --cached --name-only | grep -E "(package\.json|app\.json|App\.tsx|bu
   fi
 fi
 
+# Check for sensitive account identifiers being (re-)introduced
+echo "Checking for sensitive account identifiers..."
+STAGED_ALL=$(git diff --cached --name-only || true)
+
+# app.json: EAS projectId, owner, and personal package names must not be re-added
+if echo "$STAGED_ALL" | grep -q "app\.json"; then
+  STAGED_APPJSON_NEW=$(git diff --cached app.json | grep "^+" | grep -v "^+++" || true)
+  if echo "$STAGED_APPJSON_NEW" | grep -qE '"projectId"|"owner"\s*:'; then
+    echo "❌ ERROR: app.json enthält account-spezifische EAS-Daten (projectId/owner)!"
+    echo "Diese Felder lokal halten und zur Build-Zeit per Umgebungsvariable injizieren."
+    echo "Siehe Issue #150."
+    exit 1
+  fi
+  if echo "$STAGED_APPJSON_NEW" | grep -qE '"(package|bundleIdentifier)"\s*:\s*"com\.sven'; then
+    echo "❌ ERROR: app.json enthält persönliche Store-Package-Namen (com.sven...)!"
+    echo "Persönliche Identifikatoren lokal halten. Siehe Issue #150."
+    exit 1
+  fi
+fi
+
+# Workflow files: SHA1 signing fingerprint must not be hardcoded
+if echo "$STAGED_ALL" | grep -qE "\.github/workflows/"; then
+  STAGED_WORKFLOW_NEW=$(git diff --cached -- .github/workflows/ | grep "^+" | grep -v "^+++" || true)
+  if echo "$STAGED_WORKFLOW_NEW" | grep -qiE "EXPECTED_SHA1\s*=|SHA1\s*=\s*['\"][0-9A-F:]{2}"; then
+    echo "❌ ERROR: Hardcoded SHA1-Signing-Fingerabdruck in Workflow-Datei!"
+    echo "Als GitHub Secret auslagern (z.B. ANDROID_KEY_SHA1). Siehe Issue #150."
+    exit 1
+  fi
+fi
+
+# Internal docs: warn (not block) when being staged
+for internal_doc in "docs/ANDROID_BUILD.md" "docs/RELEASE_CHECKLIST.md" "scripts/setup-twa-step1.sh" ".claude/CLAUDE.md"; do
+  if echo "$STAGED_ALL" | grep -qF "$internal_doc"; then
+    echo "⚠️  WARNUNG: Interne Datei wird committed: $internal_doc"
+    echo "   Prüfe, ob diese Datei im öffentlichen Repo sein soll (Issue #150)."
+  fi
+done
+
 echo "✅ Pre-commit checks passed!"


### PR DESCRIPTION
Prevents re-introduction of account-specific identifiers after cleanup:
- app.json: blocks projectId, owner field, and com.sven* package names
- Workflow files: blocks hardcoded SHA1 signing fingerprints
- Internal docs: warns (non-blocking) when staged

Checks use staged diff (only new + lines) so existing content
can still be committed during cleanup (Issue #150).

https://claude.ai/code/session_01NffxXWPQ6nntQMTaJhLGZ3