### PR TITLE
fix: UX-Bugfixes (Issue #159)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -217,7 +217,6 @@ export default function App() {
       {menuRendered && (
         <SettingsMenu
           colors={colors}
-          isDarkMode={isDarkMode}
           screenHeight={screenHeight}
           menuAnimatedStyle={menuAnimatedStyle}
           difficultyMode={game.gameState.difficultyMode}

--- a/App.tsx
+++ b/App.tsx
@@ -217,6 +217,7 @@ export default function App() {
       {menuRendered && (
         <SettingsMenu
           colors={colors}
+          isDarkMode={isDarkMode}
           screenHeight={screenHeight}
           menuAnimatedStyle={menuAnimatedStyle}
           difficultyMode={game.gameState.difficultyMode}

--- a/__mocks__/@expo-google-fonts.js
+++ b/__mocks__/@expo-google-fonts.js
@@ -1,0 +1,3 @@
+module.exports = {
+  useFonts: () => [true, null],
+};

--- a/__mocks__/expo-font.js
+++ b/__mocks__/expo-font.js
@@ -1,0 +1,4 @@
+module.exports = {
+  useFonts: () => [true, null],
+  loadAsync: () => Promise.resolve(),
+};

--- a/__mocks__/expo-linear-gradient.js
+++ b/__mocks__/expo-linear-gradient.js
@@ -1,0 +1,7 @@
+const React = require('react');
+const { View } = require('react-native');
+
+const LinearGradient = ({ children, style }) =>
+  React.createElement(View, { style }, children);
+
+module.exports = { LinearGradient };

--- a/__mocks__/expo-status-bar.js
+++ b/__mocks__/expo-status-bar.js
@@ -1,0 +1,5 @@
+const React = require('react');
+
+module.exports = {
+  StatusBar: () => React.createElement('StatusBar'),
+};

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     paddingHorizontal: 10,
     paddingVertical: 4,
-    alignSelf: 'flex-start',
+    alignSelf: 'center',
   },
   text: {
     fontSize: 13,

--- a/components/GameCard.test.tsx
+++ b/components/GameCard.test.tsx
@@ -233,18 +233,18 @@ describe('GameCard - Button accessibility', () => {
         <GameCard {...defaultProps} gameState={inputState} />
       );
 
-      expect(getByText('←')).toBeTruthy();
+      expect(getByText('⌫')).toBeTruthy();
     });
 
-    it('renders check button (✓)', () => {
+    it('renders check button', () => {
       const { getByText } = render(
         <GameCard {...defaultProps} gameState={inputState} />
       );
 
-      expect(getByText('✓')).toBeTruthy();
+      expect(getByText('Prüfen')).toBeTruthy();
     });
 
-    it('renders next button (→) after answer is checked', () => {
+    it('renders next button after answer is checked', () => {
       const checkedState: GameState = {
         ...inputState,
         isAnswerChecked: true,
@@ -254,7 +254,7 @@ describe('GameCard - Button accessibility', () => {
         <GameCard {...defaultProps} gameState={checkedState} />
       );
 
-      expect(getByText('→')).toBeTruthy();
+      expect(getByText('Weiter →')).toBeTruthy();
     });
   });
 
@@ -318,9 +318,8 @@ describe('GameCard - Button accessibility', () => {
         <GameCard {...defaultProps} gameState={state} />
       );
 
-      // Numpad digits should not be present (except those that match choice values)
-      expect(queryByText('←')).toBeNull();
-      expect(queryByText('✓')).toBeNull();
+      // Numpad-specific elements must not be present
+      expect(queryByText('⌫')).toBeNull();
     });
 
     it('does not render numpad in NUMBER_SEQUENCE mode', () => {
@@ -332,16 +331,17 @@ describe('GameCard - Button accessibility', () => {
         <GameCard {...defaultProps} gameState={state} />
       );
 
-      expect(queryByText('←')).toBeNull();
-      expect(queryByText('✓')).toBeNull();
+      expect(queryByText('⌫')).toBeNull();
     });
 
-    it('does not render choice buttons in INPUT mode', () => {
+    it('does not render numpad-specific buttons in INPUT mode', () => {
       const { queryByText } = render(
         <GameCard {...defaultProps} gameState={baseGameState} />
       );
 
-      expect(queryByText('Prüfen')).toBeNull();
+      // In INPUT mode the numpad shows "Prüfen", not GradientCheckButton — but same label
+      // Verify the numpad is present via backspace button
+      expect(queryByText('⌫')).toBeTruthy();
     });
   });
 

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -119,6 +119,8 @@ export function GameCard({
                 userAnswer={gameState.userAnswer}
                 isAnswerChecked={gameState.isAnswerChecked}
                 reduceMotion={reduceMotion}
+                checkLabel={t.check}
+                nextLabel={t.nextQuestion}
               />
             )}
 

--- a/components/Numpad.tsx
+++ b/components/Numpad.tsx
@@ -16,6 +16,8 @@ interface NumpadProps {
   userAnswer: string;
   isAnswerChecked: boolean;
   reduceMotion: React.MutableRefObject<boolean>;
+  checkLabel: string;
+  nextLabel: string;
 }
 
 export function Numpad({
@@ -24,6 +26,8 @@ export function Numpad({
   userAnswer,
   isAnswerChecked,
   reduceMotion,
+  checkLabel,
+  nextLabel,
 }: NumpadProps) {
   const canCheck = userAnswer !== '' || isAnswerChecked;
   const pulseAnim = useRef(new Animated.Value(1)).current;
@@ -81,13 +85,13 @@ export function Numpad({
                   style={styles.checkButton}
                 >
                   <Text style={styles.checkButtonText}>
-                    {isAnswerChecked ? '→' : '✓'}
+                    {isAnswerChecked ? nextLabel : checkLabel}
                   </Text>
                 </LinearGradient>
               </TouchableOpacity>
             ) : (
               <View style={[styles.checkButton, styles.checkButtonDisabled]}>
-                <Text style={styles.checkButtonText}>✓</Text>
+                <Text style={styles.checkButtonText}>{checkLabel}</Text>
               </View>
             )}
           </Animated.View>
@@ -197,7 +201,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#94A3B8',
   },
   checkButtonText: {
-    fontSize: 24,
+    fontSize: 16,
     fontWeight: 'bold',
     color: '#fff',
   },

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -14,6 +14,7 @@ import { CONTACT_EMAIL, DESIGN_TOKENS } from '../utils/constants';
 
 interface SettingsMenuProps {
   colors: ThemeColors;
+  isDarkMode: boolean;
   screenHeight: number;
   menuAnimatedStyle: {
     transform: { translateY: Animated.Value }[];
@@ -59,6 +60,7 @@ interface SettingsMenuProps {
 
 export function SettingsMenu({
   colors,
+  isDarkMode,
   screenHeight,
   menuAnimatedStyle,
   difficultyMode,
@@ -72,6 +74,11 @@ export function SettingsMenu({
   onOpenAbout,
   t,
 }: SettingsMenuProps) {
+  const buttonBg = isDarkMode ? '#2D3748' : '#f7f8ff';
+  const buttonBorder = isDarkMode ? '#4A5568' : '#dde3ff';
+  const buttonText = isDarkMode ? '#E8EAED' : '#2d2b55';
+  const sectionTitle = isDarkMode ? '#9b8ecf' : '#9b8ecf';
+  const modeInfo = isDarkMode ? '#9b8ecf' : '#9b8ecf';
   return (
     <>
       <TouchableOpacity
@@ -79,7 +86,7 @@ export function SettingsMenu({
         activeOpacity={1}
         onPress={onHideMenu}
       />
-      <Animated.View style={[styles.settingsMenu, { maxHeight: screenHeight - 80 }, menuAnimatedStyle]}>
+      <Animated.View style={[styles.settingsMenu, { maxHeight: screenHeight - 80, backgroundColor: colors.settingsMenu }, menuAnimatedStyle]}>
         <LinearGradient
           colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
           start={{ x: 0, y: 0 }}
@@ -110,7 +117,7 @@ export function SettingsMenu({
 
         {/* Operation Settings */}
         <View style={styles.settingsSection}>
-          <Text style={styles.settingsSectionTitle}>{t.operation}</Text>
+          <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.operation}</Text>
           <View style={styles.operationGrid}>
             {([
               { op: Operation.ADDITION, symbol: '+', label: t.addition },
@@ -125,13 +132,14 @@ export function SettingsMenu({
                   key={op}
                   style={[
                     styles.operationButton,
+                    { backgroundColor: buttonBg, borderColor: buttonBorder },
                     isActive && styles.operationButtonActive,
                     isChallenge && { opacity: 0.6 },
                   ]}
                   onPress={() => onToggleOperation(op)}
                   disabled={isChallenge}
                 >
-                  <Text style={[styles.operationButtonText, isActive && styles.operationButtonTextActive]}>
+                  <Text style={[styles.operationButtonText, { color: buttonText }, isActive && styles.operationButtonTextActive]}>
                     {symbol} {label}
                   </Text>
                 </TouchableOpacity>
@@ -144,37 +152,37 @@ export function SettingsMenu({
 
         {/* Difficulty Mode Settings */}
         <View style={styles.settingsSection}>
-          <Text style={styles.settingsSectionTitle}>{t.difficultyMode}</Text>
+          <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.difficultyMode}</Text>
           <View style={styles.themeToggle}>
             <TouchableOpacity
-              style={[styles.themeButton, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonActive]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.SIMPLE)}
             >
-              <Text style={[styles.themeButtonText, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonTextActive]}>
+              <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonTextActive]}>
                 {t.simpleMode}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.themeButton, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonActive]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.CREATIVE)}
             >
-              <Text style={[styles.themeButtonText, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonTextActive]}>
+              <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonTextActive]}>
                 {t.creativeMode}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.themeButton, difficultyMode === DifficultyMode.CHALLENGE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CHALLENGE && styles.themeButtonActive]}
               onPress={() => {
                 onChangeDifficultyMode(DifficultyMode.CHALLENGE);
                 onHideMenu();
               }}
             >
-              <Text style={[styles.themeButtonText, difficultyMode === DifficultyMode.CHALLENGE && styles.themeButtonTextActive]}>
+              <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.CHALLENGE && styles.themeButtonTextActive]}>
                 {t.challenge}
               </Text>
             </TouchableOpacity>
           </View>
-          <Text style={styles.settingsModeInfo}>
+          <Text style={[styles.settingsModeInfo, { color: modeInfo }]}>
             {difficultyMode === DifficultyMode.SIMPLE
               ? t.simpleModeInfo
               : difficultyMode === DifficultyMode.CREATIVE
@@ -187,7 +195,7 @@ export function SettingsMenu({
 
         {/* Number Range Settings */}
         <View style={styles.settingsSection}>
-          <Text style={styles.settingsSectionTitle}>{t.numberRange}</Text>
+          <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.numberRange}</Text>
           <View style={styles.numberRangeGrid}>
             {([
               { range: NumberRange.RANGE_10, label: t.upTo10 },
@@ -202,13 +210,14 @@ export function SettingsMenu({
                   key={range}
                   style={[
                     styles.rangeButton,
+                    { backgroundColor: buttonBg, borderColor: buttonBorder },
                     isActive && styles.rangeButtonActive,
                     isChallengeMode && { opacity: 0.6 },
                   ]}
                   onPress={() => onSetNumberRange(range)}
                   disabled={isChallengeMode}
                 >
-                  <Text style={[styles.rangeButtonText, isActive && styles.rangeButtonTextActive]}>
+                  <Text style={[styles.rangeButtonText, { color: buttonText }, isActive && styles.rangeButtonTextActive]}>
                     {label}
                   </Text>
                 </TouchableOpacity>
@@ -270,7 +279,6 @@ const styles = StyleSheet.create({
     right: 16,
     left: 16,
     borderRadius: DESIGN_TOKENS.NUMPAD_BORDER_RADIUS,
-    backgroundColor: '#fff',
     elevation: 12,
     shadowColor: '#667eea',
     shadowOffset: { width: 0, height: 4 },

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -14,7 +14,6 @@ import { CONTACT_EMAIL, DESIGN_TOKENS } from '../utils/constants';
 
 interface SettingsMenuProps {
   colors: ThemeColors;
-  isDarkMode: boolean;
   screenHeight: number;
   menuAnimatedStyle: {
     transform: { translateY: Animated.Value }[];
@@ -60,7 +59,6 @@ interface SettingsMenuProps {
 
 export function SettingsMenu({
   colors,
-  isDarkMode,
   screenHeight,
   menuAnimatedStyle,
   difficultyMode,
@@ -74,11 +72,11 @@ export function SettingsMenu({
   onOpenAbout,
   t,
 }: SettingsMenuProps) {
-  const buttonBg = isDarkMode ? '#2D3748' : '#f7f8ff';
-  const buttonBorder = isDarkMode ? '#4A5568' : '#dde3ff';
-  const buttonText = isDarkMode ? '#E8EAED' : '#2d2b55';
-  const sectionTitle = isDarkMode ? '#9b8ecf' : '#9b8ecf';
-  const modeInfo = isDarkMode ? '#9b8ecf' : '#9b8ecf';
+  const buttonBg = colors.buttonInactive;
+  const buttonBorder = colors.border;
+  const buttonText = colors.buttonInactiveText;
+  const sectionTitle = colors.textSecondary;
+  const modeInfo = colors.textSecondary;
   return (
     <>
       <TouchableOpacity

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,8 +28,12 @@ module.exports = {
   ],
   moduleNameMapper: {
     '^react-native$': 'react-native-web',
+    '^expo-linear-gradient$': '<rootDir>/__mocks__/expo-linear-gradient.js',
+    '^expo-font$': '<rootDir>/__mocks__/expo-font.js',
+    '^expo-status-bar$': '<rootDir>/__mocks__/expo-status-bar.js',
+    '^@expo-google-fonts/(.*)$': '<rootDir>/__mocks__/@expo-google-fonts.js',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(expo-localization)/)',
+    'node_modules/(?!(expo-localization|expo-linear-gradient|expo-font|expo-status-bar|@expo-google-fonts)/)',
   ],
 };


### PR DESCRIPTION
## Summary

- **SettingsMenu Dark Mode**: Hintergrundfarbe war hardcoded `#fff` → nutzt jetzt `colors.settingsMenu`; Button/Text-Farben passen sich dem Dark Mode an (neues `isDarkMode` Prop)
- **Prüfen-Button einheitlich**: Numpad zeigte `✓`/`→` Emoji-Icons, Multiple-Choice/Sequence zeigten Text — jetzt überall Text (`t.check` / `t.nextQuestion`)
- **Challenge Header Badge**: `alignSelf: 'flex-start'` → `'center'`, Badge jetzt auf gleicher Höhe wie Herzen und "Stufe x"
- **Check-Button Position**: Nach dem UI-Redesign (PR #162) bereits korrekt innerhalb der Karte — keine weitere Änderung nötig

## Test plan

- [ ] Dark Mode aktivieren → SettingsMenu öffnen: Hintergrund und Texte lesbar
- [ ] INPUT-Modus: Prüfen-Button zeigt "Prüfen" / "Weiter →" (nicht mehr ✓/→)
- [ ] Multiple-Choice & Number-Sequence: Check-Button zeigt ebenfalls "Prüfen" / "Weiter →"
- [ ] Challenge-Modus starten: Badge (Punktestand) auf gleicher Höhe wie Herzen und "Stufe x"

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)