### PR TITLE
fix: PersonalizeModal Dark Mode (Issue #164)

### DIFF
--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -42,7 +42,7 @@ export function PersonalizeModal({
         onPress={onClose}
       />
 
-      <View style={styles.settingsMenu}>
+      <View style={[styles.settingsMenu, { backgroundColor: colors.settingsMenu }]}>
         <LinearGradient
           colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
           start={{ x: 0, y: 0 }}
@@ -56,7 +56,7 @@ export function PersonalizeModal({
         </LinearGradient>
 
         <View style={styles.settingsSection}>
-          <Text style={styles.settingsSectionTitle}>
+          <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>
             {t.appearance}
           </Text>
           <View style={styles.chipRow}>
@@ -81,10 +81,10 @@ export function PersonalizeModal({
           </View>
         </View>
 
-        <View style={styles.settingsDivider} />
+        <View style={[styles.settingsDivider, { backgroundColor: colors.border }]} />
 
         <View style={styles.settingsSection}>
-          <Text style={styles.settingsSectionTitle}>
+          <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>
             {t.language}
           </Text>
           <View style={styles.chipRow}>
@@ -123,7 +123,6 @@ const styles = StyleSheet.create({
     right: 16,
     left: 16,
     borderRadius: DESIGN_TOKENS.NUMPAD_BORDER_RADIUS,
-    backgroundColor: '#fff',
     elevation: 12,
     shadowColor: '#667eea',
     shadowOffset: { width: 0, height: 4 },
@@ -161,7 +160,6 @@ const styles = StyleSheet.create({
   settingsSectionTitle: {
     fontSize: 11,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: '#9b8ecf',
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.08,
@@ -172,7 +170,6 @@ const styles = StyleSheet.create({
   },
   settingsDivider: {
     height: 1,
-    backgroundColor: 'rgba(102,126,234,0.1)',
     marginVertical: 2,
   },
 });


### PR DESCRIPTION
## Summary
- Behebt fehlenden Dark-Mode-Support im Personalisieren-Menü
- `backgroundColor` des Containers nutzte hardcodiertes `#fff` statt `colors.settingsMenu`
- Abschnittstitel ("Erscheinungsbild", "Sprache") verwendeten hardcodiertes `#9b8ecf` statt `colors.textSecondary`
- Trennlinie verwendete hardcodiertes `rgba(102,126,234,0.1)` statt `colors.border`

Closes #164

## Test plan
- [ ] Dark Mode aktivieren → PersonalizeModal hat dunklen Hintergrund
- [ ] Abschnittstitel und Trennlinie passen sich dem Theme an
- [ ] Light Mode: kein visueller Unterschied zum vorherigen Zustand
- [ ] `npx jest` — alle 11 Suites grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)