### PR TITLE
Promote testing → staging: dark-mode Chip fix + settings font

### DIFF
--- a/components/Chip.test.tsx
+++ b/components/Chip.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Chip } from './Chip';
+import { getThemeColors } from '../utils/theme';
+
+describe('Chip', () => {
+  it('uses theme-aware inactive colors in dark mode', () => {
+    const colors = getThemeColors(true);
+    const { getByText } = render(
+      <Chip label="Dark" active={false} onPress={jest.fn()} colors={colors} />
+    );
+
+    const label = getByText('Dark');
+    const button = label.closest('[role="button"]') ?? label.parentElement;
+
+    expect(button).not.toBeNull();
+    expect(window.getComputedStyle(button as Element).backgroundColor).toBe('rgb(30, 41, 59)'); // platform-safe
+    expect(window.getComputedStyle(label).color).toBe('rgb(148, 163, 184)'); // platform-safe
+  });
+
+  it('keeps the active state contrast and remains clickable', () => {
+    const colors = getThemeColors(true);
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <Chip label="System" active onPress={onPress} colors={colors} />
+    );
+
+    const label = getByText('System');
+    const button = label.closest('[role="button"]') ?? label.parentElement;
+
+    fireEvent.click(label);
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(button).not.toBeNull();
+    expect(window.getComputedStyle(button as Element).backgroundColor).toBe('rgb(102, 126, 234)'); // platform-safe
+    expect(window.getComputedStyle(label).color).toBe('rgb(255, 255, 255)'); // platform-safe
+  });
+});

--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -17,7 +17,7 @@ export function Chip({ label, active, onPress, colors, disabled = false, size = 
     <TouchableOpacity
       style={[
         styles.chip,
-        { borderColor: colors.border },
+        { backgroundColor: colors.buttonInactive, borderColor: colors.border },
         active && styles.chipActive,
         disabled && { opacity: 0.6 },
         size === 'sm' && styles.chipSm,
@@ -28,7 +28,7 @@ export function Chip({ label, active, onPress, colors, disabled = false, size = 
       <Text
         style={[
           styles.chipText,
-          { color: colors.text },
+          { color: colors.buttonInactiveText },
           active && styles.chipTextActive,
           size === 'sm' && styles.chipTextSm,
         ]}
@@ -49,7 +49,6 @@ const styles = StyleSheet.create({
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     borderWidth: 2,
     borderColor: '#dde3ff',
-    backgroundColor: '#f7f8ff',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
   chipText: {
     fontSize: 14,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: '#2d2b55',
   },
   chipTextActive: {
     color: '#fff',

--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
     letterSpacing: 0.3,
   },

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -294,7 +294,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
     letterSpacing: 0.3,
   },


### PR DESCRIPTION
Überträgt den geprüften und gemergten Fix aus `testing` nach `staging`.

**Enthält:**
- Dark-Mode Chip-Kontrast: theme-aware `buttonInactive` / `buttonInactiveText`
- Settings-Titel: `FONT_NUMBER` → `FONT_UI` (PersonalizeModal, SettingsMenu)
- Regressionstest: `Chip.test.tsx`

Reviewed und approved in PR #171.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDmQbM4M4oJA5P7s456o5Y)_