### PR TITLE
feat: Eltern-Dashboard – Spielstatistiken der letzten 4 Wochen (#169)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,10 @@ import { GameCard } from './components/GameCard';
 import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
+import { ParentDashboard } from './components/ParentDashboard';
 import { FloatingStars } from './components/FloatingStars';
+import { saveSessionRecord } from './utils/storage';
+import { SessionRecord } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -47,6 +50,7 @@ export default function App() {
   const [menuRendered, setMenuRendered] = useState(false);
   const [aboutVisible, setAboutVisible] = useState(false);
   const [personalizeVisible, setPersonalizeVisible] = useState(false);
+  const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
 
@@ -72,6 +76,9 @@ export default function App() {
     onMotivationShow: (score: number) => {
       setMotivationScore(score);
       setShowMotivation(true);
+    },
+    onSessionComplete: (record: SessionRecord) => {
+      saveSessionRecord(record);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -233,6 +240,7 @@ export default function App() {
             setAboutVisible(true);
             hideMenu();
           }}
+          onOpenParentDashboard={() => setParentDashboardVisible(true)}
           t={t}
         />
       )}
@@ -285,6 +293,13 @@ export default function App() {
       <AboutModal
         visible={aboutVisible}
         onClose={() => setAboutVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <ParentDashboard
+        visible={parentDashboardVisible}
+        onClose={() => setParentDashboardVisible(false)}
         colors={colors}
         t={t}
       />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,15 +31,28 @@ npm run test:coverage # Coverage
 
 ## Wichtige Dateien
 
-| Datei                        | Inhalt                              |
-|------------------------------|-------------------------------------|
-| `utils/constants.ts`         | Farben (THEME_COLORS), DESIGN_TOKENS |
-| `utils/theme.ts`             | `getThemeColors(isDarkMode)`        |
-| `types/game.ts`              | ThemeColors, GameState, Enums       |
-| `jest.config.js`             | Jest-Konfiguration                  |
-| `components/Chip.tsx`        | Chip-Button (theme-aware seit #171) |
+| Datei                              | Inhalt                                          |
+|------------------------------------|-------------------------------------------------|
+| `utils/constants.ts`               | Farben (THEME_COLORS), DESIGN_TOKENS, STORAGE_KEYS |
+| `utils/theme.ts`                   | `getThemeColors(isDarkMode)`                    |
+| `utils/storage.ts`                 | Storage-Helfer inkl. `saveSessionRecord` / `getSessionRecords` |
+| `types/game.ts`                    | ThemeColors, GameState, Enums, `SessionRecord`  |
+| `jest.config.js`                   | Jest-Konfiguration                              |
+| `components/Chip.tsx`              | Chip-Button (theme-aware seit #171)             |
+| `components/ParentDashboard.tsx`   | Eltern-Dashboard Modal (neu seit #174)          |
 
 ## Letzte Änderungen
+
+### PR #174 → testing (2026-05-08) – offen, CI pending
+Schließt Issue #169 – Eltern-Dashboard
+- `types/game.ts`: Neues `SessionRecord`-Interface (timestamp, operations, correctTasks, errors, errorRate, difficultyMode, numberRange)
+- `utils/constants.ts`: Storage-Key `app-parent-stats` ergänzt
+- `utils/storage.ts`: `saveSessionRecord()` + `getSessionRecords()` – Einträge älter als 28 Tage werden automatisch bereinigt
+- `hooks/useGameLogic.ts`: Optionaler `onSessionComplete`-Callback; wird nach jeder Runde (Normal, Kreativ, Challenge) aufgerufen – außerhalb des `setGameState`-Updaters
+- `components/ParentDashboard.tsx`: Neues Modal – Sitzungsliste nach Tag gruppiert, Fehlerquote farbcodiert (grün ≤10%, gelb ≤30%, rot >30%), 7-Tage-Zusammenfassung, Challenge-Badge ⚡
+- `components/SettingsMenu.tsx`: „Eltern-Dashboard"-Button neben „Personalisieren"; neues Prop `onOpenParentDashboard`
+- `i18n/translations.ts`: 10 neue Keys (DE/EN) – `parentDashboard`, `parentDashboardSubtitle`, `parentNoData`, `parentSessions`, `parentAvgError`, `parentToday`, `parentYesterday`, `parentCorrect`, `parentErrors`
+- `App.tsx`: `saveSessionRecord` in `onSessionComplete`; `parentDashboardVisible`-State; `<ParentDashboard>`-Einbindung
 
 ### PR #171 → testing (2026-05-06)
 - `Chip.tsx`: Dark-Mode-Fix – hardcodierte Farben durch `colors.buttonInactive` / `colors.buttonInactiveText` ersetzt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# 1x1 Trainer – Claude Memory
+
+## Branch-Workflow
+
+```
+feature/fix → testing → staging → main
+```
+
+| Branch    | Zweck                              | Status    |
+|-----------|------------------------------------|-----------|
+| `main`    | Produktion (protected)             | stabil    |
+| `staging` | Pre-Release, Qualitätssicherung    | aktuell   |
+| `testing` | Integration neuer Features/Fixes   | aktuell   |
+
+- PRs von Copilot/Claude landen zunächst gegen `testing`, nicht `main`
+- Nach Review und CI-Grün: `testing → staging` per Squash-Merge
+- `staging → main` nur für echte Releases
+
+## Testing
+
+```bash
+npm test              # Jest
+npm run test:watch    # Watch-Modus
+npm run test:coverage # Coverage
+```
+
+- Test-Runner: Jest + jsdom
+- React Native → React Native Web (via `moduleNameMapper`)
+- `@testing-library/react` (nicht react-native)
+- `window.getComputedStyle` funktioniert für RN-Styles (jsdom + RNW)
+
+## Wichtige Dateien
+
+| Datei                        | Inhalt                              |
+|------------------------------|-------------------------------------|
+| `utils/constants.ts`         | Farben (THEME_COLORS), DESIGN_TOKENS |
+| `utils/theme.ts`             | `getThemeColors(isDarkMode)`        |
+| `types/game.ts`              | ThemeColors, GameState, Enums       |
+| `jest.config.js`             | Jest-Konfiguration                  |
+| `components/Chip.tsx`        | Chip-Button (theme-aware seit #171) |
+
+## Letzte Änderungen
+
+### PR #171 → testing (2026-05-06)
+- `Chip.tsx`: Dark-Mode-Fix – hardcodierte Farben durch `colors.buttonInactive` / `colors.buttonInactiveText` ersetzt
+- `PersonalizeModal.tsx`, `SettingsMenu.tsx`: Titel-Font `FONT_NUMBER` → `FONT_UI`
+- `Chip.test.tsx`: Neuer Regressionstest für Dark-Mode-Kontrast
+
+### PR #172 → staging (2026-05-06)
+- Promotion von `testing` → `staging` (enthält #171)

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -107,8 +107,8 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
   const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
   const recentRecords = records.filter(r => r.timestamp >= sevenDaysAgo);
   const avgErrorRate =
-    records.length > 0
-      ? records.reduce((sum, r) => sum + r.errorRate, 0) / records.length
+    recentRecords.length > 0
+      ? recentRecords.reduce((sum, r) => sum + r.errorRate, 0) / recentRecords.length
       : null;
 
   const getDayLabel = (key: string) => {

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode } from '../types/game';
+import { getSessionRecords } from '../utils/storage';
+import { DESIGN_TOKENS } from '../utils/constants';
+import { modalStyles } from '../styles/modalStyles';
+
+const OP_SYMBOL: Record<Operation, string> = {
+  [Operation.ADDITION]: '+',
+  [Operation.SUBTRACTION]: '−',
+  [Operation.MULTIPLICATION]: '×',
+  [Operation.DIVISION]: '÷',
+};
+
+interface ParentDashboardProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  t: {
+    parentDashboard: string;
+    parentDashboardSubtitle: string;
+    parentNoData: string;
+    parentSessions: string;
+    parentAvgError: string;
+    parentToday: string;
+    parentYesterday: string;
+    parentCorrect: string;
+    parentErrors: string;
+    ok: string;
+  };
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const h = d.getHours().toString().padStart(2, '0');
+  const m = d.getMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+}
+
+function isSameDay(ts: number, reference: Date): boolean {
+  const d = new Date(ts);
+  return (
+    d.getFullYear() === reference.getFullYear() &&
+    d.getMonth() === reference.getMonth() &&
+    d.getDate() === reference.getDate()
+  );
+}
+
+function groupByDay(records: SessionRecord[]): { label: string; entries: SessionRecord[] }[] {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const map = new Map<string, SessionRecord[]>();
+
+  for (const r of [...records].sort((a, b) => b.timestamp - a.timestamp)) {
+    let key: string;
+    if (isSameDay(r.timestamp, today)) {
+      key = '__today__';
+    } else if (isSameDay(r.timestamp, yesterday)) {
+      key = '__yesterday__';
+    } else {
+      key = formatDate(r.timestamp);
+    }
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(r);
+  }
+
+  return Array.from(map.entries()).map(([label, entries]) => ({ label, entries }));
+}
+
+function errorRateColor(rate: number): string {
+  if (rate <= 0.1) return '#10B981';
+  if (rate <= 0.3) return '#F59E0B';
+  return '#EF4444';
+}
+
+export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
+  const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setLoading(true);
+      getSessionRecords().then((data) => {
+        setRecords(data);
+        setLoading(false);
+      });
+    }
+  }, [visible]);
+
+  const grouped = groupByDay(records);
+
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const recentRecords = records.filter(r => r.timestamp >= sevenDaysAgo);
+  const avgErrorRate =
+    records.length > 0
+      ? records.reduce((sum, r) => sum + r.errorRate, 0) / records.length
+      : null;
+
+  const getDayLabel = (key: string) => {
+    if (key === '__today__') return t.parentToday;
+    if (key === '__yesterday__') return t.parentYesterday;
+    return key;
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[styles.container, { backgroundColor: colors.settingsMenu }]}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.parentDashboard}</Text>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{t.parentDashboardSubtitle}</Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={[styles.closeText, { color: colors.text }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Summary bar */}
+          {records.length > 0 && (
+            <View style={[styles.summaryBar, { borderColor: colors.border }]}>
+              <View style={styles.summaryItem}>
+                <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
+                <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
+              </View>
+              {avgErrorRate !== null && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {avgErrorRate !== null && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: errorRateColor(avgErrorRate) }]}>
+                    {Math.round(avgErrorRate * 100)}%
+                  </Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
+                </View>
+              )}
+            </View>
+          )}
+
+          {/* Content */}
+          {loading ? (
+            <ActivityIndicator style={styles.loader} color={DESIGN_TOKENS.GRADIENT_PRIMARY[0]} />
+          ) : records.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{t.parentNoData}</Text>
+          ) : (
+            <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
+              {grouped.map(({ label, entries }) => (
+                <View key={label}>
+                  <Text style={[styles.dayLabel, { color: colors.textSecondary }]}>{getDayLabel(label)}</Text>
+                  {entries.map((r) => (
+                    <View key={r.id} style={[styles.row, { borderColor: colors.border }]}>
+                      <Text style={[styles.rowTime, { color: colors.textSecondary }]}>{formatTime(r.timestamp)}</Text>
+                      <Text style={[styles.rowOps, { color: colors.text }]}>
+                        {r.operations.map(op => OP_SYMBOL[op]).join(' ')}
+                      </Text>
+                      <Text style={[styles.rowScore, { color: colors.text }]}>
+                        {r.correctTasks}/{r.totalTasks}
+                      </Text>
+                      <View style={[styles.errorBadge, { backgroundColor: errorRateColor(r.errorRate) + '22' }]}>
+                        <Text style={[styles.errorBadgeText, { color: errorRateColor(r.errorRate) }]}>
+                          {Math.round(r.errorRate * 100)}%
+                        </Text>
+                      </View>
+                      {r.difficultyMode === DifficultyMode.CHALLENGE && (
+                        <Text style={styles.challengeBadge}>⚡</Text>
+                      )}
+                    </View>
+                  ))}
+                </View>
+              ))}
+            </ScrollView>
+          )}
+
+          {/* Close button */}
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Text style={styles.closeBtnText}>{t.ok}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 24,
+    padding: 20,
+    width: '90%',
+    maxWidth: 420,
+    maxHeight: '85%',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  subtitle: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+  },
+  closeButton: {
+    padding: 6,
+    minWidth: 36,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  summaryBar: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderRadius: 12,
+    marginBottom: 14,
+    overflow: 'hidden',
+  },
+  summaryItem: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  summaryDivider: {
+    width: 1,
+  },
+  summaryValue: {
+    fontSize: 22,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+  },
+  summaryLabel: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  loader: {
+    marginVertical: 32,
+  },
+  emptyText: {
+    textAlign: 'center',
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginVertical: 32,
+  },
+  list: {
+    maxHeight: 340,
+    marginBottom: 12,
+  },
+  dayLabel: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 10,
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderBottomWidth: 1,
+    gap: 8,
+  },
+  rowTime: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    width: 38,
+  },
+  rowOps: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    flex: 1,
+    letterSpacing: 2,
+  },
+  rowScore: {
+    fontSize: 13,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    minWidth: 36,
+    textAlign: 'right',
+  },
+  errorBadge: {
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 8,
+    minWidth: 42,
+    alignItems: 'center',
+  },
+  errorBadgeText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  challengeBadge: {
+    fontSize: 13,
+  },
+  closeBtn: {
+    backgroundColor: ACTIVE_COLOR,
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  closeBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -30,6 +30,7 @@ interface SettingsMenuProps {
   onHideMenu: () => void;
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
+  onOpenParentDashboard: () => void;
   // Translations
   t: {
     operation: string;
@@ -50,6 +51,7 @@ interface SettingsMenuProps {
     upTo50: string;
     upTo100: string;
     personalize: string;
+    parentDashboard: string;
     feedback: string;
     support: string;
     about: string;
@@ -70,6 +72,7 @@ export function SettingsMenu({
   onHideMenu,
   onOpenPersonalize,
   onOpenAbout,
+  onOpenParentDashboard,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -102,12 +105,18 @@ export function SettingsMenu({
         <ScrollView bounces={false}>
 
         {/* Personalize Button */}
-        <View style={styles.settingsSection}>
+        <View style={[styles.settingsSection, styles.topButtonsSection]}>
           <TouchableOpacity
             style={styles.personalizeButton}
             onPress={onOpenPersonalize}
           >
             <Text style={styles.personalizeButtonText}>{t.personalize}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.personalizeButton}
+            onPress={() => { onOpenParentDashboard(); onHideMenu(); }}
+          >
+            <Text style={styles.personalizeButtonText}>{t.parentDashboard}</Text>
           </TouchableOpacity>
         </View>
 
@@ -319,6 +328,9 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontFamily: DESIGN_TOKENS.FONT_UI,
     color: ACTIVE_COLOR,
+  },
+  topButtonsSection: {
+    gap: 8,
   },
   personalizeButton: {
     width: '100%',

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -187,6 +187,10 @@ export function useGameLogic({
   const fireSessionComplete = (finalScore: number, totalTasks: number, selectedOperations: Set<Operation>) => {
     if (!onSessionComplete) return;
     const errors = totalTasks - finalScore;
+    const effectiveRange =
+      gameState.difficultyMode === DifficultyMode.CHALLENGE
+        ? getChallengeLevel(finalScore).numberRange
+        : numberRange;
     const record: SessionRecord = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
       timestamp: Date.now(),
@@ -196,7 +200,7 @@ export function useGameLogic({
       errors,
       errorRate: totalTasks > 0 ? errors / totalTasks : 0,
       difficultyMode: gameState.difficultyMode,
-      numberRange,
+      numberRange: effectiveRange,
     };
     onSessionComplete(record);
   };

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -4,15 +4,16 @@
  */
 
 import { useState, useMemo } from 'react';
-import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState } from '../types/game';
+import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord } from '../types/game';
 import { TOTAL_TASKS, MAX_CHOICE_GENERATION_ATTEMPTS, MAX_RANDOM_ANSWER, CHALLENGE_MAX_LIVES, getChallengeLevel, getChallengeLevelNumber } from '../utils/constants';
 
 interface UseGameLogicProps {
   initialOperation: Operation;
-  initialOperations?: Operation[]; // Optional: array of selected operations
+  initialOperations?: Operation[];
   initialTotalSolvedTasks: number;
   onTotalSolvedTasksChange: (total: number) => void;
   onMotivationShow: (score: number) => void;
+  onSessionComplete?: (record: SessionRecord) => void;
   numberRange: NumberRange;
   challengeHighScore?: number;
   onChallengeHighScoreChange?: (score: number) => void;
@@ -136,6 +137,7 @@ export function useGameLogic({
   initialTotalSolvedTasks,
   onTotalSolvedTasksChange,
   onMotivationShow,
+  onSessionComplete,
   numberRange,
   challengeHighScore = 0,
   onChallengeHighScoreChange,
@@ -181,6 +183,23 @@ export function useGameLogic({
     totalSolvedTasks: initialTotalSolvedTasks,
     selectedChoice: null,
   });
+
+  const fireSessionComplete = (finalScore: number, totalTasks: number, selectedOperations: Set<Operation>) => {
+    if (!onSessionComplete) return;
+    const errors = totalTasks - finalScore;
+    const record: SessionRecord = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      timestamp: Date.now(),
+      operations: Array.from(selectedOperations),
+      totalTasks,
+      correctTasks: finalScore,
+      errors,
+      errorRate: totalTasks > 0 ? errors / totalTasks : 0,
+      difficultyMode: gameState.difficultyMode,
+      numberRange,
+    };
+    onSessionComplete(record);
+  };
 
   // Helper: Get correct answer for current question
   const getCorrectAnswer = () => {
@@ -383,6 +402,14 @@ export function useGameLogic({
     }
 
     const newScore = isCorrect ? gameState.score + 1 : gameState.score;
+    const challengeGameOver =
+      gameState.difficultyMode === DifficultyMode.CHALLENGE &&
+      gameState.challengeState !== undefined &&
+      !isCorrect &&
+      gameState.challengeState.lives - 1 <= 0;
+    if (challengeGameOver) {
+      fireSessionComplete(newScore, gameState.currentTask, gameState.selectedOperations);
+    }
 
     setGameState((prev) => {
       const newState: GameState = {
@@ -458,6 +485,10 @@ export function useGameLogic({
     const isLastTask = gameState.currentTask === gameState.totalTasks;
     const newTotalSolvedTasks = gameState.totalSolvedTasks + 1;
 
+    if (isLastTask) {
+      fireSessionComplete(gameState.score, gameState.totalTasks, gameState.selectedOperations);
+    }
+
     setGameState((prev) => {
       // Show motivation message after every 10 tasks
       if (newTotalSolvedTasks > 0 && newTotalSolvedTasks % 10 === 0) {
@@ -465,7 +496,6 @@ export function useGameLogic({
       }
 
       if (isLastTask) {
-        // Last task - show results
         return {
           ...prev,
           showResult: true,

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -83,6 +83,16 @@ export interface TranslationStrings {
   tryAgain: string;
   settings: string;
   ok: string;
+  // Parent Dashboard
+  parentDashboard: string;
+  parentDashboardSubtitle: string;
+  parentNoData: string;
+  parentSessions: string;
+  parentAvgError: string;
+  parentToday: string;
+  parentYesterday: string;
+  parentCorrect: string;
+  parentErrors: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -164,6 +174,16 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Settings',
     ok: 'OK',
     encouragement: 'You can do it! 💪',
+    // Parent Dashboard
+    parentDashboard: 'Parent Dashboard',
+    parentDashboardSubtitle: 'Last 4 weeks · tap ✕ to close',
+    parentNoData: 'No sessions recorded yet. Play a few rounds first!',
+    parentSessions: 'Sessions (7 days)',
+    parentAvgError: 'Avg. Error Rate',
+    parentToday: 'Today',
+    parentYesterday: 'Yesterday',
+    parentCorrect: 'Correct',
+    parentErrors: 'Errors',
   },
   de: {
     // Settings Menu
@@ -243,5 +263,15 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Einstellungen',
     ok: 'OK',
     encouragement: 'Du schaffst das! 💪',
+    // Parent Dashboard
+    parentDashboard: 'Eltern-Dashboard',
+    parentDashboardSubtitle: 'Letzte 4 Wochen · ✕ zum Schließen',
+    parentNoData: 'Noch keine Einheiten gespeichert. Spielt zuerst ein paar Runden!',
+    parentSessions: 'Einheiten (7 Tage)',
+    parentAvgError: 'Ø Fehlerquote',
+    parentToday: 'Heute',
+    parentYesterday: 'Gestern',
+    parentCorrect: 'Richtig',
+    parentErrors: 'Fehler',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -67,6 +67,18 @@ export interface GameState {
   challengeState?: ChallengeState; // Challenge mode state
 }
 
+export interface SessionRecord {
+  id: string;
+  timestamp: number;
+  operations: Operation[];
+  totalTasks: number;
+  correctTasks: number;
+  errors: number;
+  errorRate: number;
+  difficultyMode: DifficultyMode;
+  numberRange: NumberRange;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -22,6 +22,7 @@ export const STORAGE_KEYS = {
   TOTAL_TASKS: 'app-total-tasks',
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
+  PARENT_STATS: 'app-parent-stats',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -21,8 +21,10 @@ import {
   getNumberRange,
   saveChallengeHighScore,
   getChallengeHighScore,
+  saveSessionRecord,
+  getSessionRecords,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -446,5 +448,92 @@ describe('Challenge High Score Storage', () => {
     await saveChallengeHighScore(25);
     const result = await getChallengeHighScore();
     expect(result).toBe(25);
+  });
+});
+
+describe('Session Records Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  const makeRecord = (overrides: Partial<SessionRecord> = {}): SessionRecord => ({
+    id: 'test-id',
+    timestamp: Date.now(),
+    operations: [Operation.MULTIPLICATION],
+    totalTasks: 10,
+    correctTasks: 8,
+    errors: 2,
+    errorRate: 0.2,
+    difficultyMode: DifficultyMode.SIMPLE,
+    numberRange: NumberRange.RANGE_10,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return empty array when no records stored', async () => {
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should save and retrieve a session record', async () => {
+    const record = makeRecord({ id: 'abc' });
+    await saveSessionRecord(record);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('abc');
+    expect(result[0].correctTasks).toBe(8);
+    expect(result[0].errorRate).toBe(0.2);
+  });
+
+  it('should accumulate multiple records', async () => {
+    await saveSessionRecord(makeRecord({ id: 'r1' }));
+    await saveSessionRecord(makeRecord({ id: 'r2' }));
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(2);
+  });
+
+  it('should prune records older than 28 days', async () => {
+    const old = makeRecord({ id: 'old', timestamp: Date.now() - 29 * 24 * 60 * 60 * 1000 });
+    const fresh = makeRecord({ id: 'fresh', timestamp: Date.now() });
+    mockStore['app-parent-stats'] = JSON.stringify([old, fresh]);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('fresh');
+  });
+
+  it('should filter out malformed entries missing operations', async () => {
+    const bad = { id: 'bad', timestamp: Date.now(), totalTasks: 10 };
+    const good = makeRecord({ id: 'good' });
+    mockStore['app-parent-stats'] = JSON.stringify([bad, good]);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('good');
+  });
+
+  it('should return empty array for corrupted JSON', async () => {
+    mockStore['app-parent-stats'] = '{not valid json}';
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when stored value is not an array', async () => {
+    mockStore['app-parent-stats'] = '{"id":"x"}';
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should correctly compute error rate in saved record', async () => {
+    const record = makeRecord({ totalTasks: 10, correctTasks: 7, errors: 3, errorRate: 0.3 });
+    await saveSessionRecord(record);
+    const [retrieved] = await getSessionRecords();
+    expect(retrieved.errorRate).toBe(0.3);
+    expect(retrieved.errors).toBe(3);
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, SessionRecord } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -146,6 +146,31 @@ export const getChallengeHighScore = async (): Promise<number> => {
     return isNaN(parsed) ? 0 : parsed;
   }
   return 0;
+};
+
+const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
+
+export const saveSessionRecord = async (record: SessionRecord): Promise<void> => {
+  const records = await getSessionRecords();
+  const now = Date.now();
+  const pruned = records.filter(r => now - r.timestamp < FOUR_WEEKS_MS);
+  pruned.push(record);
+  await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(pruned));
+};
+
+export const getSessionRecords = async (): Promise<SessionRecord[]> => {
+  const value = await getStorageItem(STORAGE_KEYS.PARENT_STATS);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    const now = Date.now();
+    return parsed.filter(
+      (r: SessionRecord) => r && typeof r.timestamp === 'number' && now - r.timestamp < FOUR_WEEKS_MS
+    );
+  } catch {
+    return [];
+  }
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -150,13 +150,25 @@ export const getChallengeHighScore = async (): Promise<number> => {
 
 const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
 
-export const saveSessionRecord = async (record: SessionRecord): Promise<void> => {
-  const records = await getSessionRecords();
-  const now = Date.now();
-  const pruned = records.filter(r => now - r.timestamp < FOUR_WEEKS_MS);
-  pruned.push(record);
-  await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(pruned));
-};
+function isValidSessionRecord(r: unknown): r is SessionRecord {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.timestamp === 'number' &&
+    Array.isArray(obj.operations) &&
+    typeof obj.totalTasks === 'number' &&
+    typeof obj.correctTasks === 'number' &&
+    typeof obj.errors === 'number' &&
+    typeof obj.errorRate === 'number' &&
+    typeof obj.difficultyMode === 'string' &&
+    typeof obj.numberRange === 'string'
+  );
+}
+
+function pruneOldRecords(records: SessionRecord[], now: number): SessionRecord[] {
+  return records.filter(r => now - r.timestamp < FOUR_WEEKS_MS);
+}
 
 export const getSessionRecords = async (): Promise<SessionRecord[]> => {
   const value = await getStorageItem(STORAGE_KEYS.PARENT_STATS);
@@ -164,13 +176,16 @@ export const getSessionRecords = async (): Promise<SessionRecord[]> => {
   try {
     const parsed = JSON.parse(value);
     if (!Array.isArray(parsed)) return [];
-    const now = Date.now();
-    return parsed.filter(
-      (r: SessionRecord) => r && typeof r.timestamp === 'number' && now - r.timestamp < FOUR_WEEKS_MS
-    );
+    return pruneOldRecords(parsed.filter(isValidSessionRecord), Date.now());
   } catch {
     return [];
   }
+};
+
+export const saveSessionRecord = async (record: SessionRecord): Promise<void> => {
+  const records = await getSessionRecords();
+  records.push(record);
+  await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {


### PR DESCRIPTION
## Zusammenfassung

Schließt Issue #169 – Eltern-Dashboard für Spielstatistiken.

- **Neues `SessionRecord`-Interface** (`types/game.ts`): Timestamp, Operationen, richtige Antworten, Fehler, Fehlerquote, Schwierigkeitsgrad, Zahlenbereich
- **Persistente Speicherung** (`utils/storage.ts`): Sitzungen werden nach jeder Runde gespeichert, Einträge älter als 4 Wochen werden automatisch bereinigt
- **Automatische Erfassung** (`hooks/useGameLogic.ts`): `onSessionComplete`-Callback wird nach jeder Spielrunde (Normal, Kreativ, Challenge) ausgelöst
- **`ParentDashboard`-Modal** (`components/ParentDashboard.tsx`):
  - Erreichbar über Einstellungen → „Eltern-Dashboard"
  - Zusammenfassung: Einheiten der letzten 7 Tage + Ø Fehlerquote
  - Sitzungsliste nach Tag gruppiert (Heute / Gestern / Datum)
  - Fehlerquote mit Farbindikator (grün ≤10 %, gelb ≤30 %, rot >30 %)
  - Challenge-Runden mit ⚡-Kennzeichnung
- **Übersetzungen** (DE/EN) für alle neuen UI-Texte

## Testplan

- [ ] Spielrunde beenden → Einstellungen öffnen → „Eltern-Dashboard" → Sitzung erscheint
- [ ] Fehlerquote stimmt mit tatsächlichen Fehlern überein
- [ ] Challenge-Runde endet durch 3 Fehler → Sitzung wird ebenfalls gespeichert
- [ ] Einheiten älter als 28 Tage werden nicht angezeigt (manueller Storage-Test)
- [ ] Dark Mode: Dashboard korrekt themed
- [ ] EN/DE Sprachwechsel: Texte korrekt übersetzt
- [ ] `npm test` → 397 Tests, alle grün

https://claude.ai/code/session_015CxhPUcMawv8ikgGJsWTnv

---
_Generated by [Claude Code](https://claude.ai/code/session_015CxhPUcMawv8ikgGJsWTnv)_