### PR TITLE
docs: CLAUDE.md in zwei Schichten aufteilen (öffentlich/privat)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,7 +31,10 @@ import { GameCard } from './components/GameCard';
 import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
+import { ParentDashboard } from './components/ParentDashboard';
 import { FloatingStars } from './components/FloatingStars';
+import { saveSessionRecord } from './utils/storage';
+import { SessionRecord } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -47,6 +50,7 @@ export default function App() {
   const [menuRendered, setMenuRendered] = useState(false);
   const [aboutVisible, setAboutVisible] = useState(false);
   const [personalizeVisible, setPersonalizeVisible] = useState(false);
+  const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
 
@@ -72,6 +76,9 @@ export default function App() {
     onMotivationShow: (score: number) => {
       setMotivationScore(score);
       setShowMotivation(true);
+    },
+    onSessionComplete: (record: SessionRecord) => {
+      saveSessionRecord(record);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -233,6 +240,7 @@ export default function App() {
             setAboutVisible(true);
             hideMenu();
           }}
+          onOpenParentDashboard={() => setParentDashboardVisible(true)}
           t={t}
         />
       )}
@@ -285,6 +293,13 @@ export default function App() {
       <AboutModal
         visible={aboutVisible}
         onClose={() => setAboutVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <ParentDashboard
+        visible={parentDashboardVisible}
+        onClose={() => setParentDashboardVisible(false)}
         colors={colors}
         t={t}
       />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,10 @@
-# 1x1 Trainer – Claude Memory
+# 1x1 Trainer – Projektdokumentation für Claude
+
+> **Zwei-Schichten-Dokumentation:**
+> Diese Datei ist öffentlich im Repo. Sensible Infos (Keystore, Gerät-IDs, Secrets) liegen in `docs/private/CLAUDE.md` (gitignored, nur lokal).
+> **Telefon-Workflow:** Notizen vom iPhone ans Ende dieser Datei schreiben → am Mac in die richtige Schicht einsortieren.
+
+---
 
 ## Branch-Workflow
 
@@ -6,15 +12,50 @@
 feature/fix → testing → staging → main
 ```
 
-| Branch    | Zweck                              | Status    |
-|-----------|------------------------------------|-----------|
-| `main`    | Produktion (protected)             | stabil    |
-| `staging` | Pre-Release, Qualitätssicherung    | aktuell   |
-| `testing` | Integration neuer Features/Fixes   | aktuell   |
+| Branch    | Zweck                              |
+|-----------|------------------------------------|
+| `main`    | Produktion (protected)             |
+| `staging` | Pre-Release, Qualitätssicherung    |
+| `testing` | Integration neuer Features/Fixes   |
 
-- PRs von Copilot/Claude landen zunächst gegen `testing`, nicht `main`
-- Nach Review und CI-Grün: `testing → staging` per Squash-Merge
-- `staging → main` nur für echte Releases
+- PRs von Copilot/Claude immer gegen `testing` öffnen, nicht `main`
+- Copilot öffnet PRs automatisch gegen `main` → vor Merge: `gh pr edit <nr> --base testing`
+- `gh pr merge` erlaubt kein `--base`-Flag — Basis muss vorher im PR geändert werden
+- Nach jedem main-Merge: staging und testing synchronisieren
+
+## Merge-Workflow (PR → staging → main)
+
+```bash
+gh pr merge <nr> --squash --delete-branch
+git checkout main && git merge staging && git push origin main
+git checkout staging && git merge main && git push origin staging
+git checkout testing && git merge main && git push origin testing
+git checkout main
+```
+
+---
+
+## Versionsbump-Checkliste
+
+Beim Erhöhen der Version IMMER alle drei Stellen aktualisieren:
+1. `package.json` → `version`
+2. `app.json` → `expo.version` + `android.versionCode` (+1)
+3. `utils/constants.ts` → `APP_VERSION`
+
+→ Wird `constants.ts` vergessen, schlägt der CI-Check "version consistency" fehl.
+→ Skript: `./scripts/bump-version.sh patch|minor|major`
+
+**bump Input bei CI:** IMMER `none` verwenden — Branch Protection blockiert Bot-Pushes auf `main`.
+
+---
+
+## Build-Workflow (Übersicht)
+
+- **APK (Test):** Lokal bauen — Details in `docs/private/CLAUDE.md`
+- **AAB (Play Store):** GitHub Actions → `Build Android` → profile: `production`
+- Workflow: `.github/workflows/build-android.yml`
+
+---
 
 ## Testing
 
@@ -29,35 +70,81 @@ npm run test:coverage # Coverage
 - `@testing-library/react` (nicht react-native)
 - `window.getComputedStyle` funktioniert für RN-Styles (jsdom + RNW)
 
+### Jest-Konfiguration — Fallstricke
+
+- `expo-linear-gradient`, `expo-font`, `expo-status-bar`, `@expo-google-fonts` müssen in `transformIgnorePatterns` **und** `moduleNameMapper` eingetragen sein
+- Neue Expo-Pakete immer in **beiden** Listen ergänzen
+- `usePreferences.test.tsx` hat strukturelle React 19 `act()`-Warnung — Issue #160 (low priority)
+
+---
+
+## Aktueller Stand (2026-05-10)
+
+- Version: **1.3.4** / versionCode 24
+- Tests: 415 passed, 3 skipped, 13/13 Suites grün
+- Branches: `staging` und `main` synchron; `testing` 2 Commits hinter staging
+- Offene Issues: #165, #160, #156, #146, #131, #100, #96
+- Security: 21 Vulnerabilities (alle über Expo-Tooling, build-time) → Issue #146
+
+### Zuletzt gemergt (staging)
+
+| PR | Was |
+|----|-----|
+| #177 | TypeScript-Fixes in Test-Dateien + isValidSessionRecord Enum-Validierung + Challenge-Ops Fix |
+| #175 | Eltern-Dashboard als Beta kennzeichnen + 7→28 Tage Fix + Copilot-Review-Fixes |
+| #174 | Eltern-Dashboard (SessionRecord, ParentDashboard-Modal, Storage, i18n) |
+| #173 | CLAUDE.md erstellt |
+| #171 | Dark-Mode Chip-Kontrast + Settings-Font |
+
+---
+
 ## Wichtige Dateien
 
-| Datei                              | Inhalt                                          |
-|------------------------------------|-------------------------------------------------|
-| `utils/constants.ts`               | Farben (THEME_COLORS), DESIGN_TOKENS, STORAGE_KEYS |
-| `utils/theme.ts`                   | `getThemeColors(isDarkMode)`                    |
-| `utils/storage.ts`                 | Storage-Helfer inkl. `saveSessionRecord` / `getSessionRecords` |
-| `types/game.ts`                    | ThemeColors, GameState, Enums, `SessionRecord`  |
-| `jest.config.js`                   | Jest-Konfiguration                              |
-| `components/Chip.tsx`              | Chip-Button (theme-aware seit #171)             |
-| `components/ParentDashboard.tsx`   | Eltern-Dashboard Modal (neu seit #174)          |
+| Datei | Inhalt |
+|-------|--------|
+| `utils/constants.ts` | THEME_COLORS, DESIGN_TOKENS, STORAGE_KEYS, CHALLENGE_LEVELS |
+| `utils/theme.ts` | `getThemeColors(isDarkMode)` |
+| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `FOUR_WEEKS_MS` |
+| `utils/animations.ts` | `prefersReducedMotion()` — liest Accessibility-Einstellung |
+| `types/game.ts` | ThemeColors, GameState, Enums, SessionRecord |
+| `i18n/translations.ts` | DE/EN Übersetzungen, `TranslationStrings`-Interface |
+| `hooks/useGameLogic.ts` | Gesamte Spiellogik, `onSessionComplete`-Callback |
+| `components/ParentDashboard.tsx` | Eltern-Dashboard Modal (Beta) |
+| `components/GameCard.tsx` | Hauptspielansicht (alle 3 Antwortmodi) |
+| `styles/modalStyles.ts` | Gemeinsame Modal-Styles |
+| `jest.config.js` | Jest-Konfiguration |
+| `docs/private/CLAUDE.md` | Sensible Build/Keystore-Details (gitignored) |
 
-## Letzte Änderungen
+---
 
-### PR #174 → testing (2026-05-08) – offen, CI pending
-Schließt Issue #169 – Eltern-Dashboard
-- `types/game.ts`: Neues `SessionRecord`-Interface (timestamp, operations, correctTasks, errors, errorRate, difficultyMode, numberRange)
-- `utils/constants.ts`: Storage-Key `app-parent-stats` ergänzt
-- `utils/storage.ts`: `saveSessionRecord()` + `getSessionRecords()` – Einträge älter als 28 Tage werden automatisch bereinigt
-- `hooks/useGameLogic.ts`: Optionaler `onSessionComplete`-Callback; wird nach jeder Runde (Normal, Kreativ, Challenge) aufgerufen – außerhalb des `setGameState`-Updaters
-- `components/ParentDashboard.tsx`: Neues Modal – Sitzungsliste nach Tag gruppiert, Fehlerquote farbcodiert (grün ≤10%, gelb ≤30%, rot >30%), 7-Tage-Zusammenfassung, Challenge-Badge ⚡
-- `components/SettingsMenu.tsx`: „Eltern-Dashboard"-Button neben „Personalisieren"; neues Prop `onOpenParentDashboard`
-- `i18n/translations.ts`: 10 neue Keys (DE/EN) – `parentDashboard`, `parentDashboardSubtitle`, `parentNoData`, `parentSessions`, `parentAvgError`, `parentToday`, `parentYesterday`, `parentCorrect`, `parentErrors`
-- `App.tsx`: `saveSessionRecord` in `onSessionComplete`; `parentDashboardVisible`-State; `<ParentDashboard>`-Einbindung
+## Architektur-Fallstricke
 
-### PR #171 → testing (2026-05-06)
-- `Chip.tsx`: Dark-Mode-Fix – hardcodierte Farben durch `colors.buttonInactive` / `colors.buttonInactiveText` ersetzt
-- `PersonalizeModal.tsx`, `SettingsMenu.tsx`: Titel-Font `FONT_NUMBER` → `FONT_UI`
-- `Chip.test.tsx`: Neuer Regressionstest für Dark-Mode-Kontrast
+- **`APP_VERSION` in `utils/constants.ts`** beim Versionsbump leicht vergessen → immer `bump-version.sh` verwenden
+- **Animated-Wrapper brauchen flex:** `Pressable` > `Animated.View` → Pressable braucht `style={{ flex: 1 }}`, sonst füllen Buttons in flex-row nicht die Breite
+- **Keine Early Returns vor Hooks!** React Error #310 — alle Hooks müssen immer in gleicher Reihenfolge aufgerufen werden
+- **fontWeight auf Android:** Nur `'normal'`/`'bold'`/`'400'`/`'700'` verwenden — `'500'`/`'600'` werden auf älteren Geräten nicht interpoliert → Text unsichtbar (Issue #138)
+- **elevation + transparent:** Kein `elevation > 0` bei `backgroundColor: 'transparent'` → weißer Kasten auf Android (Issue #138)
+- **numpadRow braucht feste Höhe:** `height: 60` + `alignItems: 'stretch'` nötig
+- **GameCard Layout:** `justifyContent: 'center'` + `gap: 16` statt `space-between`
+- **Deploy Race Condition:** Alle 3 Deploy-Workflows müssen dieselbe `concurrency.group` teilen (`gh-pages-deploy`)
+- **Number Sequence Grid:** 2-Spalten-Grid (`width: '48%'`, `flexWrap: 'wrap'`) für kleine Bildschirme
+- **Merge-Konflikt staging→main:** temporäre Workflow-Dateien können kollidieren → staging-Version bevorzugen
+- **Expo-Pakete in Jest:** Neue Pakete immer in `transformIgnorePatterns` **und** `moduleNameMapper` eintragen
 
-### PR #172 → staging (2026-05-06)
-- Promotion von `testing` → `staging` (enthält #171)
+---
+
+## Eltern-Dashboard (Beta) — Hinweise
+
+- `SessionRecord` wird nach jeder Runde (Normal, Kreativ, Challenge) gespeichert
+- Challenge-Sessions: `operations` kommt aus `getChallengeLevel(score).operations`, nicht aus `selectedOperations`
+- `getSessionRecords()` prunet automatisch Einträge älter als 28 Tage und schreibt zurück
+- `FOUR_WEEKS_MS` ist in `utils/storage.ts` exportiert — nicht duplizieren
+- `isValidSessionRecord` validiert alle Felder gegen Enum-Werte
+
+---
+
+## Offene TODOs / Bekannte Einschränkungen
+
+- Größere Dependency-Updates verschoben: react-native 0.84, jest 30, react 19.2.4, async-storage 3.x
+- jest 30 würde 4x low Vulnerabilities (jest-environment-jsdom) beheben → Issue #146
+- Reanimated wurde durch `Animated` core ersetzt (Web-Kompatibilität) — Issue #131

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# 1x1 Trainer – Claude Memory
+
+## Branch-Workflow
+
+```
+feature/fix → testing → staging → main
+```
+
+| Branch    | Zweck                              | Status    |
+|-----------|------------------------------------|-----------|
+| `main`    | Produktion (protected)             | stabil    |
+| `staging` | Pre-Release, Qualitätssicherung    | aktuell   |
+| `testing` | Integration neuer Features/Fixes   | aktuell   |
+
+- PRs von Copilot/Claude landen zunächst gegen `testing`, nicht `main`
+- Nach Review und CI-Grün: `testing → staging` per Squash-Merge
+- `staging → main` nur für echte Releases
+
+## Testing
+
+```bash
+npm test              # Jest
+npm run test:watch    # Watch-Modus
+npm run test:coverage # Coverage
+```
+
+- Test-Runner: Jest + jsdom
+- React Native → React Native Web (via `moduleNameMapper`)
+- `@testing-library/react` (nicht react-native)
+- `window.getComputedStyle` funktioniert für RN-Styles (jsdom + RNW)
+
+## Wichtige Dateien
+
+| Datei                              | Inhalt                                          |
+|------------------------------------|-------------------------------------------------|
+| `utils/constants.ts`               | Farben (THEME_COLORS), DESIGN_TOKENS, STORAGE_KEYS |
+| `utils/theme.ts`                   | `getThemeColors(isDarkMode)`                    |
+| `utils/storage.ts`                 | Storage-Helfer inkl. `saveSessionRecord` / `getSessionRecords` |
+| `types/game.ts`                    | ThemeColors, GameState, Enums, `SessionRecord`  |
+| `jest.config.js`                   | Jest-Konfiguration                              |
+| `components/Chip.tsx`              | Chip-Button (theme-aware seit #171)             |
+| `components/ParentDashboard.tsx`   | Eltern-Dashboard Modal (neu seit #174)          |
+
+## Letzte Änderungen
+
+### PR #174 → testing (2026-05-08) – offen, CI pending
+Schließt Issue #169 – Eltern-Dashboard
+- `types/game.ts`: Neues `SessionRecord`-Interface (timestamp, operations, correctTasks, errors, errorRate, difficultyMode, numberRange)
+- `utils/constants.ts`: Storage-Key `app-parent-stats` ergänzt
+- `utils/storage.ts`: `saveSessionRecord()` + `getSessionRecords()` – Einträge älter als 28 Tage werden automatisch bereinigt
+- `hooks/useGameLogic.ts`: Optionaler `onSessionComplete`-Callback; wird nach jeder Runde (Normal, Kreativ, Challenge) aufgerufen – außerhalb des `setGameState`-Updaters
+- `components/ParentDashboard.tsx`: Neues Modal – Sitzungsliste nach Tag gruppiert, Fehlerquote farbcodiert (grün ≤10%, gelb ≤30%, rot >30%), 7-Tage-Zusammenfassung, Challenge-Badge ⚡
+- `components/SettingsMenu.tsx`: „Eltern-Dashboard"-Button neben „Personalisieren"; neues Prop `onOpenParentDashboard`
+- `i18n/translations.ts`: 10 neue Keys (DE/EN) – `parentDashboard`, `parentDashboardSubtitle`, `parentNoData`, `parentSessions`, `parentAvgError`, `parentToday`, `parentYesterday`, `parentCorrect`, `parentErrors`
+- `App.tsx`: `saveSessionRecord` in `onSessionComplete`; `parentDashboardVisible`-State; `<ParentDashboard>`-Einbindung
+
+### PR #171 → testing (2026-05-06)
+- `Chip.tsx`: Dark-Mode-Fix – hardcodierte Farben durch `colors.buttonInactive` / `colors.buttonInactiveText` ersetzt
+- `PersonalizeModal.tsx`, `SettingsMenu.tsx`: Titel-Font `FONT_NUMBER` → `FONT_UI`
+- `Chip.test.tsx`: Neuer Regressionstest für Dark-Mode-Kontrast
+
+### PR #172 → staging (2026-05-06)
+- Promotion von `testing` → `staging` (enthält #171)

--- a/components/Chip.test.tsx
+++ b/components/Chip.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { Chip } from './Chip';
+import { getThemeColors } from '../utils/theme';
+
+describe('Chip', () => {
+  it('uses theme-aware inactive colors in dark mode', () => {
+    const colors = getThemeColors(true);
+    const { getByText } = render(
+      <Chip label="Dark" active={false} onPress={jest.fn()} colors={colors} />
+    );
+
+    const label = getByText('Dark');
+    const button = label.closest('[role="button"]') ?? label.parentElement;
+
+    expect(button).not.toBeNull();
+    expect(window.getComputedStyle(button as Element).backgroundColor).toBe('rgb(30, 41, 59)'); // platform-safe
+    expect(window.getComputedStyle(label).color).toBe('rgb(148, 163, 184)'); // platform-safe
+  });
+
+  it('keeps the active state contrast and remains clickable', () => {
+    const colors = getThemeColors(true);
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <Chip label="System" active onPress={onPress} colors={colors} />
+    );
+
+    const label = getByText('System');
+    const button = label.closest('[role="button"]') ?? label.parentElement;
+
+    fireEvent.click(label);
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(button).not.toBeNull();
+    expect(window.getComputedStyle(button as Element).backgroundColor).toBe('rgb(102, 126, 234)'); // platform-safe
+    expect(window.getComputedStyle(label).color).toBe('rgb(255, 255, 255)'); // platform-safe
+  });
+});

--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -17,7 +17,7 @@ export function Chip({ label, active, onPress, colors, disabled = false, size = 
     <TouchableOpacity
       style={[
         styles.chip,
-        { borderColor: colors.border },
+        { backgroundColor: colors.buttonInactive, borderColor: colors.border },
         active && styles.chipActive,
         disabled && { opacity: 0.6 },
         size === 'sm' && styles.chipSm,
@@ -28,7 +28,7 @@ export function Chip({ label, active, onPress, colors, disabled = false, size = 
       <Text
         style={[
           styles.chipText,
-          { color: colors.text },
+          { color: colors.buttonInactiveText },
           active && styles.chipTextActive,
           size === 'sm' && styles.chipTextSm,
         ]}
@@ -49,7 +49,6 @@ const styles = StyleSheet.create({
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     borderWidth: 2,
     borderColor: '#dde3ff',
-    backgroundColor: '#f7f8ff',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -64,7 +63,6 @@ const styles = StyleSheet.create({
   chipText: {
     fontSize: 14,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: '#2d2b55',
   },
   chipTextActive: {
     color: '#fff',

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode } from '../types/game';
+import { getSessionRecords } from '../utils/storage';
+import { DESIGN_TOKENS } from '../utils/constants';
+import { modalStyles } from '../styles/modalStyles';
+
+const OP_SYMBOL: Record<Operation, string> = {
+  [Operation.ADDITION]: '+',
+  [Operation.SUBTRACTION]: '−',
+  [Operation.MULTIPLICATION]: '×',
+  [Operation.DIVISION]: '÷',
+};
+
+interface ParentDashboardProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  t: {
+    parentDashboard: string;
+    parentDashboardSubtitle: string;
+    parentNoData: string;
+    parentSessions: string;
+    parentAvgError: string;
+    parentToday: string;
+    parentYesterday: string;
+    parentCorrect: string;
+    parentErrors: string;
+    ok: string;
+  };
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const h = d.getHours().toString().padStart(2, '0');
+  const m = d.getMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+function formatDate(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+}
+
+function isSameDay(ts: number, reference: Date): boolean {
+  const d = new Date(ts);
+  return (
+    d.getFullYear() === reference.getFullYear() &&
+    d.getMonth() === reference.getMonth() &&
+    d.getDate() === reference.getDate()
+  );
+}
+
+function groupByDay(records: SessionRecord[]): { label: string; entries: SessionRecord[] }[] {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const map = new Map<string, SessionRecord[]>();
+
+  for (const r of [...records].sort((a, b) => b.timestamp - a.timestamp)) {
+    let key: string;
+    if (isSameDay(r.timestamp, today)) {
+      key = '__today__';
+    } else if (isSameDay(r.timestamp, yesterday)) {
+      key = '__yesterday__';
+    } else {
+      key = formatDate(r.timestamp);
+    }
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(r);
+  }
+
+  return Array.from(map.entries()).map(([label, entries]) => ({ label, entries }));
+}
+
+function errorRateColor(rate: number): string {
+  if (rate <= 0.1) return '#10B981';
+  if (rate <= 0.3) return '#F59E0B';
+  return '#EF4444';
+}
+
+export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
+  const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setLoading(true);
+      getSessionRecords().then((data) => {
+        setRecords(data);
+        setLoading(false);
+      });
+    }
+  }, [visible]);
+
+  const grouped = groupByDay(records);
+
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const recentRecords = records.filter(r => r.timestamp >= sevenDaysAgo);
+  const avgErrorRate =
+    recentRecords.length > 0
+      ? recentRecords.reduce((sum, r) => sum + r.errorRate, 0) / recentRecords.length
+      : null;
+
+  const getDayLabel = (key: string) => {
+    if (key === '__today__') return t.parentToday;
+    if (key === '__yesterday__') return t.parentYesterday;
+    return key;
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[styles.container, { backgroundColor: colors.settingsMenu }]}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.parentDashboard}</Text>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>{t.parentDashboardSubtitle}</Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={[styles.closeText, { color: colors.text }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Summary bar */}
+          {records.length > 0 && (
+            <View style={[styles.summaryBar, { borderColor: colors.border }]}>
+              <View style={styles.summaryItem}>
+                <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
+                <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
+              </View>
+              {avgErrorRate !== null && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {avgErrorRate !== null && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: errorRateColor(avgErrorRate) }]}>
+                    {Math.round(avgErrorRate * 100)}%
+                  </Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
+                </View>
+              )}
+            </View>
+          )}
+
+          {/* Content */}
+          {loading ? (
+            <ActivityIndicator style={styles.loader} color={DESIGN_TOKENS.GRADIENT_PRIMARY[0]} />
+          ) : records.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{t.parentNoData}</Text>
+          ) : (
+            <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
+              {grouped.map(({ label, entries }) => (
+                <View key={label}>
+                  <Text style={[styles.dayLabel, { color: colors.textSecondary }]}>{getDayLabel(label)}</Text>
+                  {entries.map((r) => (
+                    <View key={r.id} style={[styles.row, { borderColor: colors.border }]}>
+                      <Text style={[styles.rowTime, { color: colors.textSecondary }]}>{formatTime(r.timestamp)}</Text>
+                      <Text style={[styles.rowOps, { color: colors.text }]}>
+                        {r.operations.map(op => OP_SYMBOL[op]).join(' ')}
+                      </Text>
+                      <Text style={[styles.rowScore, { color: colors.text }]}>
+                        {r.correctTasks}/{r.totalTasks}
+                      </Text>
+                      <View style={[styles.errorBadge, { backgroundColor: errorRateColor(r.errorRate) + '22' }]}>
+                        <Text style={[styles.errorBadgeText, { color: errorRateColor(r.errorRate) }]}>
+                          {Math.round(r.errorRate * 100)}%
+                        </Text>
+                      </View>
+                      {r.difficultyMode === DifficultyMode.CHALLENGE && (
+                        <Text style={styles.challengeBadge}>⚡</Text>
+                      )}
+                    </View>
+                  ))}
+                </View>
+              ))}
+            </ScrollView>
+          )}
+
+          {/* Close button */}
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Text style={styles.closeBtnText}>{t.ok}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 24,
+    padding: 20,
+    width: '90%',
+    maxWidth: 420,
+    maxHeight: '85%',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  subtitle: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+  },
+  closeButton: {
+    padding: 6,
+    minWidth: 36,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  summaryBar: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderRadius: 12,
+    marginBottom: 14,
+    overflow: 'hidden',
+  },
+  summaryItem: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  summaryDivider: {
+    width: 1,
+  },
+  summaryValue: {
+    fontSize: 22,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+  },
+  summaryLabel: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+    textAlign: 'center',
+  },
+  loader: {
+    marginVertical: 32,
+  },
+  emptyText: {
+    textAlign: 'center',
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginVertical: 32,
+  },
+  list: {
+    maxHeight: 340,
+    marginBottom: 12,
+  },
+  dayLabel: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 10,
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderBottomWidth: 1,
+    gap: 8,
+  },
+  rowTime: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    width: 38,
+  },
+  rowOps: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    flex: 1,
+    letterSpacing: 2,
+  },
+  rowScore: {
+    fontSize: 13,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    minWidth: 36,
+    textAlign: 'right',
+  },
+  errorBadge: {
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 8,
+    minWidth: 42,
+    alignItems: 'center',
+  },
+  errorBadgeText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  challengeBadge: {
+    fontSize: 13,
+  },
+  closeBtn: {
+    backgroundColor: ACTIVE_COLOR,
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  closeBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
     letterSpacing: 0.3,
   },

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -30,6 +30,7 @@ interface SettingsMenuProps {
   onHideMenu: () => void;
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
+  onOpenParentDashboard: () => void;
   // Translations
   t: {
     operation: string;
@@ -50,6 +51,7 @@ interface SettingsMenuProps {
     upTo50: string;
     upTo100: string;
     personalize: string;
+    parentDashboard: string;
     feedback: string;
     support: string;
     about: string;
@@ -70,6 +72,7 @@ export function SettingsMenu({
   onHideMenu,
   onOpenPersonalize,
   onOpenAbout,
+  onOpenParentDashboard,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -102,12 +105,18 @@ export function SettingsMenu({
         <ScrollView bounces={false}>
 
         {/* Personalize Button */}
-        <View style={styles.settingsSection}>
+        <View style={[styles.settingsSection, styles.topButtonsSection]}>
           <TouchableOpacity
             style={styles.personalizeButton}
             onPress={onOpenPersonalize}
           >
             <Text style={styles.personalizeButtonText}>{t.personalize}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.personalizeButton}
+            onPress={() => { onOpenParentDashboard(); onHideMenu(); }}
+          >
+            <Text style={styles.personalizeButtonText}>{t.parentDashboard}</Text>
           </TouchableOpacity>
         </View>
 
@@ -319,6 +328,9 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontFamily: DESIGN_TOKENS.FONT_UI,
     color: ACTIVE_COLOR,
+  },
+  topButtonsSection: {
+    gap: 8,
   },
   personalizeButton: {
     width: '100%',

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -294,7 +294,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
     letterSpacing: 0.3,
   },

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -4,15 +4,16 @@
  */
 
 import { useState, useMemo } from 'react';
-import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState } from '../types/game';
+import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord } from '../types/game';
 import { TOTAL_TASKS, MAX_CHOICE_GENERATION_ATTEMPTS, MAX_RANDOM_ANSWER, CHALLENGE_MAX_LIVES, getChallengeLevel, getChallengeLevelNumber } from '../utils/constants';
 
 interface UseGameLogicProps {
   initialOperation: Operation;
-  initialOperations?: Operation[]; // Optional: array of selected operations
+  initialOperations?: Operation[];
   initialTotalSolvedTasks: number;
   onTotalSolvedTasksChange: (total: number) => void;
   onMotivationShow: (score: number) => void;
+  onSessionComplete?: (record: SessionRecord) => void;
   numberRange: NumberRange;
   challengeHighScore?: number;
   onChallengeHighScoreChange?: (score: number) => void;
@@ -136,6 +137,7 @@ export function useGameLogic({
   initialTotalSolvedTasks,
   onTotalSolvedTasksChange,
   onMotivationShow,
+  onSessionComplete,
   numberRange,
   challengeHighScore = 0,
   onChallengeHighScoreChange,
@@ -181,6 +183,27 @@ export function useGameLogic({
     totalSolvedTasks: initialTotalSolvedTasks,
     selectedChoice: null,
   });
+
+  const fireSessionComplete = (finalScore: number, totalTasks: number, selectedOperations: Set<Operation>) => {
+    if (!onSessionComplete) return;
+    const errors = totalTasks - finalScore;
+    const effectiveRange =
+      gameState.difficultyMode === DifficultyMode.CHALLENGE
+        ? getChallengeLevel(finalScore).numberRange
+        : numberRange;
+    const record: SessionRecord = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      timestamp: Date.now(),
+      operations: Array.from(selectedOperations),
+      totalTasks,
+      correctTasks: finalScore,
+      errors,
+      errorRate: totalTasks > 0 ? errors / totalTasks : 0,
+      difficultyMode: gameState.difficultyMode,
+      numberRange: effectiveRange,
+    };
+    onSessionComplete(record);
+  };
 
   // Helper: Get correct answer for current question
   const getCorrectAnswer = () => {
@@ -383,6 +406,14 @@ export function useGameLogic({
     }
 
     const newScore = isCorrect ? gameState.score + 1 : gameState.score;
+    const challengeGameOver =
+      gameState.difficultyMode === DifficultyMode.CHALLENGE &&
+      gameState.challengeState !== undefined &&
+      !isCorrect &&
+      gameState.challengeState.lives - 1 <= 0;
+    if (challengeGameOver) {
+      fireSessionComplete(newScore, gameState.currentTask, gameState.selectedOperations);
+    }
 
     setGameState((prev) => {
       const newState: GameState = {
@@ -458,6 +489,10 @@ export function useGameLogic({
     const isLastTask = gameState.currentTask === gameState.totalTasks;
     const newTotalSolvedTasks = gameState.totalSolvedTasks + 1;
 
+    if (isLastTask) {
+      fireSessionComplete(gameState.score, gameState.totalTasks, gameState.selectedOperations);
+    }
+
     setGameState((prev) => {
       // Show motivation message after every 10 tasks
       if (newTotalSolvedTasks > 0 && newTotalSolvedTasks % 10 === 0) {
@@ -465,7 +500,6 @@ export function useGameLogic({
       }
 
       if (isLastTask) {
-        // Last task - show results
         return {
           ...prev,
           showResult: true,

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -83,6 +83,16 @@ export interface TranslationStrings {
   tryAgain: string;
   settings: string;
   ok: string;
+  // Parent Dashboard
+  parentDashboard: string;
+  parentDashboardSubtitle: string;
+  parentNoData: string;
+  parentSessions: string;
+  parentAvgError: string;
+  parentToday: string;
+  parentYesterday: string;
+  parentCorrect: string;
+  parentErrors: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -164,6 +174,16 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Settings',
     ok: 'OK',
     encouragement: 'You can do it! 💪',
+    // Parent Dashboard
+    parentDashboard: 'Parent Dashboard',
+    parentDashboardSubtitle: 'Last 4 weeks · tap ✕ to close',
+    parentNoData: 'No sessions recorded yet. Play a few rounds first!',
+    parentSessions: 'Sessions (7 days)',
+    parentAvgError: 'Avg. Error Rate',
+    parentToday: 'Today',
+    parentYesterday: 'Yesterday',
+    parentCorrect: 'Correct',
+    parentErrors: 'Errors',
   },
   de: {
     // Settings Menu
@@ -243,5 +263,15 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Einstellungen',
     ok: 'OK',
     encouragement: 'Du schaffst das! 💪',
+    // Parent Dashboard
+    parentDashboard: 'Eltern-Dashboard',
+    parentDashboardSubtitle: 'Letzte 4 Wochen · ✕ zum Schließen',
+    parentNoData: 'Noch keine Einheiten gespeichert. Spielt zuerst ein paar Runden!',
+    parentSessions: 'Einheiten (7 Tage)',
+    parentAvgError: 'Ø Fehlerquote',
+    parentToday: 'Heute',
+    parentYesterday: 'Gestern',
+    parentCorrect: 'Richtig',
+    parentErrors: 'Fehler',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -67,6 +67,18 @@ export interface GameState {
   challengeState?: ChallengeState; // Challenge mode state
 }
 
+export interface SessionRecord {
+  id: string;
+  timestamp: number;
+  operations: Operation[];
+  totalTasks: number;
+  correctTasks: number;
+  errors: number;
+  errorRate: number;
+  difficultyMode: DifficultyMode;
+  numberRange: NumberRange;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -22,6 +22,7 @@ export const STORAGE_KEYS = {
   TOTAL_TASKS: 'app-total-tasks',
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
+  PARENT_STATS: 'app-parent-stats',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -21,8 +21,10 @@ import {
   getNumberRange,
   saveChallengeHighScore,
   getChallengeHighScore,
+  saveSessionRecord,
+  getSessionRecords,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -446,5 +448,92 @@ describe('Challenge High Score Storage', () => {
     await saveChallengeHighScore(25);
     const result = await getChallengeHighScore();
     expect(result).toBe(25);
+  });
+});
+
+describe('Session Records Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  const makeRecord = (overrides: Partial<SessionRecord> = {}): SessionRecord => ({
+    id: 'test-id',
+    timestamp: Date.now(),
+    operations: [Operation.MULTIPLICATION],
+    totalTasks: 10,
+    correctTasks: 8,
+    errors: 2,
+    errorRate: 0.2,
+    difficultyMode: DifficultyMode.SIMPLE,
+    numberRange: NumberRange.RANGE_10,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return empty array when no records stored', async () => {
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should save and retrieve a session record', async () => {
+    const record = makeRecord({ id: 'abc' });
+    await saveSessionRecord(record);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('abc');
+    expect(result[0].correctTasks).toBe(8);
+    expect(result[0].errorRate).toBe(0.2);
+  });
+
+  it('should accumulate multiple records', async () => {
+    await saveSessionRecord(makeRecord({ id: 'r1' }));
+    await saveSessionRecord(makeRecord({ id: 'r2' }));
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(2);
+  });
+
+  it('should prune records older than 28 days', async () => {
+    const old = makeRecord({ id: 'old', timestamp: Date.now() - 29 * 24 * 60 * 60 * 1000 });
+    const fresh = makeRecord({ id: 'fresh', timestamp: Date.now() });
+    mockStore['app-parent-stats'] = JSON.stringify([old, fresh]);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('fresh');
+  });
+
+  it('should filter out malformed entries missing operations', async () => {
+    const bad = { id: 'bad', timestamp: Date.now(), totalTasks: 10 };
+    const good = makeRecord({ id: 'good' });
+    mockStore['app-parent-stats'] = JSON.stringify([bad, good]);
+    const result = await getSessionRecords();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('good');
+  });
+
+  it('should return empty array for corrupted JSON', async () => {
+    mockStore['app-parent-stats'] = '{not valid json}';
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when stored value is not an array', async () => {
+    mockStore['app-parent-stats'] = '{"id":"x"}';
+    const result = await getSessionRecords();
+    expect(result).toEqual([]);
+  });
+
+  it('should correctly compute error rate in saved record', async () => {
+    const record = makeRecord({ totalTasks: 10, correctTasks: 7, errors: 3, errorRate: 0.3 });
+    await saveSessionRecord(record);
+    const [retrieved] = await getSessionRecords();
+    expect(retrieved.errorRate).toBe(0.3);
+    expect(retrieved.errors).toBe(3);
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, SessionRecord } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -146,6 +146,46 @@ export const getChallengeHighScore = async (): Promise<number> => {
     return isNaN(parsed) ? 0 : parsed;
   }
   return 0;
+};
+
+const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
+
+function isValidSessionRecord(r: unknown): r is SessionRecord {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.timestamp === 'number' &&
+    Array.isArray(obj.operations) &&
+    typeof obj.totalTasks === 'number' &&
+    typeof obj.correctTasks === 'number' &&
+    typeof obj.errors === 'number' &&
+    typeof obj.errorRate === 'number' &&
+    typeof obj.difficultyMode === 'string' &&
+    typeof obj.numberRange === 'string'
+  );
+}
+
+function pruneOldRecords(records: SessionRecord[], now: number): SessionRecord[] {
+  return records.filter(r => now - r.timestamp < FOUR_WEEKS_MS);
+}
+
+export const getSessionRecords = async (): Promise<SessionRecord[]> => {
+  const value = await getStorageItem(STORAGE_KEYS.PARENT_STATS);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return pruneOldRecords(parsed.filter(isValidSessionRecord), Date.now());
+  } catch {
+    return [];
+  }
+};
+
+export const saveSessionRecord = async (record: SessionRecord): Promise<void> => {
+  const records = await getSessionRecords();
+  records.push(record);
+  await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {


### PR DESCRIPTION
## Summary
- `CLAUDE.md` (Root, öffentlich): Workflow, Architektur, Fallstricke, aktueller Stand — keine sensiblen Daten
- `docs/private/CLAUDE.md` (gitignored, neu): Keystore-Details, Gerät-IDs, adb-Befehle, Secrets — nur lokal verfügbar

## Motivation
Das Repo ist öffentlich. Claude Code wird auch auf dem iPhone (mobile App) verwendet, wo kein Zugriff auf gitignored Dateien besteht. Die Root-`CLAUDE.md` ist vom Telefon aus lesbar und gibt Claude genug Kontext für Code-Arbeit. Sensibles bleibt ausschließlich lokal.

**Telefon-Workflow:** iPhone-Notizen ans Ende der Root-`CLAUDE.md` → am Mac in die richtige Schicht einsortieren.

## Test plan
- [ ] `grep -E "ZX1G426LLK|1x1Trainer2025Secure|SHA" CLAUDE.md` → kein Treffer
- [ ] `git check-ignore docs/private/CLAUDE.md` → bestätigt gitignored

🤖 Generated with [Claude Code](https://claude.ai/claude-code)