### PR TITLE
ci: Node 24 für GitHub Actions aktivieren

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -27,7 +27,7 @@ permissions:
   contents: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -26,6 +26,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: 🤖 Android Build (${{ inputs.profile }})

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   # ============================================================================
   # JOB 1: Code Quality & Linting

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,6 +13,9 @@ concurrency:
   group: "gh-pages-deploy"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   deploy-staging:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "gh-pages-deploy"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: "gh-pages-deploy"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub Actions depreciert Node.js 20 ab dem 2. Juni 2026. Diese Änderung setzt `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` als Workflow-Variable, damit alle Actions schon jetzt mit Node 24 laufen.

Betroffen: `actions/checkout@v4`, `actions/setup-java@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>