### PR TITLE
fix(ci): ci-cd.yml-Startup-Failure beheben (Issue #152-Regression)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -321,9 +321,14 @@ jobs:
 
       - name: Scan for hardcoded keystore passwords
         run: |
+          # GitHub-Actions-Expression-Start ($ + doppelte Mustache) muss in einer
+          # Variable versteckt werden, sonst versucht der Workflow-Parser, den
+          # 'run:'-Block als Expression zu lexen und der gesamte Workflow startet
+          # nicht (0s-Startup-Failure, keine Jobs).
+          GHA_EXPR_START='${'"{"
           if grep -rEi "keystorePassword\s*=\s*['\"][^'\"]+['\"]|keyPassword\s*=\s*['\"][^'\"]+['\"]|storePassword\s*=\s*['\"][^'\"]+['\"]" . \
               --include="*.gradle" --include="*.gradle.kts" --include="*.yml" --include="*.yaml" 2>/dev/null \
-              | grep -qv "\${{"; then
+              | grep -qvF "$GHA_EXPR_START"; then
             echo "❌ Hardcoded keystore password found! Use GitHub Secrets instead."; exit 1
           fi
           echo "✅ No hardcoded keystore passwords"


### PR DESCRIPTION
## Summary

Behebt den seit 2026-04-22 bestehenden CI-Startup-Failure von \`ci-cd.yml\`. Alle Runs endeten in 0s mit 0 Jobs auf allen Branches.

**Ursache:** In Commit \`a8a51a1\` (Issue #152) wurde in \`keystore-secrets.Scan for hardcoded keystore passwords\` die Sequenz \`\${{\` in einem Shell-String verwendet. GitHubs Workflow-Parser scannt \`run:\`-Blöcke nach Expressions (\`\${{ ... }}\`) **bevor** die Shell läuft und stolpert am folgenden \`"\` — die gesamte YAML-Validierung schlägt fehl, ohne dass ein Job erzeugt wird.

**Fix:** Das Literal \`\${\` + \`{\` wird via Shell-String-Konkatenation in einer Variable versteckt, sodass der Workflow-Parser es nicht mehr als Expression-Start interpretiert. Funktional identisch.

## Verifikation

\`actionlint 1.7.12\` vor/nach:

- **vorher:** \`got unexpected character '"' while lexing expression\` bei Zeile 323:269
- **nachher:** keine Expression-Lexer-Fehler mehr (nur Shellcheck-Infos, kein Blocker)

Run-Profil:
- Letzter Erfolg: Run 24795157708 (2026-04-22)
- Stream-Beginn Failure: Run 24908807823 (2026-04-24)
- Failed Check-Suites enthielten 0 Check-Runs → Startup-Failure-Profil

## Test plan

- [ ] PR-Check-Run zeigt \`total_count > 0\` Jobs (anstatt 0s-Failure)
- [ ] Mindestens 1 Job konkludiert mit Status (success/failure), nicht "never started"
- [ ] Nach Merge: nächster Push auf \`testing\` triggert echte Job-Runs

## Scope-Disziplin

- Nur eine Datei geändert: \`.github/workflows/ci-cd.yml\`, +6/-1 Zeilen
- Keine App-Code-Änderungen → PWA in Produktion bleibt unberührt
- \`deploy.yml\` (PWA-Deploy) ist von dieser Änderung nicht betroffen

🤖 Generated with [Claude Code](https://claude.com/claude-code)