### PR TITLE
feat: Adaptives Lernen – Übungsmodus mit Schwachstellen-Fokus (Issue #188)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,9 +87,25 @@ export default function App() {
     },
     taskStats,
     onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
-      recordTaskResult(num1, num2, operation, isCorrect).then(() => {
-        getTaskStats().then(setTaskStats);
+      setTaskStats(prev => {
+        const idx = prev.findIndex(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
+        if (idx >= 0) {
+          const updated = { ...prev[idx] };
+          if (isCorrect) updated.correctCount++;
+          else updated.errorCount++;
+          updated.lastSeen = new Date().toISOString();
+          const next = [...prev];
+          next[idx] = updated;
+          return next;
+        }
+        return [...prev, {
+          num1, num2, operation,
+          correctCount: isCorrect ? 1 : 0,
+          errorCount: isCorrect ? 0 : 1,
+          lastSeen: new Date().toISOString(),
+        }];
       });
+      recordTaskResult(num1, num2, operation, isCorrect);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,

--- a/App.tsx
+++ b/App.tsx
@@ -33,8 +33,8 @@ import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord } from './utils/storage';
-import { SessionRecord } from './types/game';
+import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks } from './utils/storage';
+import { SessionRecord, TaskStat, Operation } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -53,10 +53,15 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
     return initReducedMotionListener();
+  }, []);
+
+  useEffect(() => {
+    getTaskStats().then(setTaskStats);
   }, []);
 
   // Animation values
@@ -79,6 +84,12 @@ export default function App() {
     },
     onSessionComplete: (record: SessionRecord) => {
       saveSessionRecord(record);
+    },
+    taskStats,
+    onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
+      recordTaskResult(num1, num2, operation, isCorrect).then(() => {
+        getTaskStats().then(setTaskStats);
+      });
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -228,6 +239,7 @@ export default function App() {
           difficultyMode={game.gameState.difficultyMode}
           selectedOperations={game.gameState.selectedOperations}
           numberRange={preferences.numberRange}
+          weakTaskCount={getWeakTasks(taskStats, 3, 0.3).length}
           onToggleOperation={game.toggleOperation}
           onChangeDifficultyMode={game.changeDifficultyMode}
           onSetNumberRange={preferences.setNumberRange}

--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -123,6 +123,34 @@ describe('ParentDashboard', () => {
       <ParentDashboard visible={false} onClose={jest.fn()} colors={colors} t={t} />
     );
     expect(mockGetSessionRecords).not.toHaveBeenCalled();
+    expect(mockGetTaskStats).not.toHaveBeenCalled();
+  });
+
+  it('does not show weak tasks section when no weak stats', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    // Stats exist but error rate is only 20% → not weak
+    mockGetTaskStats.mockResolvedValue([
+      { num1: 3, num2: 4, operation: 'MULTIPLICATION', correctCount: 8, errorCount: 2, lastSeen: new Date().toISOString() },
+    ]);
+    const { queryByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(mockGetTaskStats).toHaveBeenCalled());
+    expect(queryByText(t.parentWeakTasks)).toBeNull();
+  });
+
+  it('shows weak task row when a task has high error rate', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    mockGetTaskStats.mockResolvedValue([
+      { num1: 7, num2: 8, operation: 'MULTIPLICATION', correctCount: 0, errorCount: 3, lastSeen: new Date().toISOString() },
+    ]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(t.parentWeakTasks)).toBeTruthy();
+      expect(getByText('7 × 8')).toBeTruthy();
+    });
   });
 
   it('calls onClose when OK button is pressed', async () => {

--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -8,10 +8,12 @@ import { FOUR_WEEKS_MS } from '../utils/storage';
 jest.mock('../utils/storage', () => ({
   ...jest.requireActual('../utils/storage'),
   getSessionRecords: jest.fn(),
+  getTaskStats: jest.fn(),
 }));
 
-import { getSessionRecords } from '../utils/storage';
+import { getSessionRecords, getTaskStats } from '../utils/storage';
 const mockGetSessionRecords = getSessionRecords as jest.Mock;
+const mockGetTaskStats = getTaskStats as jest.Mock;
 
 const t = {
   parentDashboard: 'Eltern-Dashboard',
@@ -23,6 +25,8 @@ const t = {
   parentYesterday: 'Gestern',
   parentCorrect: 'Richtig',
   parentErrors: 'Fehler',
+  parentWeakTasks: 'Schwachstellen (Top 5)',
+  parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
   ok: 'OK',
 };
 
@@ -45,6 +49,8 @@ describe('ParentDashboard', () => {
   beforeEach(() => {
     mockGetSessionRecords.mockClear();
     mockGetSessionRecords.mockResolvedValue([]);
+    mockGetTaskStats.mockClear();
+    mockGetTaskStats.mockResolvedValue([]);
   });
 
   it('shows empty state when no records', async () => {

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -162,7 +162,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           )}
 
           {/* Weak Tasks Section */}
-          {!loading && records.length > 0 && (
+          {!loading && weakTasks.length > 0 && (
             <View style={[styles.weakSection, { borderColor: colors.border }]}>
               <Text style={[styles.weakTitle, { color: colors.textSecondary }]}>{t.parentWeakTasks}</Text>
               {weakTasks.length === 0 ? (

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -8,8 +8,8 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { ThemeColors, SessionRecord, Operation, DifficultyMode } from '../types/game';
-import { getSessionRecords, FOUR_WEEKS_MS } from '../utils/storage';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode, TaskStat } from '../types/game';
+import { getSessionRecords, getTaskStats, getWeakTasks, FOUR_WEEKS_MS } from '../utils/storage';
 import { DESIGN_TOKENS } from '../utils/constants';
 import { modalStyles } from '../styles/modalStyles';
 
@@ -34,6 +34,8 @@ interface ParentDashboardProps {
     parentYesterday: string;
     parentCorrect: string;
     parentErrors: string;
+    parentWeakTasks: string;
+    parentWeakTasksEmpty: string;
     ok: string;
   };
 }
@@ -90,13 +92,15 @@ function errorRateColor(rate: number): string {
 
 export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
   const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [weakTasks, setWeakTasks] = useState<TaskStat[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setLoading(true);
-      getSessionRecords().then((data) => {
-        setRecords(data);
+      Promise.all([getSessionRecords(), getTaskStats()]).then(([sessions, stats]) => {
+        setRecords(sessions);
+        setWeakTasks(getWeakTasks(stats).slice(0, 5));
         setLoading(false);
       });
     }
@@ -153,6 +157,36 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                   </Text>
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
                 </View>
+              )}
+            </View>
+          )}
+
+          {/* Weak Tasks Section */}
+          {!loading && records.length > 0 && (
+            <View style={[styles.weakSection, { borderColor: colors.border }]}>
+              <Text style={[styles.weakTitle, { color: colors.textSecondary }]}>{t.parentWeakTasks}</Text>
+              {weakTasks.length === 0 ? (
+                <Text style={[styles.weakEmpty, { color: colors.textSecondary }]}>{t.parentWeakTasksEmpty}</Text>
+              ) : (
+                weakTasks.map((s, i) => {
+                  const total = s.correctCount + s.errorCount;
+                  const rate = total > 0 ? s.errorCount / total : 0;
+                  return (
+                    <View key={`${s.num1}-${s.num2}-${s.operation}-${i}`} style={styles.weakRow}>
+                      <Text style={[styles.weakTask, { color: colors.text }]}>
+                        {s.num1} {OP_SYMBOL[s.operation]} {s.num2}
+                      </Text>
+                      <View style={[styles.errorBadge, { backgroundColor: errorRateColor(rate) + '22' }]}>
+                        <Text style={[styles.errorBadgeText, { color: errorRateColor(rate) }]}>
+                          {Math.round(rate * 100)}%
+                        </Text>
+                      </View>
+                      <Text style={[styles.weakAttempts, { color: colors.textSecondary }]}>
+                        {total}×
+                      </Text>
+                    </View>
+                  );
+                })
               )}
             </View>
           )}
@@ -343,6 +377,41 @@ const styles = StyleSheet.create({
   },
   challengeBadge: {
     fontSize: 13,
+  },
+  weakSection: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 10,
+    marginBottom: 12,
+  },
+  weakTitle: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+  weakEmpty: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    fontStyle: 'italic',
+  },
+  weakRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    gap: 8,
+  },
+  weakTask: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    flex: 1,
+  },
+  weakAttempts: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    minWidth: 28,
+    textAlign: 'right',
   },
   closeBtn: {
     backgroundColor: ACTIVE_COLOR,

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -23,6 +23,7 @@ interface SettingsMenuProps {
   difficultyMode: DifficultyMode;
   selectedOperations: Set<Operation>;
   numberRange: NumberRange;
+  weakTaskCount?: number;
   // Actions
   onToggleOperation: (op: Operation) => void;
   onChangeDifficultyMode: (mode: DifficultyMode) => void;
@@ -41,9 +42,11 @@ interface SettingsMenuProps {
     difficultyMode: string;
     simpleMode: string;
     creativeMode: string;
+    practiceMode: string;
     challenge: string;
     simpleModeInfo: string;
     creativeModeInfo: string;
+    practiceModeInfo: string;
     challengeInfo: string;
     numberRange: string;
     upTo10: string;
@@ -67,6 +70,7 @@ export function SettingsMenu({
   difficultyMode,
   selectedOperations,
   numberRange,
+  weakTaskCount,
   onToggleOperation,
   onChangeDifficultyMode,
   onSetNumberRange,
@@ -161,7 +165,7 @@ export function SettingsMenu({
         {/* Difficulty Mode Settings */}
         <View style={styles.settingsSection}>
           <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.difficultyMode}</Text>
-          <View style={styles.themeToggle}>
+          <View style={styles.difficultyGrid}>
             <TouchableOpacity
               style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonActive]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.SIMPLE)}
@@ -189,12 +193,22 @@ export function SettingsMenu({
                 {t.challenge}
               </Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonActive]}
+              onPress={() => onChangeDifficultyMode(DifficultyMode.PRACTICE)}
+            >
+              <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonTextActive]}>
+                {t.practiceMode}{weakTaskCount !== undefined && weakTaskCount > 0 ? ` (${weakTaskCount})` : ''}
+              </Text>
+            </TouchableOpacity>
           </View>
           <Text style={[styles.settingsModeInfo, { color: modeInfo }]}>
             {difficultyMode === DifficultyMode.SIMPLE
               ? t.simpleModeInfo
               : difficultyMode === DifficultyMode.CREATIVE
               ? t.creativeModeInfo
+              : difficultyMode === DifficultyMode.PRACTICE
+              ? t.practiceModeInfo
               : t.challengeInfo}
           </Text>
         </View>
@@ -378,6 +392,11 @@ const styles = StyleSheet.create({
   },
   themeToggle: {
     flexDirection: 'row',
+    gap: 8,
+  },
+  difficultyGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: 8,
   },
   themeButton: {

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -3,8 +3,8 @@
  * Manages all game state and logic
  */
 
-import { useState, useMemo } from 'react';
-import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord } from '../types/game';
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord, TaskStat } from '../types/game';
 import { TOTAL_TASKS, MAX_CHOICE_GENERATION_ATTEMPTS, MAX_RANDOM_ANSWER, CHALLENGE_MAX_LIVES, getChallengeLevel, getChallengeLevelNumber } from '../utils/constants';
 
 interface UseGameLogicProps {
@@ -17,6 +17,8 @@ interface UseGameLogicProps {
   numberRange: NumberRange;
   challengeHighScore?: number;
   onChallengeHighScoreChange?: (score: number) => void;
+  taskStats?: TaskStat[];
+  onTaskResult?: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => void;
 }
 
 /**
@@ -141,7 +143,13 @@ export function useGameLogic({
   numberRange,
   challengeHighScore = 0,
   onChallengeHighScoreChange,
+  taskStats,
+  onTaskResult,
 }: UseGameLogicProps) {
+  const taskStatsRef = useRef<TaskStat[]>(taskStats ?? []);
+  useEffect(() => {
+    taskStatsRef.current = taskStats ?? [];
+  }, [taskStats]);
   // Helper: Get max number based on number range
   const getMaxNumber = (range: NumberRange = numberRange) => {
     switch (range) {
@@ -237,14 +245,44 @@ export function useGameLogic({
   };
 
   // Generate a new question with proper number generation for each operation
-  const generateQuestion = (mode: GameMode = gameState.gameMode, operationSet: Set<Operation> = gameState.selectedOperations, overrideMaxNumber?: number) => {
-    // Pick a random operation from selected operations
-    const operations = Array.from(operationSet);
-    const selectedOp = operations[Math.floor(Math.random() * operations.length)];
+  const generateQuestion = (mode: GameMode = gameState.gameMode, operationSet: Set<Operation> = gameState.selectedOperations, overrideMaxNumber?: number, difficultyOverride?: DifficultyMode) => {
+    const effectiveDifficulty = difficultyOverride ?? gameState.difficultyMode;
 
     let newNum1: number;
     let newNum2: number;
     const effectiveMaxNumber = overrideMaxNumber ?? maxNumber;
+
+    // In PRACTICE mode: 75% chance to pick a weak task
+    let selectedOp: Operation;
+    if (effectiveDifficulty === DifficultyMode.PRACTICE) {
+      const weak = taskStatsRef.current.filter(s => {
+        const total = s.correctCount + s.errorCount;
+        return total >= 3 && s.errorCount / total > 0.3 && operationSet.has(s.operation);
+      });
+      if (weak.length > 0 && Math.random() < 0.75) {
+        const task = weak[Math.floor(Math.random() * weak.length)];
+        newNum1 = task.num1;
+        newNum2 = task.num2;
+        selectedOp = task.operation;
+        setGameState((prev) => ({
+          ...prev,
+          num1: newNum1,
+          num2: newNum2,
+          operation: selectedOp,
+          userAnswer: '',
+          questionPart: 2,
+          answerMode: AnswerMode.INPUT,
+          lastAnswerCorrect: null,
+          isAnswerChecked: false,
+          selectedChoice: null,
+        }));
+        return;
+      }
+    }
+
+    // Normal random generation
+    const operations = Array.from(operationSet);
+    selectedOp = operations[Math.floor(Math.random() * operations.length)];
 
     // Generate appropriate numbers based on operation
     // IMPORTANT: ALL numbers (operands AND results) must be within numberRange
@@ -327,7 +365,7 @@ export function useGameLogic({
     // In CREATIVE and CHALLENGE modes, randomize answer mode each question
     // NUMBER_SEQUENCE only available when asking for result (questionPart === 2)
     let newAnswerMode = gameState.answerMode;
-    if (gameState.difficultyMode === DifficultyMode.CREATIVE || gameState.difficultyMode === DifficultyMode.CHALLENGE) {
+    if (effectiveDifficulty === DifficultyMode.CREATIVE || effectiveDifficulty === DifficultyMode.CHALLENGE) {
       const availableModes =
         newQuestionPart === 2
           ? [AnswerMode.INPUT, AnswerMode.MULTIPLE_CHOICE, AnswerMode.NUMBER_SEQUENCE]
@@ -404,6 +442,8 @@ export function useGameLogic({
     } else {
       isCorrect = gameState.selectedChoice === correctAnswer;
     }
+
+    onTaskResult?.(gameState.num1, gameState.num2, gameState.operation, isCorrect);
 
     const newScore = isCorrect ? gameState.score + 1 : gameState.score;
     const challengeGameOver =
@@ -661,8 +701,8 @@ export function useGameLogic({
       return;
     }
 
-    if (newMode === DifficultyMode.SIMPLE) {
-      // Simple: Normal tasks with keypad input
+    if (newMode === DifficultyMode.SIMPLE || newMode === DifficultyMode.PRACTICE) {
+      // Simple / Practice: Normal tasks with keypad input
       newGameMode = GameMode.NORMAL;
       newAnswerMode = AnswerMode.INPUT;
     } else {
@@ -686,7 +726,7 @@ export function useGameLogic({
       selectedChoice: null,
       challengeState: undefined,
     }));
-    setTimeout(() => generateQuestion(newGameMode), 0);
+    setTimeout(() => generateQuestion(newGameMode, undefined, undefined, newMode), 0);
   };
 
   // Generate multiple choice options

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -255,9 +255,15 @@ export function useGameLogic({
     // In PRACTICE mode: 75% chance to pick a weak task
     let selectedOp: Operation;
     if (effectiveDifficulty === DifficultyMode.PRACTICE) {
+      const maxNum = effectiveMaxNumber;
       const weak = taskStatsRef.current.filter(s => {
         const total = s.correctCount + s.errorCount;
-        return total >= 3 && s.errorCount / total > 0.3 && operationSet.has(s.operation);
+        if (total < 3 || s.errorCount / total <= 0.3) return false;
+        if (!operationSet.has(s.operation)) return false;
+        // Ensure stored task numbers are valid for current range
+        if (s.operation === Operation.ADDITION) return s.num1 + s.num2 <= maxNum;
+        if (s.operation === Operation.MULTIPLICATION) return s.num1 * s.num2 <= maxNum;
+        return s.num1 <= maxNum && s.num2 <= maxNum;
       });
       if (weak.length > 0 && Math.random() < 0.75) {
         const task = weak[Math.floor(Math.random() * weak.length)];

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -17,8 +17,10 @@ export interface TranslationStrings {
   difficultyMode: string;
   simpleMode: string;
   creativeMode: string;
+  practiceMode: string;
   simpleModeInfo: string;
   creativeModeInfo: string;
+  practiceModeInfo: string;
   gameMode: string;
   operation: string;
   addition: string;
@@ -94,6 +96,8 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  parentWeakTasks: string;
+  parentWeakTasksEmpty: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -109,8 +113,10 @@ export const translations: Record<Language, TranslationStrings> = {
     difficultyMode: 'DIFFICULTY',
     simpleMode: 'Simple',
     creativeMode: 'Creative',
+    practiceMode: 'Practice',
     simpleModeInfo: 'Enter the result via keypad',
     creativeModeInfo: 'Random input methods and question types',
+    practiceModeInfo: 'Practicing your difficult tasks right now!',
     gameMode: 'GAME MODE',
     operation: 'OPERATION',
     addition: 'Addition',
@@ -186,6 +192,8 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    parentWeakTasks: 'Weak Areas (Top 5)',
+    parentWeakTasksEmpty: 'No weak areas identified yet.',
   },
   de: {
     // Settings Menu
@@ -199,8 +207,10 @@ export const translations: Record<Language, TranslationStrings> = {
     difficultyMode: 'SCHWIERIGKEIT',
     simpleMode: 'Einfach',
     creativeMode: 'Kreativ',
+    practiceMode: 'Übung',
     simpleModeInfo: 'Das Ergebnis wird über die Tastatur eingegeben',
     creativeModeInfo: 'Zufällige Eingabemethoden und Fragetypen',
+    practiceModeInfo: 'Du übst gerade deine schwierigen Aufgaben!',
     gameMode: 'SPIELMODUS',
     operation: 'RECHENART',
     addition: 'Addition',
@@ -276,5 +286,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    parentWeakTasks: 'Schwachstellen (Top 5)',
+    parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -26,6 +26,7 @@ export enum DifficultyMode {
   SIMPLE = 'SIMPLE',
   CREATIVE = 'CREATIVE',
   CHALLENGE = 'CHALLENGE',
+  PRACTICE = 'PRACTICE',
 }
 
 export enum NumberRange {
@@ -65,6 +66,15 @@ export interface GameState {
   totalSolvedTasks: number; // Track total tasks solved for motivation message
   selectedChoice: number | null; // For multiple choice and number sequence modes
   challengeState?: ChallengeState; // Challenge mode state
+}
+
+export interface TaskStat {
+  num1: number;
+  num2: number;
+  operation: Operation;
+  correctCount: number;
+  errorCount: number;
+  lastSeen: string; // ISO date
 }
 
 export interface SessionRecord {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  TASK_STATS: 'app-task-stats',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,8 +23,12 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getTaskStats,
+  saveTaskStats,
+  recordTaskResult,
+  getWeakTasks,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -535,5 +539,109 @@ describe('Session Records Storage', () => {
     const [retrieved] = await getSessionRecords();
     expect(retrieved.errorRate).toBe(0.3);
     expect(retrieved.errors).toBe(3);
+  });
+});
+
+describe('TaskStat Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return empty array when nothing stored', async () => {
+    expect(await getTaskStats()).toEqual([]);
+  });
+
+  it('should return empty array for corrupted JSON', async () => {
+    mockStore['app-task-stats'] = '{invalid}';
+    expect(await getTaskStats()).toEqual([]);
+  });
+
+  it('should filter out invalid entries on read', async () => {
+    const bad = { num1: 'x', num2: 2, operation: 'MULTIPLICATION', correctCount: 1, errorCount: 0, lastSeen: 'now' };
+    const good: TaskStat = { num1: 3, num2: 4, operation: Operation.MULTIPLICATION, correctCount: 2, errorCount: 1, lastSeen: new Date().toISOString() };
+    mockStore['app-task-stats'] = JSON.stringify([bad, good]);
+    const result = await getTaskStats();
+    expect(result).toHaveLength(1);
+    expect(result[0].num1).toBe(3);
+  });
+
+  it('should save and retrieve task stats', async () => {
+    const stat: TaskStat = { num1: 7, num2: 8, operation: Operation.MULTIPLICATION, correctCount: 1, errorCount: 2, lastSeen: '2026-01-01T00:00:00.000Z' };
+    await saveTaskStats([stat]);
+    const result = await getTaskStats();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(stat);
+  });
+
+  it('recordTaskResult creates new entry for unknown task', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({ num1: 3, num2: 4, operation: Operation.MULTIPLICATION, correctCount: 0, errorCount: 1 });
+  });
+
+  it('recordTaskResult increments existing entry', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, true);
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0].correctCount).toBe(1);
+    expect(stats[0].errorCount).toBe(2);
+  });
+
+  it('recordTaskResult keeps separate entries for different tasks', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    await recordTaskResult(3, 5, Operation.MULTIPLICATION, true);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(2);
+  });
+});
+
+describe('getWeakTasks', () => {
+  const makeStat = (num1: number, num2: number, correct: number, error: number): TaskStat => ({
+    num1, num2, operation: Operation.MULTIPLICATION,
+    correctCount: correct, errorCount: error,
+    lastSeen: new Date().toISOString(),
+  });
+
+  it('returns only tasks with > 30% error rate and >= 3 attempts', () => {
+    const stats = [
+      makeStat(7, 8, 0, 3),  // 100% error, 3 attempts → weak
+      makeStat(3, 4, 8, 2),  // 20% error → not weak
+      makeStat(6, 7, 1, 2),  // 67% error, only 3 attempts → weak
+      makeStat(9, 6, 5, 0),  // 0% error → not weak
+      makeStat(2, 3, 1, 1),  // 50% error, 2 attempts → not enough attempts
+    ];
+    const result = getWeakTasks(stats);
+    expect(result).toHaveLength(2);
+    expect(result.map(s => `${s.num1}×${s.num2}`)).toContain('7×8');
+    expect(result.map(s => `${s.num1}×${s.num2}`)).toContain('6×7');
+  });
+
+  it('sorts by error rate descending', () => {
+    const stats = [
+      makeStat(6, 7, 1, 2),  // 67%
+      makeStat(7, 8, 0, 3),  // 100%
+      makeStat(5, 6, 1, 4),  // 80%
+    ];
+    const result = getWeakTasks(stats);
+    expect(result[0]).toMatchObject({ num1: 7, num2: 8 }); // 100%
+    expect(result[1]).toMatchObject({ num1: 5, num2: 6 }); // 80%
+    expect(result[2]).toMatchObject({ num1: 6, num2: 7 }); // 67%
+  });
+
+  it('respects custom minAttempts and minErrorRate', () => {
+    const stats = [makeStat(7, 8, 1, 1)]; // 50% error, 2 attempts
+    expect(getWeakTasks(stats, 2, 0.4)).toHaveLength(1);
+    expect(getWeakTasks(stats, 3, 0.4)).toHaveLength(0);
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -227,29 +227,34 @@ export const saveTaskStats = async (stats: TaskStat[]): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.TASK_STATS, JSON.stringify(stats));
 };
 
+let taskStatsQueue: Promise<void> = Promise.resolve();
+
 export const recordTaskResult = async (
   num1: number,
   num2: number,
   operation: Operation,
   isCorrect: boolean,
 ): Promise<void> => {
-  const stats = await getTaskStats();
-  const existing = stats.find(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
-  if (existing) {
-    if (isCorrect) existing.correctCount++;
-    else existing.errorCount++;
-    existing.lastSeen = new Date().toISOString();
-  } else {
-    stats.push({
-      num1,
-      num2,
-      operation,
-      correctCount: isCorrect ? 1 : 0,
-      errorCount: isCorrect ? 0 : 1,
-      lastSeen: new Date().toISOString(),
-    });
-  }
-  await saveTaskStats(stats);
+  taskStatsQueue = taskStatsQueue.then(async () => {
+    const stats = await getTaskStats();
+    const existing = stats.find(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
+    if (existing) {
+      if (isCorrect) existing.correctCount++;
+      else existing.errorCount++;
+      existing.lastSeen = new Date().toISOString();
+    } else {
+      stats.push({
+        num1,
+        num2,
+        operation,
+        correctCount: isCorrect ? 1 : 0,
+        errorCount: isCorrect ? 0 : 1,
+        lastSeen: new Date().toISOString(),
+      });
+    }
+    await saveTaskStats(stats);
+  });
+  return taskStatsQueue;
 };
 
 export const getWeakTasks = (stats: TaskStat[], minAttempts = 3, minErrorRate = 0.3): TaskStat[] => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -196,6 +196,74 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   const records = await getSessionRecords();
   records.push(record);
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
+};
+
+function isValidTaskStat(r: unknown): r is TaskStat {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.num1 === 'number' &&
+    typeof obj.num2 === 'number' &&
+    typeof obj.operation === 'string' && VALID_OPERATIONS.has(obj.operation) &&
+    typeof obj.correctCount === 'number' &&
+    typeof obj.errorCount === 'number' &&
+    typeof obj.lastSeen === 'string'
+  );
+}
+
+export const getTaskStats = async (): Promise<TaskStat[]> => {
+  const value = await getStorageItem(STORAGE_KEYS.TASK_STATS);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidTaskStat);
+  } catch {
+    return [];
+  }
+};
+
+export const saveTaskStats = async (stats: TaskStat[]): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.TASK_STATS, JSON.stringify(stats));
+};
+
+export const recordTaskResult = async (
+  num1: number,
+  num2: number,
+  operation: Operation,
+  isCorrect: boolean,
+): Promise<void> => {
+  const stats = await getTaskStats();
+  const existing = stats.find(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
+  if (existing) {
+    if (isCorrect) existing.correctCount++;
+    else existing.errorCount++;
+    existing.lastSeen = new Date().toISOString();
+  } else {
+    stats.push({
+      num1,
+      num2,
+      operation,
+      correctCount: isCorrect ? 1 : 0,
+      errorCount: isCorrect ? 0 : 1,
+      lastSeen: new Date().toISOString(),
+    });
+  }
+  await saveTaskStats(stats);
+};
+
+export const getWeakTasks = (stats: TaskStat[], minAttempts = 3, minErrorRate = 0.3): TaskStat[] => {
+  return stats
+    .filter(s => {
+      const total = s.correctCount + s.errorCount;
+      const rate = total > 0 ? s.errorCount / total : 0;
+      return total >= minAttempts && rate > minErrorRate;
+    })
+    .sort((a, b) => {
+      const rateA = a.errorCount / (a.correctCount + a.errorCount);
+      const rateB = b.errorCount / (b.correctCount + b.errorCount);
+      return rateB - rateA;
+    });
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {


### PR DESCRIPTION
$(cat <<'EOF'
## Zusammenfassung

Implementierung von Issue #188: Adaptives Lernen mit Schwachstellen-Fokus.

- **Neuer `PRACTICE`-Modus** im Schwierigkeits-Menü (4. Button „Übung/Practice")
- **TaskStat-Tracking**: Jede beantwortete Aufgabe (z. B. `7×8`) wird mit `correctCount`/`errorCount` im Storage gespeichert (`app-task-stats`)
- **Gewichteter Algorithmus**: Im Übungsmodus werden Aufgaben mit Fehlerrate > 30% (nach mind. 3 Versuchen) mit 75% Wahrscheinlichkeit bevorzugt gezeigt
- **Eltern-Dashboard**: Neue „Schwachstellen (Top 5)"-Sektion zeigt die häufigsten Fehleraufgaben mit Fehlerrate
- **Kein Datenverlust**: Bestehende Session-Records bleiben unberührt; TaskStats sind ein separater Storage Key

## Geänderte Dateien

| Datei | Änderung |
|-------|----------|
| `types/game.ts` | `TaskStat`-Interface + `DifficultyMode.PRACTICE` |
| `utils/constants.ts` | `STORAGE_KEYS.TASK_STATS` |
| `utils/storage.ts` | `getTaskStats`, `saveTaskStats`, `recordTaskResult`, `getWeakTasks` |
| `hooks/useGameLogic.ts` | `taskStats`/`onTaskResult`-Props, PRACTICE-Gewichtung in `generateQuestion`, `difficultyOverride`-Parameter |
| `i18n/translations.ts` | `practiceMode`, `practiceModeInfo`, `parentWeakTasks`, `parentWeakTasksEmpty` (DE+EN) |
| `components/SettingsMenu.tsx` | PRACTICE-Button mit Anzahl schwacher Aufgaben |
| `components/ParentDashboard.tsx` | Top-5-Schwachstellen-Sektion |
| `App.tsx` | TaskStats laden, `onTaskResult`-Callback, `weakTaskCount` an SettingsMenu |

## Akzeptanzkriterien (aus Issue #188)

- [x] Aufgaben-Statistiken werden pro konkreter Aufgabe gespeichert
- [x] „Übungsmodus" bevorzugt Aufgaben mit hoher Fehlerrate (>30%, mind. 3 Versuche, Gewicht 3×)
- [x] Parent Dashboard zeigt Top-Fehleraufgaben
- [x] Kein Datenverlust bei Update (separater Storage Key, bestehende Daten unberührt)
- [x] Performance: TaskStat-Berechnung ist synchron aus vorgeladenem Array — kein Lag

## Test-Ergebnis

```
Test Suites: 13 passed, 13 total
Tests:       3 skipped, 415 passed, 418 total
```

Closes #188
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF3yNriucqiB3f2pAVmFup)_