### PR TITLE
feat: Achievement & Badge System (#184)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,9 +32,12 @@ import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
+import { BadgesModal } from './components/BadgesModal';
+import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
 import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks } from './utils/storage';
 import { SessionRecord, TaskStat, Operation } from './types/game';
+import { useBadges } from './hooks/useBadges';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -51,6 +54,7 @@ export default function App() {
   const [aboutVisible, setAboutVisible] = useState(false);
   const [personalizeVisible, setPersonalizeVisible] = useState(false);
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
+  const [badgesVisible, setBadgesVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
@@ -73,6 +77,7 @@ export default function App() {
   // Use custom hooks
   const preferences = usePreferences();
   const theme = useTheme(preferences.themeMode);
+  const badgeSystem = useBadges();
   const game = useGameLogic({
     initialOperation: preferences.operation,
     initialOperations: preferences.operations,
@@ -83,7 +88,9 @@ export default function App() {
       setShowMotivation(true);
     },
     onSessionComplete: (record: SessionRecord) => {
-      saveSessionRecord(record);
+      saveSessionRecord(record).then(() => {
+        badgeSystem.checkAndUnlock(record);
+      });
     },
     taskStats,
     onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
@@ -269,6 +276,7 @@ export default function App() {
             hideMenu();
           }}
           onOpenParentDashboard={() => setParentDashboardVisible(true)}
+          onOpenBadges={() => setBadgesVisible(true)}
           t={t}
         />
       )}
@@ -330,6 +338,20 @@ export default function App() {
         onClose={() => setParentDashboardVisible(false)}
         colors={colors}
         t={t}
+      />
+
+      <BadgesModal
+        visible={badgesVisible}
+        onClose={() => setBadgesVisible(false)}
+        colors={colors}
+        badges={badgeSystem.badges}
+        t={t}
+      />
+
+      <BadgeUnlockToast
+        badgeIds={badgeSystem.newlyUnlocked}
+        onDone={badgeSystem.clearNewlyUnlocked}
+        badgeNewUnlockedLabel={t.badgeNewUnlocked}
       />
     </SafeAreaView>
   );

--- a/App.tsx
+++ b/App.tsx
@@ -88,9 +88,9 @@ export default function App() {
       setShowMotivation(true);
     },
     onSessionComplete: (record: SessionRecord) => {
-      saveSessionRecord(record).then(() => {
-        badgeSystem.checkAndUnlock(record);
-      });
+      saveSessionRecord(record)
+        .then(() => badgeSystem.checkAndUnlock(record))
+        .catch((err) => console.error('Session save / badge unlock failed:', err));
     },
     taskStats,
     onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
@@ -345,6 +345,7 @@ export default function App() {
         onClose={() => setBadgesVisible(false)}
         colors={colors}
         badges={badgeSystem.badges}
+        language={preferences.language}
         t={t}
       />
 

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, StyleSheet, Text, View } from 'react-native';
 import { BADGE_DEFINITIONS, DESIGN_TOKENS } from '../utils/constants';
-import { ANIMATION_DURATIONS } from '../utils/animations';
-import { prefersReducedMotion } from '../utils/animations';
+import { ANIMATION_DURATIONS, prefersReducedMotion } from '../utils/animations';
 
 interface BadgeUnlockToastProps {
   badgeIds: string[];
@@ -18,6 +17,10 @@ export function BadgeUnlockToast({ badgeIds, onDone, badgeNewUnlockedLabel }: Ba
 
   useEffect(() => {
     if (badgeIds.length === 0) return;
+
+    // Always reset to initial hidden state so repeated toasts animate correctly
+    opacity.setValue(0);
+    translateY.setValue(40);
 
     const reduced = prefersReducedMotion();
 
@@ -58,8 +61,7 @@ export function BadgeUnlockToast({ badgeIds, onDone, badgeNewUnlockedLabel }: Ba
     }, DISPLAY_DURATION);
 
     return () => clearTimeout(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [badgeIds]);
+  }, [badgeIds, onDone, opacity, translateY]);
 
   if (badgeIds.length === 0) return null;
 
@@ -75,7 +77,7 @@ export function BadgeUnlockToast({ badgeIds, onDone, badgeNewUnlockedLabel }: Ba
       <Text style={styles.icon}>{icon}</Text>
       <View style={styles.textGroup}>
         <Text style={styles.label}>{badgeNewUnlockedLabel}</Text>
-        <Text style={styles.extra}>{extra || ''}</Text>
+        {extra ? <Text style={styles.extra}>{extra}</Text> : null}
       </View>
     </Animated.View>
   );

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { BADGE_DEFINITIONS, DESIGN_TOKENS } from '../utils/constants';
+import { ANIMATION_DURATIONS } from '../utils/animations';
+import { prefersReducedMotion } from '../utils/animations';
+
+interface BadgeUnlockToastProps {
+  badgeIds: string[];
+  onDone: () => void;
+  badgeNewUnlockedLabel: string;
+}
+
+const DISPLAY_DURATION = 2400;
+
+export function BadgeUnlockToast({ badgeIds, onDone, badgeNewUnlockedLabel }: BadgeUnlockToastProps) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(40)).current;
+
+  useEffect(() => {
+    if (badgeIds.length === 0) return;
+
+    const reduced = prefersReducedMotion();
+
+    if (reduced) {
+      opacity.setValue(1);
+      translateY.setValue(0);
+      const t = setTimeout(onDone, DISPLAY_DURATION);
+      return () => clearTimeout(t);
+    }
+
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: ANIMATION_DURATIONS.NORMAL,
+        useNativeDriver: true,
+      }),
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        speed: 20,
+        bounciness: 8,
+      }),
+    ]).start();
+
+    const timer = setTimeout(() => {
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: ANIMATION_DURATIONS.NORMAL,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: 30,
+          duration: ANIMATION_DURATIONS.NORMAL,
+          useNativeDriver: true,
+        }),
+      ]).start(() => onDone());
+    }, DISPLAY_DURATION);
+
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [badgeIds]);
+
+  if (badgeIds.length === 0) return null;
+
+  const first = BADGE_DEFINITIONS.find(b => b.id === badgeIds[0]);
+  const icon = first?.icon ?? '🏅';
+  const extra = badgeIds.length > 1 ? ` +${badgeIds.length - 1}` : '';
+
+  return (
+    <Animated.View
+      style={[styles.toast, { opacity, transform: [{ translateY }] }]}
+      pointerEvents="none"
+    >
+      <Text style={styles.icon}>{icon}</Text>
+      <View style={styles.textGroup}>
+        <Text style={styles.label}>{badgeNewUnlockedLabel}</Text>
+        <Text style={styles.extra}>{extra || ''}</Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    bottom: 32,
+    left: 24,
+    right: 24,
+    backgroundColor: DESIGN_TOKENS.GRADIENT_PRIMARY[1],
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    elevation: 16,
+    shadowColor: '#764ba2',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.35,
+    shadowRadius: 12,
+    zIndex: 2000,
+  },
+  icon: {
+    fontSize: 28,
+  },
+  textGroup: {
+    flex: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: '#fff',
+  },
+  extra: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: 'rgba(255,255,255,0.75)',
+  },
+});

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -7,7 +7,7 @@ import {
   Modal,
   ScrollView,
 } from 'react-native';
-import { ThemeColors } from '../types/game';
+import { ThemeColors, Language } from '../types/game';
 import { BADGE_DEFINITIONS, BadgeCategory, DESIGN_TOKENS } from '../utils/constants';
 import { BadgeStore } from '../utils/storage';
 import { modalStyles } from '../styles/modalStyles';
@@ -17,6 +17,7 @@ interface BadgesModalProps {
   onClose: () => void;
   colors: ThemeColors;
   badges: BadgeStore;
+  language: Language;
   t: {
     badges: string;
     badgesSubtitle: string;
@@ -98,12 +99,20 @@ function getCategoryLabel(cat: BadgeCategory, t: BadgesModalProps['t']): string 
   return map[cat];
 }
 
-function formatUnlockDate(ts: number): string {
-  const d = new Date(ts);
-  return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+function formatUnlockDate(ts: number, language: Language): string {
+  try {
+    return new Intl.DateTimeFormat(language === 'de' ? 'de-DE' : 'en-US', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(new Date(ts));
+  } catch {
+    const d = new Date(ts);
+    return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+  }
 }
 
-export function BadgesModal({ visible, onClose, colors, badges, t }: BadgesModalProps) {
+export function BadgesModal({ visible, onClose, colors, badges, language, t }: BadgesModalProps) {
   const unlockedCount = Object.keys(badges).length;
   const totalCount = BADGE_DEFINITIONS.length;
 
@@ -166,7 +175,7 @@ export function BadgesModal({ visible, onClose, colors, badges, t }: BadgesModal
                           </Text>
                           {isUnlocked && (
                             <Text style={styles.unlockedDate}>
-                              {t.badgeUnlockedOn} {formatUnlockDate(unlockedAt)}
+                              {t.badgeUnlockedOn} {formatUnlockDate(unlockedAt, language)}
                             </Text>
                           )}
                         </View>

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  ScrollView,
+} from 'react-native';
+import { ThemeColors } from '../types/game';
+import { BADGE_DEFINITIONS, BadgeCategory, DESIGN_TOKENS } from '../utils/constants';
+import { BadgeStore } from '../utils/storage';
+import { modalStyles } from '../styles/modalStyles';
+
+interface BadgesModalProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  badges: BadgeStore;
+  t: {
+    badges: string;
+    badgesSubtitle: string;
+    badgeLocked: string;
+    badgeUnlockedOn: string;
+    badgeCategoryStreak: string;
+    badgeCategoryPerformance: string;
+    badgeCategoryChallenge: string;
+    badgeCategoryExplorer: string;
+    badgeStreak3Name: string;
+    badgeStreak7Name: string;
+    badgeStreak30Name: string;
+    badgePerfect1Name: string;
+    badgePerfect5Name: string;
+    badgeAllOpsName: string;
+    badgeChallengeLevel3Name: string;
+    badgeChallengeLevel6Name: string;
+    badgeChallengeNoErrorsName: string;
+    badgeRange100Name: string;
+    badgeCreativeModeName: string;
+    badgeStreak3Desc: string;
+    badgeStreak7Desc: string;
+    badgeStreak30Desc: string;
+    badgePerfect1Desc: string;
+    badgePerfect5Desc: string;
+    badgeAllOpsDesc: string;
+    badgeChallengeLevel3Desc: string;
+    badgeChallengeLevel6Desc: string;
+    badgeChallengeNoErrorsDesc: string;
+    badgeRange100Desc: string;
+    badgeCreativeModeDesc: string;
+    ok: string;
+  };
+}
+
+const CATEGORY_ORDER: BadgeCategory[] = ['streak', 'performance', 'challenge', 'explorer'];
+
+function getBadgeName(id: string, t: BadgesModalProps['t']): string {
+  const map: Record<string, string> = {
+    streak_3: t.badgeStreak3Name,
+    streak_7: t.badgeStreak7Name,
+    streak_30: t.badgeStreak30Name,
+    perfect_1: t.badgePerfect1Name,
+    perfect_5: t.badgePerfect5Name,
+    all_operations: t.badgeAllOpsName,
+    challenge_level_3: t.badgeChallengeLevel3Name,
+    challenge_level_6: t.badgeChallengeLevel6Name,
+    challenge_no_errors: t.badgeChallengeNoErrorsName,
+    range_100: t.badgeRange100Name,
+    creative_mode: t.badgeCreativeModeName,
+  };
+  return map[id] ?? id;
+}
+
+function getBadgeDesc(id: string, t: BadgesModalProps['t']): string {
+  const map: Record<string, string> = {
+    streak_3: t.badgeStreak3Desc,
+    streak_7: t.badgeStreak7Desc,
+    streak_30: t.badgeStreak30Desc,
+    perfect_1: t.badgePerfect1Desc,
+    perfect_5: t.badgePerfect5Desc,
+    all_operations: t.badgeAllOpsDesc,
+    challenge_level_3: t.badgeChallengeLevel3Desc,
+    challenge_level_6: t.badgeChallengeLevel6Desc,
+    challenge_no_errors: t.badgeChallengeNoErrorsDesc,
+    range_100: t.badgeRange100Desc,
+    creative_mode: t.badgeCreativeModeDesc,
+  };
+  return map[id] ?? '';
+}
+
+function getCategoryLabel(cat: BadgeCategory, t: BadgesModalProps['t']): string {
+  const map: Record<BadgeCategory, string> = {
+    streak: t.badgeCategoryStreak,
+    performance: t.badgeCategoryPerformance,
+    challenge: t.badgeCategoryChallenge,
+    explorer: t.badgeCategoryExplorer,
+  };
+  return map[cat];
+}
+
+function formatUnlockDate(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+}
+
+export function BadgesModal({ visible, onClose, colors, badges, t }: BadgesModalProps) {
+  const unlockedCount = Object.keys(badges).length;
+  const totalCount = BADGE_DEFINITIONS.length;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[styles.container, { backgroundColor: colors.settingsMenu }]}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.badges}</Text>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+                {unlockedCount}/{totalCount} · {t.badgesSubtitle}
+              </Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={[styles.closeText, { color: colors.text }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Badge grid by category */}
+          <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
+            {CATEGORY_ORDER.map(cat => {
+              const defs = BADGE_DEFINITIONS.filter(b => b.category === cat);
+              return (
+                <View key={cat} style={styles.categorySection}>
+                  <Text style={[styles.categoryLabel, { color: colors.textSecondary }]}>
+                    {getCategoryLabel(cat, t).toUpperCase()}
+                  </Text>
+                  <View style={styles.grid}>
+                    {defs.map(def => {
+                      const unlockedAt = badges[def.id];
+                      const isUnlocked = Boolean(unlockedAt);
+                      return (
+                        <View
+                          key={def.id}
+                          style={[
+                            styles.badgeCard,
+                            { backgroundColor: colors.card, borderColor: colors.border },
+                            isUnlocked && styles.badgeCardUnlocked,
+                          ]}
+                        >
+                          <Text style={[styles.badgeIcon, !isUnlocked && styles.badgeIconLocked]}>
+                            {isUnlocked ? def.icon : '🔒'}
+                          </Text>
+                          <Text
+                            style={[
+                              styles.badgeName,
+                              { color: isUnlocked ? colors.text : colors.textSecondary },
+                            ]}
+                            numberOfLines={2}
+                          >
+                            {getBadgeName(def.id, t)}
+                          </Text>
+                          <Text
+                            style={[styles.badgeDesc, { color: colors.textSecondary }]}
+                            numberOfLines={2}
+                          >
+                            {getBadgeDesc(def.id, t)}
+                          </Text>
+                          {isUnlocked && (
+                            <Text style={styles.unlockedDate}>
+                              {t.badgeUnlockedOn} {formatUnlockDate(unlockedAt)}
+                            </Text>
+                          )}
+                        </View>
+                      );
+                    })}
+                  </View>
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          {/* Close button */}
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Text style={styles.closeBtnText}>{t.ok}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 24,
+    padding: 20,
+    width: '92%',
+    maxWidth: 440,
+    maxHeight: '88%',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  subtitle: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+  },
+  closeButton: {
+    padding: 6,
+    minWidth: 36,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  scroll: {
+    maxHeight: 440,
+    marginBottom: 12,
+  },
+  categorySection: {
+    marginBottom: 14,
+  },
+  categoryLabel: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    letterSpacing: 0.8,
+    marginBottom: 8,
+    marginLeft: 2,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  badgeCard: {
+    width: '48%',
+    borderWidth: 1.5,
+    borderRadius: 14,
+    padding: 10,
+    alignItems: 'center',
+    opacity: 0.5,
+  },
+  badgeCardUnlocked: {
+    opacity: 1,
+    borderColor: ACTIVE_COLOR + '55',
+  },
+  badgeIcon: {
+    fontSize: 28,
+    marginBottom: 4,
+  },
+  badgeIconLocked: {
+    opacity: 0.4,
+  },
+  badgeName: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    marginBottom: 2,
+  },
+  badgeDesc: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 14,
+  },
+  unlockedDate: {
+    fontSize: 9,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: ACTIVE_COLOR,
+    marginTop: 4,
+    textAlign: 'center',
+  },
+  closeBtn: {
+    backgroundColor: ACTIVE_COLOR,
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  closeBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -32,6 +32,7 @@ interface SettingsMenuProps {
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
   onOpenParentDashboard: () => void;
+  onOpenBadges: () => void;
   // Translations
   t: {
     operation: string;
@@ -56,6 +57,7 @@ interface SettingsMenuProps {
     personalize: string;
     parentDashboard: string;
     parentDashboardMenu: string;
+    badgesMenu: string;
     feedback: string;
     support: string;
     about: string;
@@ -78,6 +80,7 @@ export function SettingsMenu({
   onOpenPersonalize,
   onOpenAbout,
   onOpenParentDashboard,
+  onOpenBadges,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -122,6 +125,12 @@ export function SettingsMenu({
             onPress={() => { onOpenParentDashboard(); onHideMenu(); }}
           >
             <Text style={styles.personalizeButtonText}>{t.parentDashboardMenu}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.personalizeButton}
+            onPress={() => { onOpenBadges(); onHideMenu(); }}
+          >
+            <Text style={styles.personalizeButtonText}>{t.badgesMenu}</Text>
           </TouchableOpacity>
         </View>
 

--- a/hooks/useBadges.test.ts
+++ b/hooks/useBadges.test.ts
@@ -1,4 +1,4 @@
-import { getStreakDays, countPerfectSessions, hasAllOperationsPerfect, computeNewlyUnlocked } from './useBadges';
+import { getStreakDays, countPerfectSessions, hasAllOperationsPerfect, computeNewlyUnlocked, advanceStreak } from './useBadges';
 import { DifficultyMode, NumberRange, Operation } from '../types/game';
 import type { SessionRecord } from '../types/game';
 import type { BadgeStore } from '../utils/storage';
@@ -158,14 +158,53 @@ describe('computeNewlyUnlocked', () => {
     expect(ids).not.toContain('range_100');
   });
 
-  it('unlocks streak_3 after 3 consecutive days', () => {
-    const records = [
-      makeRecord({ timestamp: daysAgo(0) }),
-      makeRecord({ timestamp: daysAgo(1) }),
-      makeRecord({ timestamp: daysAgo(2) }),
-    ];
-    const ids = computeNewlyUnlocked(records[0], records, 0, existing);
+  it('unlocks streak_3 after 3 consecutive days (via persisted streak)', () => {
+    const record = makeRecord({ timestamp: daysAgo(0) });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing, 3);
     expect(ids).toContain('streak_3');
     expect(ids).not.toContain('streak_7');
+  });
+
+  it('unlocks streak_30 when persisted streak is 30 (bypasses 28-day prune)', () => {
+    const record = makeRecord({ timestamp: daysAgo(0) });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing, 30);
+    expect(ids).toContain('streak_3');
+    expect(ids).toContain('streak_7');
+    expect(ids).toContain('streak_30');
+  });
+});
+
+describe('advanceStreak', () => {
+  function isoToday(): string {
+    const d = new Date();
+    return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+  }
+  function isoYesterday(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+  }
+
+  it('starts streak at 1 on first ever play', () => {
+    const result = advanceStreak({ currentStreak: 0, lastPlayedDay: '' });
+    expect(result.currentStreak).toBe(1);
+    expect(result.lastPlayedDay).toBe(isoToday());
+  });
+
+  it('does not increase streak when called twice on same day', () => {
+    const today = isoToday();
+    const result = advanceStreak({ currentStreak: 5, lastPlayedDay: today });
+    expect(result.currentStreak).toBe(5);
+  });
+
+  it('increments streak on consecutive day', () => {
+    const result = advanceStreak({ currentStreak: 4, lastPlayedDay: isoYesterday() });
+    expect(result.currentStreak).toBe(5);
+    expect(result.lastPlayedDay).toBe(isoToday());
+  });
+
+  it('resets streak to 1 after a gap', () => {
+    const result = advanceStreak({ currentStreak: 10, lastPlayedDay: '2020-01-01' });
+    expect(result.currentStreak).toBe(1);
   });
 });

--- a/hooks/useBadges.test.ts
+++ b/hooks/useBadges.test.ts
@@ -1,0 +1,171 @@
+import { getStreakDays, countPerfectSessions, hasAllOperationsPerfect, computeNewlyUnlocked } from './useBadges';
+import { DifficultyMode, NumberRange, Operation } from '../types/game';
+import type { SessionRecord } from '../types/game';
+import type { BadgeStore } from '../utils/storage';
+
+function makeRecord(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: Math.random().toString(),
+    timestamp: Date.now(),
+    operations: [Operation.MULTIPLICATION],
+    totalTasks: 10,
+    correctTasks: 10,
+    errors: 0,
+    errorRate: 0,
+    difficultyMode: DifficultyMode.SIMPLE,
+    numberRange: NumberRange.RANGE_10,
+    ...overrides,
+  };
+}
+
+function daysAgo(n: number): number {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(12, 0, 0, 0);
+  return d.getTime();
+}
+
+describe('getStreakDays', () => {
+  it('returns 0 for empty records', () => {
+    expect(getStreakDays([])).toBe(0);
+  });
+
+  it('returns 1 when only today has a session', () => {
+    const records = [makeRecord({ timestamp: daysAgo(0) })];
+    expect(getStreakDays(records)).toBe(1);
+  });
+
+  it('counts consecutive days ending today', () => {
+    const records = [
+      makeRecord({ timestamp: daysAgo(0) }),
+      makeRecord({ timestamp: daysAgo(1) }),
+      makeRecord({ timestamp: daysAgo(2) }),
+    ];
+    expect(getStreakDays(records)).toBe(3);
+  });
+
+  it('breaks streak when a day is missing', () => {
+    const records = [
+      makeRecord({ timestamp: daysAgo(0) }),
+      // day 1 missing
+      makeRecord({ timestamp: daysAgo(2) }),
+    ];
+    expect(getStreakDays(records)).toBe(1);
+  });
+
+  it('returns 0 when most recent session was yesterday only', () => {
+    const records = [makeRecord({ timestamp: daysAgo(1) })];
+    expect(getStreakDays(records)).toBe(0);
+  });
+});
+
+describe('countPerfectSessions', () => {
+  it('counts sessions where correctTasks === totalTasks in non-challenge mode', () => {
+    const records = [
+      makeRecord({ correctTasks: 10, totalTasks: 10 }),
+      makeRecord({ correctTasks: 8,  totalTasks: 10 }),
+      makeRecord({ correctTasks: 10, totalTasks: 10 }),
+    ];
+    expect(countPerfectSessions(records)).toBe(2);
+  });
+
+  it('excludes challenge sessions', () => {
+    const records = [
+      makeRecord({ correctTasks: 10, totalTasks: 10, difficultyMode: DifficultyMode.CHALLENGE }),
+    ];
+    expect(countPerfectSessions(records)).toBe(0);
+  });
+
+  it('excludes sessions with fewer than 10 tasks', () => {
+    const records = [makeRecord({ correctTasks: 5, totalTasks: 5 })];
+    expect(countPerfectSessions(records)).toBe(0);
+  });
+});
+
+describe('hasAllOperationsPerfect', () => {
+  it('returns false when not all ops have a perfect session', () => {
+    const records = [
+      makeRecord({ operations: [Operation.ADDITION],       correctTasks: 10 }),
+      makeRecord({ operations: [Operation.SUBTRACTION],    correctTasks: 10 }),
+      makeRecord({ operations: [Operation.MULTIPLICATION], correctTasks: 10 }),
+      // division missing
+    ];
+    expect(hasAllOperationsPerfect(records)).toBe(false);
+  });
+
+  it('returns true when all 4 operations have a perfect session', () => {
+    const records = [
+      makeRecord({ operations: [Operation.ADDITION],       correctTasks: 10 }),
+      makeRecord({ operations: [Operation.SUBTRACTION],    correctTasks: 10 }),
+      makeRecord({ operations: [Operation.MULTIPLICATION], correctTasks: 10 }),
+      makeRecord({ operations: [Operation.DIVISION],       correctTasks: 10 }),
+    ];
+    expect(hasAllOperationsPerfect(records)).toBe(true);
+  });
+});
+
+describe('computeNewlyUnlocked', () => {
+  const existing: BadgeStore = {};
+
+  it('unlocks range_100 when record uses RANGE_100', () => {
+    const record = makeRecord({ numberRange: NumberRange.RANGE_100 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('range_100');
+  });
+
+  it('unlocks creative_mode when record is creative', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CREATIVE });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('creative_mode');
+  });
+
+  it('unlocks challenge_no_errors for challenge with 0 errors', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CHALLENGE, errors: 0 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('challenge_no_errors');
+  });
+
+  it('does not unlock challenge_no_errors when errors > 0', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CHALLENGE, errors: 1 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).not.toContain('challenge_no_errors');
+  });
+
+  it('unlocks challenge_level_3 when challengeHighScore reaches level 3 (score=10)', () => {
+    const record = makeRecord();
+    const ids = computeNewlyUnlocked(record, [record], 10, existing);
+    expect(ids).toContain('challenge_level_3');
+    expect(ids).not.toContain('challenge_level_6');
+  });
+
+  it('unlocks challenge_level_6 when challengeHighScore reaches level 6 (score=30)', () => {
+    const record = makeRecord();
+    const ids = computeNewlyUnlocked(record, [record], 30, existing);
+    expect(ids).toContain('challenge_level_3');
+    expect(ids).toContain('challenge_level_6');
+  });
+
+  it('unlocks perfect_1 on first perfect session', () => {
+    const record = makeRecord({ timestamp: daysAgo(0), correctTasks: 10, totalTasks: 10 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('perfect_1');
+  });
+
+  it('does not re-unlock already earned badges', () => {
+    const record = makeRecord({ numberRange: NumberRange.RANGE_100 });
+    const alreadyHas: BadgeStore = { range_100: Date.now() - 1000 };
+    const ids = computeNewlyUnlocked(record, [record], 0, alreadyHas);
+    expect(ids).not.toContain('range_100');
+  });
+
+  it('unlocks streak_3 after 3 consecutive days', () => {
+    const records = [
+      makeRecord({ timestamp: daysAgo(0) }),
+      makeRecord({ timestamp: daysAgo(1) }),
+      makeRecord({ timestamp: daysAgo(2) }),
+    ];
+    const ids = computeNewlyUnlocked(records[0], records, 0, existing);
+    expect(ids).toContain('streak_3');
+    expect(ids).not.toContain('streak_7');
+  });
+});

--- a/hooks/useBadges.ts
+++ b/hooks/useBadges.ts
@@ -1,0 +1,133 @@
+/**
+ * useBadges Hook
+ * Manages achievement badge state, persistence, and unlock logic.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { SessionRecord, Operation, DifficultyMode, NumberRange } from '../types/game';
+import { getBadges, saveBadges, getSessionRecords, getChallengeHighScore, BadgeStore } from '../utils/storage';
+import { getChallengeLevelNumber } from '../utils/constants';
+
+// --- pure badge-condition logic (exported for unit tests) ---
+
+export function getStreakDays(records: SessionRecord[]): number {
+  if (records.length === 0) return 0;
+
+  const uniqueDays = new Set<string>();
+  for (const r of records) {
+    const d = new Date(r.timestamp);
+    uniqueDays.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`);
+  }
+
+  let streak = 0;
+  const cursor = new Date();
+  while (true) {
+    const key = `${cursor.getFullYear()}-${cursor.getMonth()}-${cursor.getDate()}`;
+    if (!uniqueDays.has(key)) break;
+    streak++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return streak;
+}
+
+export function countPerfectSessions(records: SessionRecord[]): number {
+  return records.filter(
+    r =>
+      r.difficultyMode !== DifficultyMode.CHALLENGE &&
+      r.totalTasks >= 10 &&
+      r.correctTasks === r.totalTasks,
+  ).length;
+}
+
+export function hasAllOperationsPerfect(records: SessionRecord[]): boolean {
+  const ops: Operation[] = [
+    Operation.ADDITION,
+    Operation.SUBTRACTION,
+    Operation.MULTIPLICATION,
+    Operation.DIVISION,
+  ];
+  return ops.every(op =>
+    records.some(
+      r =>
+        r.difficultyMode !== DifficultyMode.CHALLENGE &&
+        r.totalTasks >= 10 &&
+        r.correctTasks === r.totalTasks &&
+        r.operations.includes(op),
+    ),
+  );
+}
+
+export function computeNewlyUnlocked(
+  record: SessionRecord,
+  allRecords: SessionRecord[],
+  challengeHighScore: number,
+  existing: BadgeStore,
+): string[] {
+  const result: string[] = [];
+  const unlock = (id: string) => {
+    if (!existing[id]) result.push(id);
+  };
+
+  const streak = getStreakDays(allRecords);
+  if (streak >= 3)  unlock('streak_3');
+  if (streak >= 7)  unlock('streak_7');
+  if (streak >= 30) unlock('streak_30');
+
+  const perfects = countPerfectSessions(allRecords);
+  if (perfects >= 1) unlock('perfect_1');
+  if (perfects >= 5) unlock('perfect_5');
+  if (hasAllOperationsPerfect(allRecords)) unlock('all_operations');
+
+  const levelNum = getChallengeLevelNumber(challengeHighScore);
+  if (levelNum >= 3) unlock('challenge_level_3');
+  if (levelNum >= 6) unlock('challenge_level_6');
+  if (record.difficultyMode === DifficultyMode.CHALLENGE && record.errors === 0) {
+    unlock('challenge_no_errors');
+  }
+
+  if (record.numberRange === NumberRange.RANGE_100) unlock('range_100');
+  if (record.difficultyMode === DifficultyMode.CREATIVE) unlock('creative_mode');
+
+  return result;
+}
+
+// --- hook ---
+
+export function useBadges() {
+  const [badges, setBadges] = useState<BadgeStore>({});
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [newlyUnlocked, setNewlyUnlocked] = useState<string[]>([]);
+
+  useEffect(() => {
+    getBadges().then(b => {
+      setBadges(b);
+      setIsLoaded(true);
+    });
+  }, []);
+
+  const checkAndUnlock = useCallback(async (record: SessionRecord) => {
+    const [existing, allRecords, challengeHighScore] = await Promise.all([
+      getBadges(),
+      getSessionRecords(),
+      getChallengeHighScore(),
+    ]);
+
+    const newIds = computeNewlyUnlocked(record, allRecords, challengeHighScore, existing);
+    if (newIds.length === 0) return;
+
+    const now = Date.now();
+    const updated: BadgeStore = { ...existing };
+    for (const id of newIds) {
+      updated[id] = now;
+    }
+    await saveBadges(updated);
+    setBadges(updated);
+    setNewlyUnlocked(newIds);
+  }, []);
+
+  const clearNewlyUnlocked = useCallback(() => {
+    setNewlyUnlocked([]);
+  }, []);
+
+  return { badges, isLoaded, newlyUnlocked, checkAndUnlock, clearNewlyUnlocked };
+}

--- a/hooks/useBadges.ts
+++ b/hooks/useBadges.ts
@@ -5,7 +5,16 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { SessionRecord, Operation, DifficultyMode, NumberRange } from '../types/game';
-import { getBadges, saveBadges, getSessionRecords, getChallengeHighScore, BadgeStore } from '../utils/storage';
+import {
+  getBadges,
+  saveBadges,
+  getSessionRecords,
+  getChallengeHighScore,
+  getStreakData,
+  saveStreakData,
+  BadgeStore,
+  StreakData,
+} from '../utils/storage';
 import { getChallengeLevelNumber } from '../utils/constants';
 
 // --- pure badge-condition logic (exported for unit tests) ---
@@ -57,18 +66,21 @@ export function hasAllOperationsPerfect(records: SessionRecord[]): boolean {
   );
 }
 
+// streakDays is optional: if provided it overrides the in-records computation,
+// allowing the persistent streak counter to bypass the 28-day session record prune limit.
 export function computeNewlyUnlocked(
   record: SessionRecord,
   allRecords: SessionRecord[],
   challengeHighScore: number,
   existing: BadgeStore,
+  streakDays?: number,
 ): string[] {
   const result: string[] = [];
   const unlock = (id: string) => {
     if (!existing[id]) result.push(id);
   };
 
-  const streak = getStreakDays(allRecords);
+  const streak = streakDays ?? getStreakDays(allRecords);
   if (streak >= 3)  unlock('streak_3');
   if (streak >= 7)  unlock('streak_7');
   if (streak >= 30) unlock('streak_30');
@@ -91,6 +103,26 @@ export function computeNewlyUnlocked(
   return result;
 }
 
+function todayISODate(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+}
+
+function yesterdayISODate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+}
+
+export function advanceStreak(current: StreakData): StreakData {
+  const today = todayISODate();
+  if (current.lastPlayedDay === today) return current;
+  if (current.lastPlayedDay === yesterdayISODate()) {
+    return { currentStreak: current.currentStreak + 1, lastPlayedDay: today };
+  }
+  return { currentStreak: 1, lastPlayedDay: today };
+}
+
 // --- hook ---
 
 export function useBadges() {
@@ -106,13 +138,23 @@ export function useBadges() {
   }, []);
 
   const checkAndUnlock = useCallback(async (record: SessionRecord) => {
-    const [existing, allRecords, challengeHighScore] = await Promise.all([
+    const [existing, allRecords, challengeHighScore, streakData] = await Promise.all([
       getBadges(),
       getSessionRecords(),
       getChallengeHighScore(),
+      getStreakData(),
     ]);
 
-    const newIds = computeNewlyUnlocked(record, allRecords, challengeHighScore, existing);
+    const updatedStreak = advanceStreak(streakData);
+    await saveStreakData(updatedStreak);
+
+    const newIds = computeNewlyUnlocked(
+      record,
+      allRecords,
+      challengeHighScore,
+      existing,
+      updatedStreak.currentStreak,
+    );
     if (newIds.length === 0) return;
 
     const now = Date.now();

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -98,6 +98,39 @@ export interface TranslationStrings {
   parentErrors: string;
   parentWeakTasks: string;
   parentWeakTasksEmpty: string;
+  // Badges
+  badges: string;
+  badgesMenu: string;
+  badgesSubtitle: string;
+  badgeLocked: string;
+  badgeUnlockedOn: string;
+  badgeCategoryStreak: string;
+  badgeCategoryPerformance: string;
+  badgeCategoryChallenge: string;
+  badgeCategoryExplorer: string;
+  badgeStreak3Name: string;
+  badgeStreak7Name: string;
+  badgeStreak30Name: string;
+  badgePerfect1Name: string;
+  badgePerfect5Name: string;
+  badgeAllOpsName: string;
+  badgeChallengeLevel3Name: string;
+  badgeChallengeLevel6Name: string;
+  badgeChallengeNoErrorsName: string;
+  badgeRange100Name: string;
+  badgeCreativeModeName: string;
+  badgeStreak3Desc: string;
+  badgeStreak7Desc: string;
+  badgeStreak30Desc: string;
+  badgePerfect1Desc: string;
+  badgePerfect5Desc: string;
+  badgeAllOpsDesc: string;
+  badgeChallengeLevel3Desc: string;
+  badgeChallengeLevel6Desc: string;
+  badgeChallengeNoErrorsDesc: string;
+  badgeRange100Desc: string;
+  badgeCreativeModeDesc: string;
+  badgeNewUnlocked: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -194,6 +227,39 @@ export const translations: Record<Language, TranslationStrings> = {
     parentErrors: 'Errors',
     parentWeakTasks: 'Weak Areas (Top 5)',
     parentWeakTasksEmpty: 'No weak areas identified yet.',
+    // Badges
+    badges: 'Achievements',
+    badgesMenu: 'Achievements',
+    badgesSubtitle: 'Collect badges by reaching milestones',
+    badgeLocked: 'Locked',
+    badgeUnlockedOn: 'Unlocked',
+    badgeCategoryStreak: 'Streaks',
+    badgeCategoryPerformance: 'Performance',
+    badgeCategoryChallenge: 'Challenge',
+    badgeCategoryExplorer: 'Explorer',
+    badgeStreak3Name: 'On Fire!',
+    badgeStreak7Name: 'Hot Streak',
+    badgeStreak30Name: 'Unstoppable',
+    badgePerfect1Name: 'Perfectionist',
+    badgePerfect5Name: 'Star Player',
+    badgeAllOpsName: 'All-Rounder',
+    badgeChallengeLevel3Name: 'Rising Star',
+    badgeChallengeLevel6Name: 'Champion',
+    badgeChallengeNoErrorsName: 'Flawless',
+    badgeRange100Name: 'Big Numbers',
+    badgeCreativeModeName: 'Creative Mind',
+    badgeStreak3Desc: 'Played 3 days in a row',
+    badgeStreak7Desc: 'Played 7 days in a row',
+    badgeStreak30Desc: 'Played 30 days in a row',
+    badgePerfect1Desc: 'First perfect round (10/10)',
+    badgePerfect5Desc: '5 perfect rounds',
+    badgeAllOpsDesc: 'Perfect round with all 4 operations',
+    badgeChallengeLevel3Desc: 'Reached Challenge Level 3',
+    badgeChallengeLevel6Desc: 'Reached Challenge Level 6',
+    badgeChallengeNoErrorsDesc: 'Completed a challenge without errors',
+    badgeRange100Desc: 'Played with numbers up to 100',
+    badgeCreativeModeDesc: 'Played in Creative Mode',
+    badgeNewUnlocked: 'New badge unlocked!',
   },
   de: {
     // Settings Menu
@@ -288,5 +354,38 @@ export const translations: Record<Language, TranslationStrings> = {
     parentErrors: 'Fehler',
     parentWeakTasks: 'Schwachstellen (Top 5)',
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
+    // Badges
+    badges: 'Abzeichen',
+    badgesMenu: 'Abzeichen',
+    badgesSubtitle: 'Sammle Abzeichen durch Meilensteine',
+    badgeLocked: 'Gesperrt',
+    badgeUnlockedOn: 'Freigeschaltet',
+    badgeCategoryStreak: 'Serien',
+    badgeCategoryPerformance: 'Leistung',
+    badgeCategoryChallenge: 'Herausforderung',
+    badgeCategoryExplorer: 'Entdecker',
+    badgeStreak3Name: 'Auf Kurs!',
+    badgeStreak7Name: 'Heiße Serie',
+    badgeStreak30Name: 'Unaufhaltsam',
+    badgePerfect1Name: 'Perfektionist',
+    badgePerfect5Name: 'Superstar',
+    badgeAllOpsName: 'Allrounder',
+    badgeChallengeLevel3Name: 'Aufsteiger',
+    badgeChallengeLevel6Name: 'Champion',
+    badgeChallengeNoErrorsName: 'Fehlerlos',
+    badgeRange100Name: 'Große Zahlen',
+    badgeCreativeModeName: 'Kreativkopf',
+    badgeStreak3Desc: '3 Tage in Folge gespielt',
+    badgeStreak7Desc: '7 Tage in Folge gespielt',
+    badgeStreak30Desc: '30 Tage in Folge gespielt',
+    badgePerfect1Desc: 'Erste perfekte Runde (10/10)',
+    badgePerfect5Desc: '5 perfekte Runden',
+    badgeAllOpsDesc: 'Perfekte Runde mit allen 4 Rechenarten',
+    badgeChallengeLevel3Desc: 'Herausforderung Stufe 3 erreicht',
+    badgeChallengeLevel6Desc: 'Herausforderung Stufe 6 erreicht',
+    badgeChallengeNoErrorsDesc: 'Herausforderung ohne Fehler abgeschlossen',
+    badgeRange100Desc: 'Mit Zahlen bis 100 gespielt',
+    badgeCreativeModeDesc: 'Im Kreativmodus gespielt',
+    badgeNewUnlocked: 'Neues Abzeichen freigeschaltet!',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -89,6 +89,11 @@ export interface SessionRecord {
   numberRange: NumberRange;
 }
 
+export interface AchievementBadge {
+  id: string;
+  unlockedAt: number;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -25,6 +25,7 @@ export const STORAGE_KEYS = {
   PARENT_STATS: 'app-parent-stats',
   TASK_STATS: 'app-task-stats',
   BADGES: 'app-badges',
+  STREAK: 'app-streak',
 } as const;
 
 export type BadgeCategory = 'streak' | 'performance' | 'challenge' | 'explorer';

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -24,7 +24,30 @@ export const STORAGE_KEYS = {
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
   TASK_STATS: 'app-task-stats',
+  BADGES: 'app-badges',
 } as const;
+
+export type BadgeCategory = 'streak' | 'performance' | 'challenge' | 'explorer';
+
+export interface BadgeDefinition {
+  id: string;
+  icon: string;
+  category: BadgeCategory;
+}
+
+export const BADGE_DEFINITIONS: BadgeDefinition[] = [
+  { id: 'streak_3',             icon: '🔥',    category: 'streak' },
+  { id: 'streak_7',             icon: '🔥🔥',  category: 'streak' },
+  { id: 'streak_30',            icon: '🔥🔥🔥', category: 'streak' },
+  { id: 'perfect_1',            icon: '⭐',    category: 'performance' },
+  { id: 'perfect_5',            icon: '🌟',    category: 'performance' },
+  { id: 'all_operations',       icon: '💎',    category: 'performance' },
+  { id: 'challenge_level_3',    icon: '🏆',    category: 'challenge' },
+  { id: 'challenge_level_6',    icon: '👑',    category: 'challenge' },
+  { id: 'challenge_no_errors',  icon: '❤️',    category: 'challenge' },
+  { id: 'range_100',            icon: '🔢',    category: 'explorer' },
+  { id: 'creative_mode',        icon: '🎨',    category: 'explorer' },
+];
 
 // Challenge Mode Configuration
 export const CHALLENGE_MAX_LIVES = 3;

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -280,7 +280,13 @@ export const getBadges = async (): Promise<BadgeStore> => {
   try {
     const parsed = JSON.parse(value);
     if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as BadgeStore;
+      const validated: BadgeStore = {};
+      for (const [key, val] of Object.entries(parsed)) {
+        if (typeof val === 'number' && Number.isFinite(val)) {
+          validated[key] = val;
+        }
+      }
+      return validated;
     }
   } catch { /* ignore */ }
   return {};
@@ -288,6 +294,32 @@ export const getBadges = async (): Promise<BadgeStore> => {
 
 export const saveBadges = async (badges: BadgeStore): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.BADGES, JSON.stringify(badges));
+};
+
+// Persistent streak counter – decoupled from the 28-day session record window
+export interface StreakData {
+  currentStreak: number;
+  lastPlayedDay: string; // YYYY-MM-DD
+}
+
+export const getStreakData = async (): Promise<StreakData> => {
+  const value = await getStorageItem(STORAGE_KEYS.STREAK);
+  if (!value) return { currentStreak: 0, lastPlayedDay: '' };
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      typeof parsed === 'object' && parsed !== null &&
+      typeof parsed.currentStreak === 'number' &&
+      typeof parsed.lastPlayedDay === 'string'
+    ) {
+      return parsed as StreakData;
+    }
+  } catch { /* ignore */ }
+  return { currentStreak: 0, lastPlayedDay: '' };
+};
+
+export const saveStreakData = async (data: StreakData): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.STREAK, JSON.stringify(data));
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -271,6 +271,25 @@ export const getWeakTasks = (stats: TaskStat[], minAttempts = 3, minErrorRate = 
     });
 };
 
+// Badge storage – maps badgeId → unlock timestamp
+export type BadgeStore = Record<string, number>;
+
+export const getBadges = async (): Promise<BadgeStore> => {
+  const value = await getStorageItem(STORAGE_KEYS.BADGES);
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as BadgeStore;
+    }
+  } catch { /* ignore */ }
+  return {};
+};
+
+export const saveBadges = async (badges: BadgeStore): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.BADGES, JSON.stringify(badges));
+};
+
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.NUMBER_RANGE, range);
 };


### PR DESCRIPTION
## Summary

Implements Issue #184 — a fully persistent, bilingual achievement badge system.

- **11 badges** across 4 categories: Streaks (3/7/30 days), Performance (perfect rounds, all-ops), Challenge (Level 3/6, no errors), Explorer (Range 100, Creative Mode)
- Badges persist across app restarts via `AsyncStorage`/`localStorage` (`app-badges` key)
- New badge unlocks trigger an animated slide-up toast
- Badge gallery reachable from the Settings menu, showing unlocked/locked states with unlock dates
- Fully bilingual DE/EN

## Changed files

| File | What |
|------|------|
| `types/game.ts` | `AchievementBadge` interface |
| `utils/constants.ts` | `STORAGE_KEYS.BADGES`, `BadgeDefinition`, `BADGE_DEFINITIONS` (11 entries) |
| `utils/storage.ts` | `getBadges` / `saveBadges` helpers, `BadgeStore` type |
| `hooks/useBadges.ts` | Hook: streak calc, perfect-round count, challenge-level check, unlock logic |
| `hooks/useBadges.test.ts` | 19 new unit tests for all badge-logic functions |
| `i18n/translations.ts` | Full DE/EN translations for names, descriptions, categories |
| `components/BadgesModal.tsx` | Gallery modal — 2-col grid, locked badges greyed-out with 🔒 |
| `components/BadgeUnlockToast.tsx` | Animated slide-up toast, respects `prefersReducedMotion` |
| `components/SettingsMenu.tsx` | Badges button + `onOpenBadges` prop |
| `App.tsx` | Wires `useBadges`, triggers `checkAndUnlock` after `saveSessionRecord` |

## Acceptance criteria

- [x] ≥ 10 different badges (11 implemented)
- [x] Persistence across app restarts
- [x] New badges trigger an unlock animation
- [x] Gallery shows locked badges greyed out
- [x] Fully bilingual (DE/EN)

## Test plan

- [ ] All 14 test suites pass (`npm test` → 434 passed, 3 skipped)
- [ ] Open settings menu → "Abzeichen / Achievements" button visible
- [ ] Play a round with 10/10 correct → `perfect_1` badge unlocked, toast appears
- [ ] Play with number range 1-100 → `range_100` badge unlocked
- [ ] Play creative mode → `creative_mode` badge unlocked
- [ ] Badge gallery shows unlocked badges with date, locked badges with 🔒

https://claude.ai/code/session_01NkDEsAgqJKKvZgQ9VfiwsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkDEsAgqJKKvZgQ9VfiwsQ)_