### PR TITLE
feat: Onboarding-Tutorial für Erstnutzer (#189)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import {
 
 // Local imports
 import { translations } from './i18n/translations';
+import { STORAGE_KEYS } from './utils/constants';
 import { useTheme } from './hooks/useTheme';
 import { usePreferences } from './hooks/usePreferences';
 import { useGameLogic } from './hooks/useGameLogic';
@@ -32,8 +33,9 @@ import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
+import { OnboardingModal } from './components/OnboardingModal';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord } from './utils/storage';
+import { saveSessionRecord, getOnboardingShown, setOnboardingShown, resetOnboarding, getStorageItem } from './utils/storage';
 import { SessionRecord } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
@@ -53,6 +55,7 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [onboardingVisible, setOnboardingVisible] = useState(false);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
@@ -183,6 +186,29 @@ export default function App() {
     }
   }, [game.gameState.isAnswerChecked, game.gameState.lastAnswerCorrect]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Show onboarding for new users; silently skip for existing users (migration)
+  useEffect(() => {
+    if (!preferences.isLoaded) return;
+    (async () => {
+      const shown = await getOnboardingShown();
+      if (shown) return;
+      const rawValue = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+      if (rawValue === 'pending') {
+        // Explicit reset → always show onboarding
+        setOnboardingVisible(true);
+        return;
+      }
+      // rawValue is null → first launch: migrate existing users silently
+      const existingLanguage = await getStorageItem(STORAGE_KEYS.LANGUAGE);
+      if (existingLanguage) {
+        await setOnboardingShown();
+      } else {
+        setOnboardingVisible(true);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preferences.isLoaded]);
+
   // Generate first question on mount
   useEffect(() => {
     if (preferences.isLoaded) {
@@ -241,6 +267,10 @@ export default function App() {
             hideMenu();
           }}
           onOpenParentDashboard={() => setParentDashboardVisible(true)}
+          onResetOnboarding={async () => {
+            await resetOnboarding();
+            setOnboardingVisible(true);
+          }}
           t={t}
         />
       )}
@@ -300,6 +330,16 @@ export default function App() {
       <ParentDashboard
         visible={parentDashboardVisible}
         onClose={() => setParentDashboardVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <OnboardingModal
+        visible={onboardingVisible}
+        onFinish={async () => {
+          await setOnboardingShown();
+          setOnboardingVisible(false);
+        }}
         colors={colors}
         t={t}
       />

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -1,0 +1,337 @@
+import React, { useState, useRef } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  Animated,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { ThemeColors } from '../types/game';
+import { modalStyles } from '../styles/modalStyles';
+import { DESIGN_TOKENS } from '../utils/constants';
+
+interface OnboardingModalProps {
+  visible: boolean;
+  onFinish: () => void;
+  colors: ThemeColors;
+  t: {
+    onboardingWelcomeTitle: string;
+    onboardingWelcomeBody: string;
+    onboardingDemoTitle: string;
+    onboardingDemoTooltip: string;
+    onboardingSettingsTitle: string;
+    onboardingSettingsBody: string;
+    onboardingReadyTitle: string;
+    onboardingReadyBody: string;
+    onboardingNext: string;
+    onboardingStart: string;
+    onboardingSkip: string;
+  };
+}
+
+const DEMO_CHOICES = [5, 6, 8];
+const DEMO_CORRECT = 6;
+const TOTAL_STEPS = 4;
+
+export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModalProps) {
+  const [step, setStep] = useState(0);
+  const [demoAnswer, setDemoAnswer] = useState<number | null>(null);
+  const shakeAnim = useRef(new Animated.Value(0)).current;
+
+  const demoCorrect = demoAnswer === DEMO_CORRECT;
+  const demoWrong = demoAnswer !== null && demoAnswer !== DEMO_CORRECT;
+
+  const handleClose = () => {
+    setStep(0);
+    setDemoAnswer(null);
+    onFinish();
+  };
+
+  const handleNext = () => {
+    if (step < TOTAL_STEPS - 1) {
+      setStep(s => s + 1);
+    } else {
+      handleClose();
+    }
+  };
+
+  const handleDemoChoice = (choice: number) => {
+    if (demoAnswer !== null) return;
+    setDemoAnswer(choice);
+    if (choice !== DEMO_CORRECT) {
+      Animated.sequence([
+        Animated.timing(shakeAnim, { toValue: -8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: -5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 0, duration: 60, useNativeDriver: true }),
+      ]).start();
+    }
+  };
+
+  const canProceedStep1 = step !== 1 || demoCorrect;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[modalStyles.content, styles.container, { backgroundColor: colors.settingsMenu }]}>
+
+          {/* Progress dots */}
+          <View style={styles.dotsRow}>
+            {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.dot,
+                  i === step && styles.dotActive,
+                  { backgroundColor: i === step ? DESIGN_TOKENS.GRADIENT_PRIMARY[0] : colors.border },
+                ]}
+              />
+            ))}
+          </View>
+
+          {/* Step content */}
+          {step === 0 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🎉</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingWelcomeTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingWelcomeBody}</Text>
+            </View>
+          )}
+
+          {step === 1 && (
+            <View style={styles.stepContent}>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingDemoTitle}</Text>
+              <Animated.View style={[styles.demoCard, { backgroundColor: colors.card, transform: [{ translateX: shakeAnim }] }]}>
+                <Text style={[styles.demoEquation, { color: colors.text, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                  2 × 3 = ?
+                </Text>
+              </Animated.View>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>
+                ↑ {t.onboardingDemoTooltip}
+              </Text>
+              <View style={styles.choicesRow}>
+                {DEMO_CHOICES.map(choice => {
+                  const isSelected = demoAnswer === choice;
+                  const isCorrectChoice = choice === DEMO_CORRECT;
+                  let bg = colors.buttonInactive;
+                  let border = colors.border;
+                  let textColor = colors.text;
+                  if (isSelected && isCorrectChoice) {
+                    bg = '#ECFDF5';
+                    border = '#43e97b';
+                    textColor = '#059669';
+                  } else if (isSelected && !isCorrectChoice) {
+                    bg = '#FFF1F2';
+                    border = '#f857a6';
+                    textColor = '#be123c';
+                  }
+                  return (
+                    <TouchableOpacity
+                      key={choice}
+                      style={[styles.choiceButton, { backgroundColor: bg, borderColor: border }]}
+                      onPress={() => handleDemoChoice(choice)}
+                      disabled={demoAnswer !== null}
+                    >
+                      <Text style={[styles.choiceText, { color: textColor, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                        {choice}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+              {demoCorrect && (
+                <Text style={styles.feedbackCorrect}>✓</Text>
+              )}
+              {demoWrong && (
+                <Text style={[styles.body, { color: colors.textSecondary }]}>
+                  Nicht ganz – tippe nochmal!
+                </Text>
+              )}
+            </View>
+          )}
+
+          {step === 2 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>⚙️</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingSettingsTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingSettingsBody}</Text>
+              <LinearGradient
+                colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.menuHint}
+              >
+                <Text style={styles.menuHintText}>☰</Text>
+              </LinearGradient>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>↑ Settings</Text>
+            </View>
+          )}
+
+          {step === 3 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🚀</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingReadyTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingReadyBody}</Text>
+            </View>
+          )}
+
+          {/* Buttons */}
+          <View style={styles.buttonsRow}>
+            <TouchableOpacity style={styles.skipButton} onPress={handleClose}>
+              <Text style={[styles.skipText, { color: colors.textSecondary }]}>{t.onboardingSkip}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.nextButton, !canProceedStep1 && styles.nextButtonDisabled]}
+              onPress={handleNext}
+              disabled={!canProceedStep1}
+            >
+              <LinearGradient
+                colors={canProceedStep1 ? DESIGN_TOKENS.GRADIENT_PRIMARY : ['#ccc', '#ccc']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.nextButtonGradient}
+              >
+                <Text style={styles.nextButtonText}>
+                  {step === TOTAL_STEPS - 1 ? t.onboardingStart : t.onboardingNext}
+                </Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          </View>
+
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '88%',
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    paddingBottom: 20,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  dotActive: {
+    width: 24,
+  },
+  stepContent: {
+    alignItems: 'center',
+    minHeight: 200,
+    justifyContent: 'center',
+    gap: 12,
+    width: '100%',
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  tooltip: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  demoCard: {
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+  },
+  demoEquation: {
+    fontSize: 32,
+  },
+  choicesRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 4,
+  },
+  choiceButton: {
+    width: 64,
+    height: 56,
+    borderRadius: 12,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  choiceText: {
+    fontSize: 22,
+  },
+  feedbackCorrect: {
+    fontSize: 32,
+    color: '#059669',
+  },
+  menuHint: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  menuHintText: {
+    fontSize: 20,
+    color: '#fff',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 24,
+    gap: 12,
+  },
+  skipButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  skipText: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  nextButton: {
+    flex: 1,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  nextButtonDisabled: {
+    opacity: 0.5,
+  },
+  nextButtonGradient: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -31,6 +31,7 @@ interface SettingsMenuProps {
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
   onOpenParentDashboard: () => void;
+  onResetOnboarding: () => void;
   // Translations
   t: {
     operation: string;
@@ -57,6 +58,7 @@ interface SettingsMenuProps {
     support: string;
     about: string;
     settings: string;
+    resetOnboarding: string;
   };
 }
 
@@ -74,6 +76,7 @@ export function SettingsMenu({
   onOpenPersonalize,
   onOpenAbout,
   onOpenParentDashboard,
+  onResetOnboarding,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -263,6 +266,14 @@ export function SettingsMenu({
             <Text style={styles.settingsMenuLinkText}>{t.about}</Text>
           </TouchableOpacity>
         </View>
+
+        {/* Reset Onboarding */}
+        <TouchableOpacity
+          style={[styles.settingsSection, styles.resetOnboardingButton]}
+          onPress={() => { onResetOnboarding(); onHideMenu(); }}
+        >
+          <Text style={styles.resetOnboardingText}>{t.resetOnboarding}</Text>
+        </TouchableOpacity>
         </ScrollView>
       </Animated.View>
     </>
@@ -457,5 +468,16 @@ const styles = StyleSheet.create({
   },
   rangeButtonTextActive: {
     color: '#fff',
+  },
+  resetOnboardingButton: {
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(102,126,234,0.1)',
+  },
+  resetOnboardingText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: 'rgba(102,126,234,0.6)',
   },
 });

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -94,6 +94,19 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  // Onboarding
+  onboardingWelcomeTitle: string;
+  onboardingWelcomeBody: string;
+  onboardingDemoTitle: string;
+  onboardingDemoTooltip: string;
+  onboardingSettingsTitle: string;
+  onboardingSettingsBody: string;
+  onboardingReadyTitle: string;
+  onboardingReadyBody: string;
+  onboardingNext: string;
+  onboardingStart: string;
+  onboardingSkip: string;
+  resetOnboarding: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -186,6 +199,19 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    // Onboarding
+    onboardingWelcomeTitle: 'Welcome to 1×1 Trainer!',
+    onboardingWelcomeBody: 'Practice multiplication, division, addition and subtraction — fun and easy!',
+    onboardingDemoTitle: 'Try it out!',
+    onboardingDemoTooltip: 'Enter your answer here',
+    onboardingSettingsTitle: 'Everything Adjustable',
+    onboardingSettingsBody: 'Tap the menu button to change the operation, difficulty and number range.',
+    onboardingReadyTitle: "You're ready!",
+    onboardingReadyBody: 'Have fun practicing!',
+    onboardingNext: 'Next',
+    onboardingStart: 'Start',
+    onboardingSkip: 'Skip',
+    resetOnboarding: 'Restart tutorial',
   },
   de: {
     // Settings Menu
@@ -276,5 +302,18 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    // Onboarding
+    onboardingWelcomeTitle: 'Willkommen beim 1×1 Trainer!',
+    onboardingWelcomeBody: 'Übe Multiplikation, Division, Addition und Subtraktion – Spaß und einfach!',
+    onboardingDemoTitle: 'Probiere es aus!',
+    onboardingDemoTooltip: 'Gib deine Antwort hier ein',
+    onboardingSettingsTitle: 'Alles einstellbar',
+    onboardingSettingsBody: 'Tippe auf den Menü-Button, um Rechenart, Schwierigkeit und Zahlenbereich zu ändern.',
+    onboardingReadyTitle: 'Du bist bereit!',
+    onboardingReadyBody: 'Viel Spaß beim Üben!',
+    onboardingNext: 'Weiter',
+    onboardingStart: 'Loslegen',
+    onboardingSkip: 'Überspringen',
+    resetOnboarding: 'Tutorial zurücksetzen',
   },
 };

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  ONBOARDING_SHOWN: 'app-onboarding-done',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -198,6 +198,22 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
 };
 
+// Returns true when onboarding is done (value = 'true').
+// Returns false for null (never seen) or 'pending' (explicitly reset).
+export const getOnboardingShown = async (): Promise<boolean> => {
+  const value = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+  return value === 'true';
+};
+
+export const setOnboardingShown = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'true');
+};
+
+// Stores 'pending' so migration logic is skipped on next launch
+export const resetOnboarding = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'pending');
+};
+
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.NUMBER_RANGE, range);
 };


### PR DESCRIPTION
## Summary

- Neues `OnboardingModal`-Component mit 4 Schritten (Willkommen → Demo → Settings-Hinweis → Los geht's)
- Interaktive Demo-Aufgabe (2×3=?) mit Multiple-Choice und Shake-Animation bei Fehler
- Skip-Button auf jeder Seite; Fortschritts-Dots zeigen den aktuellen Schritt
- Storage-Key `app-onboarding-done` mit Migrations-Logik: bestehende Nutzer (die bereits `app-language` gespeichert haben) überspringen das Onboarding still
- Reset-Mechanismus via `'pending'`-Wert erzwingt Anzeige unabhängig von der Migration
- „Tutorial zurücksetzen" im Settings-Menü als dezenter Link
- Vollständige DE/EN-Übersetzungen

## Test plan

- [ ] Frischer App-Start (keine gespeicherten Präferenzen) → Onboarding erscheint
- [ ] Alle 4 Schritte durchklicken, Schritt 2 erst nach richtiger Antwort (6) weiter
- [ ] Skip-Button schließt Onboarding sofort auf jedem Schritt
- [ ] Nach Abschluss: App-Neustart → Onboarding erscheint nicht mehr
- [ ] Settings → „Tutorial zurücksetzen" → Onboarding erscheint beim nächsten Start wieder
- [ ] Bestehende Nutzer (mit gespeicherter Sprache): Onboarding erscheint nicht
- [ ] DE/EN-Sprache: Onboarding-Texte korrekt übersetzt
- [ ] 415 Tests grün (`npm test`)

Closes #189

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrTnxUeFFf7EHsbY3tE4Vv)_