### PR TITLE
fix: Copilot-Review-Suggestions für OnboardingModal umsetzen (#198)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -35,7 +35,7 @@ import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
 import { OnboardingModal } from './components/OnboardingModal';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord, getOnboardingShown, setOnboardingShown, resetOnboarding, getStorageItem } from './utils/storage';
+import { saveSessionRecord, getOnboardingDone, setOnboardingDone, resetOnboarding, getStorageItem } from './utils/storage';
 import { SessionRecord } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
@@ -190,9 +190,9 @@ export default function App() {
   useEffect(() => {
     if (!preferences.isLoaded) return;
     (async () => {
-      const shown = await getOnboardingShown();
+      const shown = await getOnboardingDone();
       if (shown) return;
-      const rawValue = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+      const rawValue = await getStorageItem(STORAGE_KEYS.ONBOARDING_DONE);
       if (rawValue === 'pending') {
         // Explicit reset → always show onboarding
         setOnboardingVisible(true);
@@ -201,7 +201,7 @@ export default function App() {
       // rawValue is null → first launch: migrate existing users silently
       const existingLanguage = await getStorageItem(STORAGE_KEYS.LANGUAGE);
       if (existingLanguage) {
-        await setOnboardingShown();
+        await setOnboardingDone();
       } else {
         setOnboardingVisible(true);
       }
@@ -337,7 +337,7 @@ export default function App() {
       <OnboardingModal
         visible={onboardingVisible}
         onFinish={async () => {
-          await setOnboardingShown();
+          await setOnboardingDone();
           setOnboardingVisible(false);
         }}
         colors={colors}

--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import {
 
 // Local imports
 import { translations } from './i18n/translations';
+import { STORAGE_KEYS } from './utils/constants';
 import { useTheme } from './hooks/useTheme';
 import { usePreferences } from './hooks/usePreferences';
 import { useGameLogic } from './hooks/useGameLogic';
@@ -32,8 +33,9 @@ import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
+import { OnboardingModal } from './components/OnboardingModal';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord } from './utils/storage';
+import { saveSessionRecord, getOnboardingShown, setOnboardingShown, resetOnboarding, getStorageItem } from './utils/storage';
 import { SessionRecord } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
@@ -53,6 +55,7 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [onboardingVisible, setOnboardingVisible] = useState(false);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
@@ -183,6 +186,29 @@ export default function App() {
     }
   }, [game.gameState.isAnswerChecked, game.gameState.lastAnswerCorrect]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Show onboarding for new users; silently skip for existing users (migration)
+  useEffect(() => {
+    if (!preferences.isLoaded) return;
+    (async () => {
+      const shown = await getOnboardingShown();
+      if (shown) return;
+      const rawValue = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+      if (rawValue === 'pending') {
+        // Explicit reset → always show onboarding
+        setOnboardingVisible(true);
+        return;
+      }
+      // rawValue is null → first launch: migrate existing users silently
+      const existingLanguage = await getStorageItem(STORAGE_KEYS.LANGUAGE);
+      if (existingLanguage) {
+        await setOnboardingShown();
+      } else {
+        setOnboardingVisible(true);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preferences.isLoaded]);
+
   // Generate first question on mount
   useEffect(() => {
     if (preferences.isLoaded) {
@@ -241,6 +267,10 @@ export default function App() {
             hideMenu();
           }}
           onOpenParentDashboard={() => setParentDashboardVisible(true)}
+          onResetOnboarding={async () => {
+            await resetOnboarding();
+            setOnboardingVisible(true);
+          }}
           t={t}
         />
       )}
@@ -300,6 +330,16 @@ export default function App() {
       <ParentDashboard
         visible={parentDashboardVisible}
         onClose={() => setParentDashboardVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <OnboardingModal
+        visible={onboardingVisible}
+        onFinish={async () => {
+          await setOnboardingShown();
+          setOnboardingVisible(false);
+        }}
         colors={colors}
         t={t}
       />

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -11,6 +11,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { ThemeColors } from '../types/game';
 import { modalStyles } from '../styles/modalStyles';
 import { DESIGN_TOKENS } from '../utils/constants';
+import { prefersReducedMotion } from '../utils/animations';
 
 interface OnboardingModalProps {
   visible: boolean;
@@ -25,6 +26,8 @@ interface OnboardingModalProps {
     onboardingSettingsBody: string;
     onboardingReadyTitle: string;
     onboardingReadyBody: string;
+    onboardingDemoRetry: string;
+    onboardingSettingsLabel: string;
     onboardingNext: string;
     onboardingStart: string;
     onboardingSkip: string;
@@ -61,13 +64,17 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
     if (demoAnswer !== null) return;
     setDemoAnswer(choice);
     if (choice !== DEMO_CORRECT) {
+      if (prefersReducedMotion()) {
+        setDemoAnswer(null);
+        return;
+      }
       Animated.sequence([
         Animated.timing(shakeAnim, { toValue: -8, duration: 60, useNativeDriver: true }),
         Animated.timing(shakeAnim, { toValue: 8, duration: 60, useNativeDriver: true }),
         Animated.timing(shakeAnim, { toValue: -5, duration: 60, useNativeDriver: true }),
         Animated.timing(shakeAnim, { toValue: 5, duration: 60, useNativeDriver: true }),
         Animated.timing(shakeAnim, { toValue: 0, duration: 60, useNativeDriver: true }),
-      ]).start();
+      ]).start(() => setDemoAnswer(null));
     }
   };
 
@@ -147,7 +154,7 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
               )}
               {demoWrong && (
                 <Text style={[styles.body, { color: colors.textSecondary }]}>
-                  Nicht ganz – tippe nochmal!
+                  {t.onboardingDemoRetry}
                 </Text>
               )}
             </View>
@@ -166,7 +173,7 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
               >
                 <Text style={styles.menuHintText}>☰</Text>
               </LinearGradient>
-              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>↑ Settings</Text>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>{t.onboardingSettingsLabel}</Text>
             </View>
           )}
 

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -1,0 +1,337 @@
+import React, { useState, useRef } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  Animated,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { ThemeColors } from '../types/game';
+import { modalStyles } from '../styles/modalStyles';
+import { DESIGN_TOKENS } from '../utils/constants';
+
+interface OnboardingModalProps {
+  visible: boolean;
+  onFinish: () => void;
+  colors: ThemeColors;
+  t: {
+    onboardingWelcomeTitle: string;
+    onboardingWelcomeBody: string;
+    onboardingDemoTitle: string;
+    onboardingDemoTooltip: string;
+    onboardingSettingsTitle: string;
+    onboardingSettingsBody: string;
+    onboardingReadyTitle: string;
+    onboardingReadyBody: string;
+    onboardingNext: string;
+    onboardingStart: string;
+    onboardingSkip: string;
+  };
+}
+
+const DEMO_CHOICES = [5, 6, 8];
+const DEMO_CORRECT = 6;
+const TOTAL_STEPS = 4;
+
+export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModalProps) {
+  const [step, setStep] = useState(0);
+  const [demoAnswer, setDemoAnswer] = useState<number | null>(null);
+  const shakeAnim = useRef(new Animated.Value(0)).current;
+
+  const demoCorrect = demoAnswer === DEMO_CORRECT;
+  const demoWrong = demoAnswer !== null && demoAnswer !== DEMO_CORRECT;
+
+  const handleClose = () => {
+    setStep(0);
+    setDemoAnswer(null);
+    onFinish();
+  };
+
+  const handleNext = () => {
+    if (step < TOTAL_STEPS - 1) {
+      setStep(s => s + 1);
+    } else {
+      handleClose();
+    }
+  };
+
+  const handleDemoChoice = (choice: number) => {
+    if (demoAnswer !== null) return;
+    setDemoAnswer(choice);
+    if (choice !== DEMO_CORRECT) {
+      Animated.sequence([
+        Animated.timing(shakeAnim, { toValue: -8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: -5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 0, duration: 60, useNativeDriver: true }),
+      ]).start();
+    }
+  };
+
+  const canProceedStep1 = step !== 1 || demoCorrect;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[modalStyles.content, styles.container, { backgroundColor: colors.settingsMenu }]}>
+
+          {/* Progress dots */}
+          <View style={styles.dotsRow}>
+            {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.dot,
+                  i === step && styles.dotActive,
+                  { backgroundColor: i === step ? DESIGN_TOKENS.GRADIENT_PRIMARY[0] : colors.border },
+                ]}
+              />
+            ))}
+          </View>
+
+          {/* Step content */}
+          {step === 0 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🎉</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingWelcomeTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingWelcomeBody}</Text>
+            </View>
+          )}
+
+          {step === 1 && (
+            <View style={styles.stepContent}>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingDemoTitle}</Text>
+              <Animated.View style={[styles.demoCard, { backgroundColor: colors.card, transform: [{ translateX: shakeAnim }] }]}>
+                <Text style={[styles.demoEquation, { color: colors.text, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                  2 × 3 = ?
+                </Text>
+              </Animated.View>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>
+                ↑ {t.onboardingDemoTooltip}
+              </Text>
+              <View style={styles.choicesRow}>
+                {DEMO_CHOICES.map(choice => {
+                  const isSelected = demoAnswer === choice;
+                  const isCorrectChoice = choice === DEMO_CORRECT;
+                  let bg = colors.buttonInactive;
+                  let border = colors.border;
+                  let textColor = colors.text;
+                  if (isSelected && isCorrectChoice) {
+                    bg = '#ECFDF5';
+                    border = '#43e97b';
+                    textColor = '#059669';
+                  } else if (isSelected && !isCorrectChoice) {
+                    bg = '#FFF1F2';
+                    border = '#f857a6';
+                    textColor = '#be123c';
+                  }
+                  return (
+                    <TouchableOpacity
+                      key={choice}
+                      style={[styles.choiceButton, { backgroundColor: bg, borderColor: border }]}
+                      onPress={() => handleDemoChoice(choice)}
+                      disabled={demoAnswer !== null}
+                    >
+                      <Text style={[styles.choiceText, { color: textColor, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                        {choice}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+              {demoCorrect && (
+                <Text style={styles.feedbackCorrect}>✓</Text>
+              )}
+              {demoWrong && (
+                <Text style={[styles.body, { color: colors.textSecondary }]}>
+                  Nicht ganz – tippe nochmal!
+                </Text>
+              )}
+            </View>
+          )}
+
+          {step === 2 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>⚙️</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingSettingsTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingSettingsBody}</Text>
+              <LinearGradient
+                colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.menuHint}
+              >
+                <Text style={styles.menuHintText}>☰</Text>
+              </LinearGradient>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>↑ Settings</Text>
+            </View>
+          )}
+
+          {step === 3 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🚀</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingReadyTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingReadyBody}</Text>
+            </View>
+          )}
+
+          {/* Buttons */}
+          <View style={styles.buttonsRow}>
+            <TouchableOpacity style={styles.skipButton} onPress={handleClose}>
+              <Text style={[styles.skipText, { color: colors.textSecondary }]}>{t.onboardingSkip}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.nextButton, !canProceedStep1 && styles.nextButtonDisabled]}
+              onPress={handleNext}
+              disabled={!canProceedStep1}
+            >
+              <LinearGradient
+                colors={canProceedStep1 ? DESIGN_TOKENS.GRADIENT_PRIMARY : ['#ccc', '#ccc']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.nextButtonGradient}
+              >
+                <Text style={styles.nextButtonText}>
+                  {step === TOTAL_STEPS - 1 ? t.onboardingStart : t.onboardingNext}
+                </Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          </View>
+
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '88%',
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    paddingBottom: 20,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  dotActive: {
+    width: 24,
+  },
+  stepContent: {
+    alignItems: 'center',
+    minHeight: 200,
+    justifyContent: 'center',
+    gap: 12,
+    width: '100%',
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  tooltip: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  demoCard: {
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+  },
+  demoEquation: {
+    fontSize: 32,
+  },
+  choicesRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 4,
+  },
+  choiceButton: {
+    width: 64,
+    height: 56,
+    borderRadius: 12,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  choiceText: {
+    fontSize: 22,
+  },
+  feedbackCorrect: {
+    fontSize: 32,
+    color: '#059669',
+  },
+  menuHint: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  menuHintText: {
+    fontSize: 20,
+    color: '#fff',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 24,
+    gap: 12,
+  },
+  skipButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  skipText: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  nextButton: {
+    flex: 1,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  nextButtonDisabled: {
+    opacity: 0.5,
+  },
+  nextButtonGradient: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -31,6 +31,7 @@ interface SettingsMenuProps {
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
   onOpenParentDashboard: () => void;
+  onResetOnboarding: () => void;
   // Translations
   t: {
     operation: string;
@@ -57,6 +58,7 @@ interface SettingsMenuProps {
     support: string;
     about: string;
     settings: string;
+    resetOnboarding: string;
   };
 }
 
@@ -74,6 +76,7 @@ export function SettingsMenu({
   onOpenPersonalize,
   onOpenAbout,
   onOpenParentDashboard,
+  onResetOnboarding,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -263,6 +266,14 @@ export function SettingsMenu({
             <Text style={styles.settingsMenuLinkText}>{t.about}</Text>
           </TouchableOpacity>
         </View>
+
+        {/* Reset Onboarding */}
+        <TouchableOpacity
+          style={[styles.settingsSection, styles.resetOnboardingButton]}
+          onPress={() => { onResetOnboarding(); onHideMenu(); }}
+        >
+          <Text style={styles.resetOnboardingText}>{t.resetOnboarding}</Text>
+        </TouchableOpacity>
         </ScrollView>
       </Animated.View>
     </>
@@ -457,5 +468,16 @@ const styles = StyleSheet.create({
   },
   rangeButtonTextActive: {
     color: '#fff',
+  },
+  resetOnboardingButton: {
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(102,126,234,0.1)',
+  },
+  resetOnboardingText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: 'rgba(102,126,234,0.6)',
   },
 });

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -94,6 +94,19 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  // Onboarding
+  onboardingWelcomeTitle: string;
+  onboardingWelcomeBody: string;
+  onboardingDemoTitle: string;
+  onboardingDemoTooltip: string;
+  onboardingSettingsTitle: string;
+  onboardingSettingsBody: string;
+  onboardingReadyTitle: string;
+  onboardingReadyBody: string;
+  onboardingNext: string;
+  onboardingStart: string;
+  onboardingSkip: string;
+  resetOnboarding: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -186,6 +199,19 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    // Onboarding
+    onboardingWelcomeTitle: 'Welcome to 1×1 Trainer!',
+    onboardingWelcomeBody: 'Practice multiplication, division, addition and subtraction — fun and easy!',
+    onboardingDemoTitle: 'Try it out!',
+    onboardingDemoTooltip: 'Enter your answer here',
+    onboardingSettingsTitle: 'Everything Adjustable',
+    onboardingSettingsBody: 'Tap the menu button to change the operation, difficulty and number range.',
+    onboardingReadyTitle: "You're ready!",
+    onboardingReadyBody: 'Have fun practicing!',
+    onboardingNext: 'Next',
+    onboardingStart: 'Start',
+    onboardingSkip: 'Skip',
+    resetOnboarding: 'Restart tutorial',
   },
   de: {
     // Settings Menu
@@ -276,5 +302,18 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    // Onboarding
+    onboardingWelcomeTitle: 'Willkommen beim 1×1 Trainer!',
+    onboardingWelcomeBody: 'Übe Multiplikation, Division, Addition und Subtraktion – Spaß und einfach!',
+    onboardingDemoTitle: 'Probiere es aus!',
+    onboardingDemoTooltip: 'Gib deine Antwort hier ein',
+    onboardingSettingsTitle: 'Alles einstellbar',
+    onboardingSettingsBody: 'Tippe auf den Menü-Button, um Rechenart, Schwierigkeit und Zahlenbereich zu ändern.',
+    onboardingReadyTitle: 'Du bist bereit!',
+    onboardingReadyBody: 'Viel Spaß beim Üben!',
+    onboardingNext: 'Weiter',
+    onboardingStart: 'Loslegen',
+    onboardingSkip: 'Überspringen',
+    resetOnboarding: 'Tutorial zurücksetzen',
   },
 };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -103,6 +103,8 @@ export interface TranslationStrings {
   onboardingSettingsBody: string;
   onboardingReadyTitle: string;
   onboardingReadyBody: string;
+  onboardingDemoRetry: string;
+  onboardingSettingsLabel: string;
   onboardingNext: string;
   onboardingStart: string;
   onboardingSkip: string;
@@ -208,6 +210,8 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingSettingsBody: 'Tap the menu button to change the operation, difficulty and number range.',
     onboardingReadyTitle: "You're ready!",
     onboardingReadyBody: 'Have fun practicing!',
+    onboardingDemoRetry: 'Not quite — try again!',
+    onboardingSettingsLabel: '↑ Settings',
     onboardingNext: 'Next',
     onboardingStart: 'Start',
     onboardingSkip: 'Skip',
@@ -311,6 +315,8 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingSettingsBody: 'Tippe auf den Menü-Button, um Rechenart, Schwierigkeit und Zahlenbereich zu ändern.',
     onboardingReadyTitle: 'Du bist bereit!',
     onboardingReadyBody: 'Viel Spaß beim Üben!',
+    onboardingDemoRetry: 'Nicht ganz – tippe nochmal!',
+    onboardingSettingsLabel: '↑ Einstellungen',
     onboardingNext: 'Weiter',
     onboardingStart: 'Loslegen',
     onboardingSkip: 'Überspringen',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  ONBOARDING_SHOWN: 'app-onboarding-done',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,7 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
-  ONBOARDING_SHOWN: 'app-onboarding-done',
+  ONBOARDING_DONE: 'app-onboarding-done',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,6 +23,9 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getOnboardingDone,
+  setOnboardingDone,
+  resetOnboarding,
 } from './storage';
 import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
 
@@ -535,5 +538,41 @@ describe('Session Records Storage', () => {
     const [retrieved] = await getSessionRecords();
     expect(retrieved.errorRate).toBe(0.3);
     expect(retrieved.errors).toBe(3);
+  });
+});
+
+describe('storage.ts - Onboarding helpers', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('getOnboardingDone returns false when key is absent', async () => {
+    expect(await getOnboardingDone()).toBe(false);
+  });
+
+  it('getOnboardingDone returns false when value is "pending"', async () => {
+    mockStore['app-onboarding-done'] = 'pending';
+    expect(await getOnboardingDone()).toBe(false);
+  });
+
+  it('setOnboardingDone persists true and getOnboardingDone returns true', async () => {
+    await setOnboardingDone();
+    expect(mockStore['app-onboarding-done']).toBe('true');
+    expect(await getOnboardingDone()).toBe(true);
+  });
+
+  it('resetOnboarding stores "pending" so getOnboardingDone returns false', async () => {
+    await setOnboardingDone();
+    await resetOnboarding();
+    expect(mockStore['app-onboarding-done']).toBe('pending');
+    expect(await getOnboardingDone()).toBe(false);
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -198,6 +198,22 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
 };
 
+// Returns true when onboarding is done (value = 'true').
+// Returns false for null (never seen) or 'pending' (explicitly reset).
+export const getOnboardingShown = async (): Promise<boolean> => {
+  const value = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+  return value === 'true';
+};
+
+export const setOnboardingShown = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'true');
+};
+
+// Stores 'pending' so migration logic is skipped on next launch
+export const resetOnboarding = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'pending');
+};
+
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.NUMBER_RANGE, range);
 };

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -200,18 +200,18 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
 
 // Returns true when onboarding is done (value = 'true').
 // Returns false for null (never seen) or 'pending' (explicitly reset).
-export const getOnboardingShown = async (): Promise<boolean> => {
-  const value = await getStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN);
+export const getOnboardingDone = async (): Promise<boolean> => {
+  const value = await getStorageItem(STORAGE_KEYS.ONBOARDING_DONE);
   return value === 'true';
 };
 
-export const setOnboardingShown = async (): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'true');
+export const setOnboardingDone = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'true');
 };
 
 // Stores 'pending' so migration logic is skipped on next launch
 export const resetOnboarding = async (): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.ONBOARDING_SHOWN, 'pending');
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'pending');
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {


### PR DESCRIPTION
## Summary

Alle 5 Copilot-Review-Kommentare aus PR #198 umgesetzt:

- **Demo-Retry-Bug**: `demoAnswer` wird nach der Shake-Animation via `.start(() => setDemoAnswer(null))` zurückgesetzt — der User kann eine falsche Antwort erneut versuchen, statt auf Schritt 2 stecken zu bleiben
- **Reduced Motion**: Shake-Animation wird übersprungen wenn `prefersReducedMotion()` aktiv ist (konsistent mit dem Rest der App)
- **i18n**: Hard-coded `"Nicht ganz – tippe nochmal!"` (Zeile 151) und `"↑ Settings"` (Zeile 169) durch `t.onboardingDemoRetry` / `t.onboardingSettingsLabel` ersetzt; neue Schlüssel in DE + EN ergänzt
- **Naming-Konsistenz**: `STORAGE_KEYS.ONBOARDING_SHOWN` → `ONBOARDING_DONE`, `getOnboardingShown`/`setOnboardingShown` → `getOnboardingDone`/`setOnboardingDone` (Key-String `app-onboarding-done` bleibt unverändert)
- **Tests**: 4 neue Unit-Tests für `getOnboardingDone`, `setOnboardingDone`, `resetOnboarding` in `utils/storage.test.ts`

## Test plan

- [ ] `npm test` — alle Suites grün (inkl. 4 neue Onboarding-Storage-Tests)
- [ ] Onboarding Demo-Schritt: falsche Antwort wählen → Shake → Buttons wieder aktiv → erneut versuchen möglich
- [ ] Reduced-Motion-Setting aktiv: kein Shake bei falscher Antwort, Buttons sofort wieder aktiv
- [ ] EN-Sprache: "Not quite — try again!" + "↑ Settings" erscheinen korrekt
- [ ] DE-Sprache: "Nicht ganz – tippe nochmal!" + "↑ Einstellungen" erscheinen korrekt

https://claude.ai/code/session_01LSY7Uhw8rsB9JBSJZY8Rtk

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSY7Uhw8rsB9JBSJZY8Rtk)_