### PR TITLE
feat: Täglicher Streak-Tracker (Issue #185)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,10 @@ import {
   SafeAreaView,
   useWindowDimensions,
   Animated,
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
 } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { useFonts } from 'expo-font';
@@ -33,8 +37,8 @@ import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord } from './utils/storage';
-import { SessionRecord } from './types/game';
+import { saveSessionRecord, getStreakData, updateStreakAfterSession, getLocalDateString } from './utils/storage';
+import { SessionRecord, StreakData } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -53,6 +57,8 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [streakData, setStreakData] = useState<StreakData>({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  const [streakWarningVisible, setStreakWarningVisible] = useState(false);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
@@ -79,6 +85,7 @@ export default function App() {
     },
     onSessionComplete: (record: SessionRecord) => {
       saveSessionRecord(record);
+      updateStreakAfterSession().then(setStreakData);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -154,6 +161,20 @@ export default function App() {
     }
   }, [isDarkMode]);
 
+  // Load streak data and show warning when appropriate
+  useEffect(() => {
+    getStreakData().then((data) => {
+      setStreakData(data);
+      const now = new Date();
+      const isEvening = now.getHours() >= 20;
+      const hasStreakToProtect = data.currentStreak > 0;
+      const hasNotPlayedToday = data.lastPlayedDate !== getLocalDateString();
+      if (isEvening && hasStreakToProtect && hasNotPlayedToday) {
+        setStreakWarningVisible(true);
+      }
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Card feedback animation (skipped when reduce motion is enabled)
   useEffect(() => {
     if (!game.gameState.isAnswerChecked || prefersReducedMotion()) return;
@@ -216,6 +237,7 @@ export default function App() {
         score={game.gameState.score}
         currentTask={game.gameState.currentTask}
         totalTasks={game.gameState.totalTasks}
+        currentStreak={streakData.currentStreak}
         onShowMenu={showMenu}
         t={t}
       />
@@ -303,6 +325,24 @@ export default function App() {
         colors={colors}
         t={t}
       />
+
+      <Modal visible={streakWarningVisible} transparent animationType="fade">
+        <View style={styles.streakOverlay}>
+          <View style={[styles.streakWarningCard, { backgroundColor: colors.settingsMenu }]}>
+            <Text style={styles.streakWarningEmoji}>🔥</Text>
+            <Text style={[styles.streakWarningTitle, { color: colors.text }]}>{t.streakWarningTitle}</Text>
+            <Text style={[styles.streakWarningMessage, { color: colors.textSecondary }]}>
+              {t.streakWarningMessage.replace('{days}', String(streakData.currentStreak))}
+            </Text>
+            <TouchableOpacity
+              style={styles.streakWarningButton}
+              onPress={() => setStreakWarningVisible(false)}
+            >
+              <Text style={styles.streakWarningButtonText}>{t.streakWarningButton}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -310,5 +350,50 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  streakOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  streakWarningCard: {
+    borderRadius: 24,
+    padding: 28,
+    width: '80%',
+    maxWidth: 340,
+    alignItems: 'center',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  streakWarningEmoji: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  streakWarningTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  streakWarningMessage: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  streakWarningButton: {
+    backgroundColor: '#F59E0B',
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  streakWarningButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: 'bold',
   },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -326,7 +326,7 @@ export default function App() {
         t={t}
       />
 
-      <Modal visible={streakWarningVisible} transparent animationType="fade">
+      <Modal visible={streakWarningVisible} transparent animationType="fade" onRequestClose={() => setStreakWarningVisible(false)}>
         <View style={styles.streakOverlay}>
           <View style={[styles.streakWarningCard, { backgroundColor: colors.settingsMenu }]}>
             <Text style={styles.streakWarningEmoji}>🔥</Text>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,6 +18,7 @@ interface HeaderProps {
   score: number;
   currentTask: number;
   totalTasks: number;
+  currentStreak?: number;
   onShowMenu: () => void;
   t: {
     level: string;
@@ -33,6 +34,7 @@ export function Header({
   score,
   currentTask,
   totalTasks,
+  currentStreak,
   onShowMenu,
   t,
 }: HeaderProps) {
@@ -66,6 +68,11 @@ export function Header({
             <Text style={styles.scoreBadgeText}>⭐ {score}</Text>
           </LinearGradient>
         </>
+      )}
+      {!!currentStreak && currentStreak > 0 && (
+        <View style={styles.streakBadge}>
+          <Text style={styles.streakText}>🔥 {currentStreak}</Text>
+        </View>
       )}
       <TouchableOpacity
         onPress={onShowMenu}
@@ -124,5 +131,18 @@ const styles = StyleSheet.create({
   settingsButtonText: {
     fontSize: 24,
     fontWeight: 'normal',
+  },
+  streakBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 14,
+    backgroundColor: 'rgba(249,212,35,0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  streakText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#F59E0B',
   },
 });

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -142,7 +142,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           </View>
 
           {/* Summary bar */}
-          {(records.length > 0 || streak.currentStreak > 0) && (
+          {(records.length > 0 || streak.currentStreak > 0 || streak.longestStreak > 0) && (
             <View style={[styles.summaryBar, { borderColor: colors.border }]}>
               {records.length > 0 && (
                 <View style={styles.summaryItem}>
@@ -161,7 +161,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
                 </View>
               )}
-              {streak.currentStreak > 0 && (
+              {streak.currentStreak > 0 && records.length > 0 && (
                 <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
               )}
               {streak.currentStreak > 0 && (
@@ -170,7 +170,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentCurrentStreak}</Text>
                 </View>
               )}
-              {streak.longestStreak > 0 && (
+              {streak.longestStreak > 0 && (records.length > 0 || streak.currentStreak > 0) && (
                 <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
               )}
               {streak.longestStreak > 0 && (

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -8,8 +8,8 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { ThemeColors, SessionRecord, Operation, DifficultyMode } from '../types/game';
-import { getSessionRecords, FOUR_WEEKS_MS } from '../utils/storage';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode, StreakData } from '../types/game';
+import { getSessionRecords, getStreakData, FOUR_WEEKS_MS } from '../utils/storage';
 import { DESIGN_TOKENS } from '../utils/constants';
 import { modalStyles } from '../styles/modalStyles';
 
@@ -34,6 +34,9 @@ interface ParentDashboardProps {
     parentYesterday: string;
     parentCorrect: string;
     parentErrors: string;
+    parentCurrentStreak: string;
+    parentLongestStreak: string;
+    parentStreakDays: string;
     ok: string;
   };
 }
@@ -90,13 +93,15 @@ function errorRateColor(rate: number): string {
 
 export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
   const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [streak, setStreak] = useState<StreakData>({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setLoading(true);
-      getSessionRecords().then((data) => {
+      Promise.all([getSessionRecords(), getStreakData()]).then(([data, streakData]) => {
         setRecords(data);
+        setStreak(streakData);
         setLoading(false);
       });
     }
@@ -137,13 +142,15 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           </View>
 
           {/* Summary bar */}
-          {records.length > 0 && (
+          {(records.length > 0 || streak.currentStreak > 0) && (
             <View style={[styles.summaryBar, { borderColor: colors.border }]}>
-              <View style={styles.summaryItem}>
-                <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
-                <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
-              </View>
-              {avgErrorRate !== null && (
+              {records.length > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
+                </View>
+              )}
+              {records.length > 0 && avgErrorRate !== null && (
                 <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
               )}
               {avgErrorRate !== null && (
@@ -152,6 +159,24 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                     {Math.round(avgErrorRate * 100)}%
                   </Text>
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
+                </View>
+              )}
+              {streak.currentStreak > 0 && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {streak.currentStreak > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: '#F59E0B' }]}>🔥 {streak.currentStreak}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentCurrentStreak}</Text>
+                </View>
+              )}
+              {streak.longestStreak > 0 && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {streak.longestStreak > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: colors.text }]}>{streak.longestStreak}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentLongestStreak}</Text>
                 </View>
               )}
             </View>

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -196,7 +196,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentLongestStreak: 'Longest Streak',
     parentStreakDays: 'Days',
     streakWarningTitle: 'Don\'t break your streak!',
-    streakWarningMessage: 'Play a quick round today to keep your streak going!',
+    streakWarningMessage: 'Play a quick round today to keep your {days}-day streak going!',
     streakWarningButton: 'Let\'s go!',
   },
   de: {
@@ -292,7 +292,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentLongestStreak: 'Längster Streak',
     parentStreakDays: 'Tage',
     streakWarningTitle: 'Brich deinen Streak nicht!',
-    streakWarningMessage: 'Spiel heute eine Runde, um deinen Streak zu halten!',
+    streakWarningMessage: 'Spiel heute eine Runde, um deinen {days}-Tage-Streak zu halten!',
     streakWarningButton: 'Los geht\'s!',
   },
 };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -94,6 +94,12 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  parentCurrentStreak: string;
+  parentLongestStreak: string;
+  parentStreakDays: string;
+  streakWarningTitle: string;
+  streakWarningMessage: string;
+  streakWarningButton: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -186,6 +192,12 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    parentCurrentStreak: 'Current Streak',
+    parentLongestStreak: 'Longest Streak',
+    parentStreakDays: 'Days',
+    streakWarningTitle: 'Don\'t break your streak!',
+    streakWarningMessage: 'Play a quick round today to keep your streak going!',
+    streakWarningButton: 'Let\'s go!',
   },
   de: {
     // Settings Menu
@@ -276,5 +288,11 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    parentCurrentStreak: 'Aktueller Streak',
+    parentLongestStreak: 'Längster Streak',
+    parentStreakDays: 'Tage',
+    streakWarningTitle: 'Brich deinen Streak nicht!',
+    streakWarningMessage: 'Spiel heute eine Runde, um deinen Streak zu halten!',
+    streakWarningButton: 'Los geht\'s!',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -79,6 +79,12 @@ export interface SessionRecord {
   numberRange: NumberRange;
 }
 
+export interface StreakData {
+  currentStreak: number;
+  lastPlayedDate: string; // YYYY-MM-DD (local date)
+  longestStreak: number;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  STREAK: 'app-streak',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,8 +23,12 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getStreakData,
+  saveStreakData,
+  updateStreakAfterSession,
+  getLocalDateString,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord, StreakData } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -535,5 +539,160 @@ describe('Session Records Storage', () => {
     const [retrieved] = await getSessionRecords();
     expect(retrieved.errorRate).toBe(0.3);
     expect(retrieved.errors).toBe(3);
+  });
+});
+
+describe('getLocalDateString()', () => {
+  it('should return YYYY-MM-DD format for today', () => {
+    const result = getLocalDateString();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('should return YYYY-MM-DD for a given date', () => {
+    const d = new Date(2024, 0, 5); // Jan 5, 2024
+    expect(getLocalDateString(d)).toBe('2024-01-05');
+  });
+
+  it('should pad month and day with leading zeros', () => {
+    const d = new Date(2024, 2, 9); // Mar 9, 2024
+    expect(getLocalDateString(d)).toBe('2024-03-09');
+  });
+});
+
+describe('Streak Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return default streak when nothing is stored', async () => {
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('should save and retrieve streak data', async () => {
+    const data: StreakData = { currentStreak: 5, lastPlayedDate: '2024-01-10', longestStreak: 7 };
+    await saveStreakData(data);
+    const result = await getStreakData();
+    expect(result).toEqual(data);
+  });
+
+  it('should return default for corrupted streak data', async () => {
+    mockStore['app-streak'] = '{invalid json}';
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('should return default for streak data with wrong types', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 'five', lastPlayedDate: 123, longestStreak: null });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+});
+
+describe('updateStreakAfterSession()', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('should start streak at 1 for first session', async () => {
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.lastPlayedDate).toBe(getLocalDateString());
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it('should not change streak when already played today', async () => {
+    const today = getLocalDateString();
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 3, lastPlayedDate: today, longestStreak: 5 });
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('should increment streak for consecutive day', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15); // Jun 15
+    jest.setSystemTime(today);
+
+    const yesterday = new Date(2024, 5, 14);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 4,
+      lastPlayedDate: getLocalDateString(yesterday),
+      longestStreak: 4,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(5);
+    expect(result.longestStreak).toBe(5);
+    expect(result.lastPlayedDate).toBe('2024-06-15');
+  });
+
+  it('should reset streak to 1 after a gap', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const twoDaysAgo = new Date(2024, 5, 13);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 10,
+      lastPlayedDate: getLocalDateString(twoDaysAgo),
+      longestStreak: 10,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(10); // longestStreak preserved
+    expect(result.lastPlayedDate).toBe('2024-06-15');
+  });
+
+  it('should update longestStreak when new streak exceeds it', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const yesterday = new Date(2024, 5, 14);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 7,
+      lastPlayedDate: getLocalDateString(yesterday),
+      longestStreak: 7,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(8);
+    expect(result.longestStreak).toBe(8);
+  });
+
+  it('should not decrease longestStreak after reset', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const threeDaysAgo = new Date(2024, 5, 12);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 3,
+      lastPlayedDate: getLocalDateString(threeDaysAgo),
+      longestStreak: 15,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(15);
   });
 });

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -595,6 +595,30 @@ describe('Streak Storage', () => {
     const result = await getStreakData();
     expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
   });
+
+  it('should return default for NaN streak values', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: NaN, lastPlayedDate: '2024-01-10', longestStreak: 5 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('should return default for negative streak values', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: -1, lastPlayedDate: '2024-01-10', longestStreak: 5 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('should return default for invalid date format', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 3, lastPlayedDate: '2024/01/10', longestStreak: 3 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('should return default for Infinity streak', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: Infinity, lastPlayedDate: '2024-01-10', longestStreak: 5 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
 });
 
 describe('updateStreakAfterSession()', () => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, StreakData } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -196,6 +196,62 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   const records = await getSessionRecords();
   records.push(record);
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
+};
+
+// Streak storage helpers
+
+export function getLocalDateString(date?: Date): string {
+  const d = date ?? new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export const getStreakData = async (): Promise<StreakData> => {
+  const value = await getStorageItem(STORAGE_KEYS.STREAK);
+  if (!value) return { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      typeof parsed.currentStreak === 'number' &&
+      typeof parsed.lastPlayedDate === 'string' &&
+      typeof parsed.longestStreak === 'number'
+    ) {
+      return parsed as StreakData;
+    }
+  } catch {
+    // fall through
+  }
+  return { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+};
+
+export const saveStreakData = async (data: StreakData): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.STREAK, JSON.stringify(data));
+};
+
+export const updateStreakAfterSession = async (): Promise<StreakData> => {
+  const today = getLocalDateString();
+  const data = await getStreakData();
+
+  if (data.lastPlayedDate === today) {
+    return data;
+  }
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = getLocalDateString(yesterday);
+
+  const newStreak = data.lastPlayedDate === yesterdayStr ? data.currentStreak + 1 : 1;
+
+  const updated: StreakData = {
+    currentStreak: newStreak,
+    lastPlayedDate: today,
+    longestStreak: Math.max(newStreak, data.longestStreak),
+  };
+
+  await saveStreakData(updated);
+  return updated;
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -208,22 +208,32 @@ export function getLocalDateString(date?: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+const STREAK_DEFAULT: StreakData = { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+
+function isNonNegInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && Number.isInteger(v);
+}
+
+function isLocalDateString(v: unknown): v is string {
+  return typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v);
+}
+
 export const getStreakData = async (): Promise<StreakData> => {
   const value = await getStorageItem(STORAGE_KEYS.STREAK);
-  if (!value) return { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+  if (!value) return STREAK_DEFAULT;
   try {
     const parsed = JSON.parse(value);
     if (
-      typeof parsed.currentStreak === 'number' &&
-      typeof parsed.lastPlayedDate === 'string' &&
-      typeof parsed.longestStreak === 'number'
+      isNonNegInt(parsed.currentStreak) &&
+      isLocalDateString(parsed.lastPlayedDate) &&
+      isNonNegInt(parsed.longestStreak)
     ) {
       return parsed as StreakData;
     }
   } catch {
     // fall through
   }
-  return { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+  return STREAK_DEFAULT;
 };
 
 export const saveStreakData = async (data: StreakData): Promise<void> => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Streak-Datenmodell** (`StreakData`): `currentStreak`, `lastPlayedDate` (YYYY-MM-DD lokal), `longestStreak` — gespeichert unter Storage-Key `app-streak`
- **Streak-Logik** in `utils/storage.ts`: DST-sicherer Datumsvergleich via `getLocalDateString()`, Inkrement/Reset nach Session, `longestStreak` wird mitgeführt
- **Header-Badge**: 🔥 {n} erscheint neben dem Score-Badge wenn `currentStreak > 0`
- **Abend-Warnung**: Modal bei App-Öffnung wenn ≥ 20 Uhr, Streak aktiv und heute noch nicht gespielt
- **ParentDashboard**: Aktueller + längster Streak im Summary-Bar
- **16 neue Tests** (alle Streak-Randfälle: erster Streak, gleicher Tag, Folgetag, Lücke, longestStreak-Updates)

## Test plan

- [ ] Tests grün: `npm test` → 13/13 Suites, 428 passed
- [ ] Nach einer Session steigt `currentStreak` um 1 (oder wird auf 1 gesetzt)
- [ ] Zweite Session am selben Tag ändert nichts am Streak
- [ ] Nach einer Pause (>1 Tag) wird Streak auf 1 zurückgesetzt, `longestStreak` bleibt
- [ ] 🔥-Badge im Header sichtbar wenn Streak > 0
- [ ] Streak überlebt App-Neustart (AsyncStorage/localStorage)
- [ ] Abend-Warnung erscheint nach 20 Uhr bei aktivem Streak ohne heutige Session
- [ ] ParentDashboard zeigt aktuellen und längsten Streak

Closes #185

https://claude.ai/code/session_011TNyMYxfpcjKsHcMKNBK1Z
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011TNyMYxfpcjKsHcMKNBK1Z)_