### PR TITLE
testing → staging: Übungsmodus, Badges, Onboarding, Streak-Tracker, CI-Tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,30 @@ jobs:
         run: npx tsc --noEmit || true
 
   # ============================================================================
-  # JOB 2: Cross-Platform Build Tests
+  # JOB 2: Jest Tests
+  # ============================================================================
+  test:
+    name: 🧪 Jest Tests
+    runs-on: ubuntu-latest
+    needs: code-quality
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --no-coverage --ci
+
+  # ============================================================================
+  # JOB 3: Cross-Platform Build Tests
   # ============================================================================
   build-web:
     name: 🌐 Build Web
@@ -342,7 +365,7 @@ jobs:
   release-checklist:
     name: 📋 Release Readiness Report
     runs-on: ubuntu-latest
-    needs: [code-quality, build-web, platform-checks, security, docs-privacy, keystore-secrets]
+    needs: [code-quality, test, build-web, platform-checks, security, docs-privacy, keystore-secrets]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -137,7 +137,7 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
             git commit -m "🧹 Auto-cleanup: Remove sensitive files from gh-pages" || true
-            git push origin gh-pages
+            git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" gh-pages
             echo "✅ Cleanup completed and pushed"
           else
             echo "✅ No cleanup needed - gh-pages is already clean"

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import {
   StyleSheet,
   SafeAreaView,
@@ -67,6 +67,7 @@ export default function App() {
   const [streakWarningVisible, setStreakWarningVisible] = useState(false);
   const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
+  const weakTaskCount = useMemo(() => getWeakTasks(taskStats, 3, 0.3).length, [taskStats]);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
@@ -313,7 +314,7 @@ export default function App() {
           difficultyMode={game.gameState.difficultyMode}
           selectedOperations={game.gameState.selectedOperations}
           numberRange={preferences.numberRange}
-          weakTaskCount={getWeakTasks(taskStats, 3, 0.3).length}
+          weakTaskCount={weakTaskCount}
           onToggleOperation={game.toggleOperation}
           onChangeDifficultyMode={game.changeDifficultyMode}
           onSetNumberRange={preferences.setNumberRange}

--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,10 @@ import {
   SafeAreaView,
   useWindowDimensions,
   Animated,
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
 } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { useFonts } from 'expo-font';
@@ -37,8 +41,8 @@ import { OnboardingModal } from './components/OnboardingModal';
 import { BadgesModal } from './components/BadgesModal';
 import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks, getOnboardingDone, setOnboardingDone, resetOnboarding, getStorageItem } from './utils/storage';
-import { SessionRecord, TaskStat, Operation } from './types/game';
+import { saveSessionRecord, getStreakData, updateStreakAfterSession, getLocalDateString, recordTaskResult, getTaskStats, getWeakTasks, getOnboardingDone, setOnboardingDone, resetOnboarding, getStorageItem } from './utils/storage';
+import { SessionRecord, StreakData, TaskStat, Operation } from './types/game';
 import { useBadges } from './hooks/useBadges';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
@@ -59,6 +63,8 @@ export default function App() {
   const [badgesVisible, setBadgesVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [streakData, setStreakData] = useState<StreakData>({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  const [streakWarningVisible, setStreakWarningVisible] = useState(false);
   const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
 
@@ -92,7 +98,11 @@ export default function App() {
     },
     onSessionComplete: (record: SessionRecord) => {
       saveSessionRecord(record)
-        .then(() => badgeSystem.checkAndUnlock(record))
+        .then(async () => {
+          const updatedStreak = await updateStreakAfterSession();
+          setStreakData(updatedStreak);
+          await badgeSystem.checkAndUnlock(record);
+        })
         .catch((err) => console.error('Session save / badge unlock failed:', err));
     },
     taskStats,
@@ -191,6 +201,20 @@ export default function App() {
     }
   }, [isDarkMode]);
 
+  // Load streak data and show warning when appropriate
+  useEffect(() => {
+    getStreakData().then((data) => {
+      setStreakData(data);
+      const now = new Date();
+      const isEvening = now.getHours() >= 20;
+      const hasStreakToProtect = data.currentStreak > 0;
+      const hasNotPlayedToday = data.lastPlayedDate !== getLocalDateString();
+      if (isEvening && hasStreakToProtect && hasNotPlayedToday) {
+        setStreakWarningVisible(true);
+      }
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Card feedback animation (skipped when reduce motion is enabled)
   useEffect(() => {
     if (!game.gameState.isAnswerChecked || prefersReducedMotion()) return;
@@ -276,6 +300,7 @@ export default function App() {
         score={game.gameState.score}
         currentTask={game.gameState.currentTask}
         totalTasks={game.gameState.totalTasks}
+        currentStreak={streakData.currentStreak}
         onShowMenu={showMenu}
         t={t}
       />
@@ -370,6 +395,24 @@ export default function App() {
         t={t}
       />
 
+      <Modal visible={streakWarningVisible} transparent animationType="fade" onRequestClose={() => setStreakWarningVisible(false)}>
+        <View style={styles.streakOverlay}>
+          <View style={[styles.streakWarningCard, { backgroundColor: colors.settingsMenu }]}>
+            <Text style={styles.streakWarningEmoji}>🔥</Text>
+            <Text style={[styles.streakWarningTitle, { color: colors.text }]}>{t.streakWarningTitle}</Text>
+            <Text style={[styles.streakWarningMessage, { color: colors.textSecondary }]}>
+              {t.streakWarningMessage.replace('{days}', String(streakData.currentStreak))}
+            </Text>
+            <TouchableOpacity
+              style={styles.streakWarningButton}
+              onPress={() => setStreakWarningVisible(false)}
+            >
+              <Text style={styles.streakWarningButtonText}>{t.streakWarningButton}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
       <OnboardingModal
         visible={onboardingVisible}
         onFinish={async () => {
@@ -401,5 +444,50 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  streakOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  streakWarningCard: {
+    borderRadius: 24,
+    padding: 28,
+    width: '80%',
+    maxWidth: 340,
+    alignItems: 'center',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  streakWarningEmoji: {
+    fontSize: 48,
+    marginBottom: 12,
+  },
+  streakWarningTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  streakWarningMessage: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  streakWarningButton: {
+    backgroundColor: '#F59E0B',
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  streakWarningButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: 'bold',
   },
 });

--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import {
 
 // Local imports
 import { translations } from './i18n/translations';
+import { STORAGE_KEYS } from './utils/constants';
 import { useTheme } from './hooks/useTheme';
 import { usePreferences } from './hooks/usePreferences';
 import { useGameLogic } from './hooks/useGameLogic';
@@ -32,10 +33,11 @@ import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
+import { OnboardingModal } from './components/OnboardingModal';
 import { BadgesModal } from './components/BadgesModal';
 import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks } from './utils/storage';
+import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks, getOnboardingDone, setOnboardingDone, resetOnboarding, getStorageItem } from './utils/storage';
 import { SessionRecord, TaskStat, Operation } from './types/game';
 import { useBadges } from './hooks/useBadges';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
@@ -57,6 +59,7 @@ export default function App() {
   const [badgesVisible, setBadgesVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
 
   // Reduced motion preference — centralized in utils/animations.ts
@@ -217,6 +220,29 @@ export default function App() {
     }
   }, [game.gameState.isAnswerChecked, game.gameState.lastAnswerCorrect]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Show onboarding for new users; silently skip for existing users (migration)
+  useEffect(() => {
+    if (!preferences.isLoaded) return;
+    (async () => {
+      const shown = await getOnboardingDone();
+      if (shown) return;
+      const rawValue = await getStorageItem(STORAGE_KEYS.ONBOARDING_DONE);
+      if (rawValue === 'pending') {
+        // Explicit reset → always show onboarding
+        setOnboardingVisible(true);
+        return;
+      }
+      // rawValue is null → first launch: migrate existing users silently
+      const existingLanguage = await getStorageItem(STORAGE_KEYS.LANGUAGE);
+      if (existingLanguage) {
+        await setOnboardingDone();
+      } else {
+        setOnboardingVisible(true);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preferences.isLoaded]);
+
   // Generate first question on mount
   useEffect(() => {
     if (preferences.isLoaded) {
@@ -276,6 +302,10 @@ export default function App() {
             hideMenu();
           }}
           onOpenParentDashboard={() => setParentDashboardVisible(true)}
+          onResetOnboarding={async () => {
+            await resetOnboarding();
+            setOnboardingVisible(true);
+          }}
           onOpenBadges={() => setBadgesVisible(true)}
           t={t}
         />
@@ -336,6 +366,16 @@ export default function App() {
       <ParentDashboard
         visible={parentDashboardVisible}
         onClose={() => setParentDashboardVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <OnboardingModal
+        visible={onboardingVisible}
+        onFinish={async () => {
+          await setOnboardingDone();
+          setOnboardingVisible(false);
+        }}
         colors={colors}
         t={t}
       />

--- a/App.tsx
+++ b/App.tsx
@@ -33,8 +33,8 @@ import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
 import { FloatingStars } from './components/FloatingStars';
-import { saveSessionRecord } from './utils/storage';
-import { SessionRecord } from './types/game';
+import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks } from './utils/storage';
+import { SessionRecord, TaskStat, Operation } from './types/game';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -53,10 +53,15 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
+  const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
 
   // Reduced motion preference — centralized in utils/animations.ts
   useEffect(() => {
     return initReducedMotionListener();
+  }, []);
+
+  useEffect(() => {
+    getTaskStats().then(setTaskStats);
   }, []);
 
   // Animation values
@@ -79,6 +84,28 @@ export default function App() {
     },
     onSessionComplete: (record: SessionRecord) => {
       saveSessionRecord(record);
+    },
+    taskStats,
+    onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
+      setTaskStats(prev => {
+        const idx = prev.findIndex(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
+        if (idx >= 0) {
+          const updated = { ...prev[idx] };
+          if (isCorrect) updated.correctCount++;
+          else updated.errorCount++;
+          updated.lastSeen = new Date().toISOString();
+          const next = [...prev];
+          next[idx] = updated;
+          return next;
+        }
+        return [...prev, {
+          num1, num2, operation,
+          correctCount: isCorrect ? 1 : 0,
+          errorCount: isCorrect ? 0 : 1,
+          lastSeen: new Date().toISOString(),
+        }];
+      });
+      recordTaskResult(num1, num2, operation, isCorrect);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -228,6 +255,7 @@ export default function App() {
           difficultyMode={game.gameState.difficultyMode}
           selectedOperations={game.gameState.selectedOperations}
           numberRange={preferences.numberRange}
+          weakTaskCount={getWeakTasks(taskStats, 3, 0.3).length}
           onToggleOperation={game.toggleOperation}
           onChangeDifficultyMode={game.changeDifficultyMode}
           onSetNumberRange={preferences.setNumberRange}

--- a/App.tsx
+++ b/App.tsx
@@ -32,9 +32,12 @@ import { ResultModal } from './components/ResultModal';
 import { MotivationModal } from './components/MotivationModal';
 import { AboutModal } from './components/AboutModal';
 import { ParentDashboard } from './components/ParentDashboard';
+import { BadgesModal } from './components/BadgesModal';
+import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
 import { saveSessionRecord, recordTaskResult, getTaskStats, getWeakTasks } from './utils/storage';
 import { SessionRecord, TaskStat, Operation } from './types/game';
+import { useBadges } from './hooks/useBadges';
 import { ANIMATION_DURATIONS, initReducedMotionListener, prefersReducedMotion } from './utils/animations';
 
 export default function App() {
@@ -51,6 +54,7 @@ export default function App() {
   const [aboutVisible, setAboutVisible] = useState(false);
   const [personalizeVisible, setPersonalizeVisible] = useState(false);
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
+  const [badgesVisible, setBadgesVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
@@ -73,6 +77,7 @@ export default function App() {
   // Use custom hooks
   const preferences = usePreferences();
   const theme = useTheme(preferences.themeMode);
+  const badgeSystem = useBadges();
   const game = useGameLogic({
     initialOperation: preferences.operation,
     initialOperations: preferences.operations,
@@ -83,7 +88,9 @@ export default function App() {
       setShowMotivation(true);
     },
     onSessionComplete: (record: SessionRecord) => {
-      saveSessionRecord(record);
+      saveSessionRecord(record)
+        .then(() => badgeSystem.checkAndUnlock(record))
+        .catch((err) => console.error('Session save / badge unlock failed:', err));
     },
     taskStats,
     onTaskResult: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => {
@@ -269,6 +276,7 @@ export default function App() {
             hideMenu();
           }}
           onOpenParentDashboard={() => setParentDashboardVisible(true)}
+          onOpenBadges={() => setBadgesVisible(true)}
           t={t}
         />
       )}
@@ -330,6 +338,21 @@ export default function App() {
         onClose={() => setParentDashboardVisible(false)}
         colors={colors}
         t={t}
+      />
+
+      <BadgesModal
+        visible={badgesVisible}
+        onClose={() => setBadgesVisible(false)}
+        colors={colors}
+        badges={badgeSystem.badges}
+        language={preferences.language}
+        t={t}
+      />
+
+      <BadgeUnlockToast
+        badgeIds={badgeSystem.newlyUnlocked}
+        onDone={badgeSystem.clearNewlyUnlocked}
+        badgeNewUnlockedLabel={t.badgeNewUnlocked}
       />
     </SafeAreaView>
   );

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,23 +78,23 @@ npm run test:coverage # Coverage
 
 ---
 
-## Aktueller Stand (2026-05-10)
+## Aktueller Stand (2026-05-21)
 
-- Version: **1.3.4** / versionCode 24
-- Tests: 415 passed, 3 skipped, 13/13 Suites grün
-- Branches: `staging` und `main` synchron; `testing` auf Stand von staging
+- Version: **1.3.5** / versionCode 24
+- Tests: 427 passed, 3 skipped, 13/13 Suites grün
+- Branches: `testing` vorn (`851f4fd`); `staging` und `main` noch auf `1b551ea`
 - Offene Issues: #165, #160, #156, #146, #131, #100, #96
 - Security: 21 Vulnerabilities (alle über Expo-Tooling, build-time) → Issue #146
 
-### Zuletzt gemergt (staging)
+### Zuletzt gemergt (testing)
 
-| PR | Was |
-|----|-----|
+| PR  | Was |
+|-----|-----|
+| #192 | Adaptives Lernen – Übungsmodus (PRACTICE) mit Schwachstellen-Fokus (Issue #188) |
+| #183 | CI/CD ci-cd.yml-Startup-Failure beheben (Issue #152-Regression) |
 | #177 | TypeScript-Fixes + isValidSessionRecord Enum-Validierung + Challenge-Ops Fix |
 | #175 | Eltern-Dashboard Beta-Badge + 28-Tage Fix + Copilot-Review-Fixes |
 | #174 | Eltern-Dashboard (SessionRecord, ParentDashboard-Modal, Storage, i18n) |
-| #173 | CLAUDE.md erstellt |
-| #171 | Dark-Mode Chip-Kontrast + Settings-Font |
 
 ---
 
@@ -104,7 +104,7 @@ npm run test:coverage # Coverage
 |-------|--------|
 | `utils/constants.ts` | THEME_COLORS, DESIGN_TOKENS, STORAGE_KEYS, CHALLENGE_LEVELS |
 | `utils/theme.ts` | `getThemeColors(isDarkMode)` |
-| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `FOUR_WEEKS_MS` |
+| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `recordTaskResult` / `getTaskStats`, `FOUR_WEEKS_MS` |
 | `utils/animations.ts` | `prefersReducedMotion()` — liest Accessibility-Einstellung |
 | `types/game.ts` | ThemeColors, GameState, Enums, SessionRecord |
 | `i18n/translations.ts` | DE/EN Übersetzungen, `TranslationStrings`-Interface |
@@ -140,6 +140,16 @@ npm run test:coverage # Coverage
 - `getSessionRecords()` bereinigt automatisch Einträge älter als 28 Tage und schreibt zurück
 - `FOUR_WEEKS_MS` ist in `utils/storage.ts` exportiert — nicht duplizieren
 - `isValidSessionRecord` validiert alle Felder gegen Enum-Werte
+
+## Adaptives Lernen / Übungsmodus (PRACTICE) — Hinweise
+
+- `TaskStat` (`types/game.ts`): pro konkreter Aufgabe (num1/num2/operation) correctCount + errorCount
+- Storage Key: `app-task-stats` (separater Key, unabhängig von Session-Records)
+- `recordTaskResult()` in `utils/storage.ts`: schreibt mit Promise-Queue (Race-Condition-sicher)
+- In App.tsx wird `taskStats` State in-memory optimistisch aktualisiert und gleichzeitig im Background persistiert
+- `DifficultyMode.PRACTICE`: 75% Chance schwache Aufgabe (Fehlerrate >30%, ≥3 Versuche), 25% zufällig; Aufgaben werden nach `effectiveMaxNumber` gefiltert (range-sicher)
+- `getWeakTasks()` in `utils/storage.ts`: filtert + sortiert nach Fehlerrate absteigend
+- ParentDashboard zeigt Top-5-Schwachstellen — unabhängig von vorhandenen Session-Records
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@ npm run test:coverage # Coverage
 ## Aktueller Stand (2026-05-23)
 
 - Version: **1.3.5** / versionCode 24
-- Tests: 454 passed, 3 skipped, 14/14 Suites grün
-- Branches: `testing` vorn (`d689c7c`); `staging` und `main` noch auf `1b551ea`
+- Tests: 475 passed, 3 skipped, 14/14 Suites grün
+- Branches: `testing` vorn (`3d52f56`); `staging` und `main` noch auf `1b551ea`
 - Offene Issues: #165, #160, #156, #146, #131, #100, #96
 - Security: 21 Vulnerabilities (alle über Expo-Tooling, build-time) → Issue #146
 
@@ -90,6 +90,7 @@ npm run test:coverage # Coverage
 
 | PR  | Was |
 |-----|-----|
+| #200 | Täglicher Streak-Tracker (Issue #185) — StreakData, 🔥 Header-Badge, Abend-Warnung, ParentDashboard |
 | #196 | fix: practiceModeFeedback im Übungsmodus in GameCard anzeigen + Tests |
 | #195 | CI: Jest-Test-Job zu ci-cd.yml hinzufügen (läuft jetzt automatisch bei PRs) |
 | #184 | Achievement & Badge System |
@@ -105,7 +106,7 @@ npm run test:coverage # Coverage
 |-------|--------|
 | `utils/constants.ts` | THEME_COLORS, DESIGN_TOKENS, STORAGE_KEYS, CHALLENGE_LEVELS |
 | `utils/theme.ts` | `getThemeColors(isDarkMode)` |
-| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `updateTaskStat` / `getTaskStats` / `getWeakTasks`, `FOUR_WEEKS_MS` |
+| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `updateTaskStat` / `getTaskStats` / `getWeakTasks`, `updateStreakAfterSession` / `getStreakData` / `saveStreakData`, `FOUR_WEEKS_MS` |
 | `utils/animations.ts` | `prefersReducedMotion()` — liest Accessibility-Einstellung |
 | `types/game.ts` | ThemeColors, GameState, Enums, SessionRecord |
 | `i18n/translations.ts` | DE/EN Übersetzungen, `TranslationStrings`-Interface |
@@ -141,6 +142,18 @@ npm run test:coverage # Coverage
 - `getSessionRecords()` bereinigt automatisch Einträge älter als 28 Tage und schreibt zurück
 - `FOUR_WEEKS_MS` ist in `utils/storage.ts` exportiert — nicht duplizieren
 - `isValidSessionRecord` validiert alle Felder gegen Enum-Werte
+
+## Streak-Tracker — Hinweise
+
+- `StreakData` (`types/game.ts`): `currentStreak`, `lastPlayedDate` (YYYY-MM-DD lokal), `longestStreak`
+- Storage Key: `app-streak`
+- `updateStreakAfterSession()` in `utils/storage.ts`: DST-sicherer Vergleich via `getLocalDateString()` — kein UTC-Offset-Problem
+- Streak-Logik: gleicher Tag → kein Update; Folgetag → +1; Lücke → Reset auf 1 (longestStreak bleibt)
+- `isNonNegInt` / `isLocalDateString`: Validatoren in storage.ts verhindern korrupte Werte (NaN, negativ, falsches Format)
+- Header zeigt 🔥 {n} Badge wenn `currentStreak > 0` (via `currentStreak`-Prop in Header.tsx)
+- Abend-Warnung: Modal bei App-Öffnung wenn `hour >= 20` + Streak aktiv + heute noch nicht gespielt
+- ParentDashboard: currentStreak + longestStreak im Summary-Bar (inkl. korrekter Divider-Logik)
+- `streakWarningMessage` enthält `{days}` Platzhalter → wird via `.replace('{days}', ...)` in App.tsx ersetzt
 
 ## Adaptives Lernen / Übungsmodus (PRACTICE) — Hinweise
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,11 @@ npm run test:coverage # Coverage
 
 ---
 
-## Aktueller Stand (2026-05-21)
+## Aktueller Stand (2026-05-23)
 
 - Version: **1.3.5** / versionCode 24
-- Tests: 427 passed, 3 skipped, 13/13 Suites grün
-- Branches: `testing` vorn (`851f4fd`); `staging` und `main` noch auf `1b551ea`
+- Tests: 451 passed, 3 skipped, 14/14 Suites grün
+- Branches: `testing` vorn (`3435d57`); `staging` und `main` noch auf `1b551ea`
 - Offene Issues: #165, #160, #156, #146, #131, #100, #96
 - Security: 21 Vulnerabilities (alle über Expo-Tooling, build-time) → Issue #146
 
@@ -90,11 +90,11 @@ npm run test:coverage # Coverage
 
 | PR  | Was |
 |-----|-----|
+| #195 | CI: Jest-Test-Job zu ci-cd.yml hinzufügen (läuft jetzt automatisch bei PRs) |
+| #184 | Achievement & Badge System |
 | #192 | Adaptives Lernen – Übungsmodus (PRACTICE) mit Schwachstellen-Fokus (Issue #188) |
 | #183 | CI/CD ci-cd.yml-Startup-Failure beheben (Issue #152-Regression) |
 | #177 | TypeScript-Fixes + isValidSessionRecord Enum-Validierung + Challenge-Ops Fix |
-| #175 | Eltern-Dashboard Beta-Badge + 28-Tage Fix + Copilot-Review-Fixes |
-| #174 | Eltern-Dashboard (SessionRecord, ParentDashboard-Modal, Storage, i18n) |
 
 ---
 
@@ -104,7 +104,7 @@ npm run test:coverage # Coverage
 |-------|--------|
 | `utils/constants.ts` | THEME_COLORS, DESIGN_TOKENS, STORAGE_KEYS, CHALLENGE_LEVELS |
 | `utils/theme.ts` | `getThemeColors(isDarkMode)` |
-| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `recordTaskResult` / `getTaskStats`, `FOUR_WEEKS_MS` |
+| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `updateTaskStat` / `getTaskStats` / `getWeakTasks`, `FOUR_WEEKS_MS` |
 | `utils/animations.ts` | `prefersReducedMotion()` — liest Accessibility-Einstellung |
 | `types/game.ts` | ThemeColors, GameState, Enums, SessionRecord |
 | `i18n/translations.ts` | DE/EN Übersetzungen, `TranslationStrings`-Interface |
@@ -143,13 +143,14 @@ npm run test:coverage # Coverage
 
 ## Adaptives Lernen / Übungsmodus (PRACTICE) — Hinweise
 
-- `TaskStat` (`types/game.ts`): pro konkreter Aufgabe (num1/num2/operation) correctCount + errorCount
+- `TaskStat` (`types/game.ts`): pro konkreter Aufgabe (num1/num2/operation) correctCount + errorCount + lastSeen
 - Storage Key: `app-task-stats` (separater Key, unabhängig von Session-Records)
-- `recordTaskResult()` in `utils/storage.ts`: schreibt mit Promise-Queue (Race-Condition-sicher)
-- In App.tsx wird `taskStats` State in-memory optimistisch aktualisiert und gleichzeitig im Background persistiert
+- `updateTaskStat()` in `utils/storage.ts`: Race-Condition-sicher via Promise-Queue
+- In App.tsx wird `taskStats` als Ref gehalten und per `useEffect` aktualisiert
 - `DifficultyMode.PRACTICE`: 75% Chance schwache Aufgabe (Fehlerrate >30%, ≥3 Versuche), 25% zufällig; Aufgaben werden nach `effectiveMaxNumber` gefiltert (range-sicher)
-- `getWeakTasks()` in `utils/storage.ts`: filtert + sortiert nach Fehlerrate absteigend
+- `getWeakTasks(stats)` in `utils/storage.ts`: reine Funktion, filtert + sortiert nach Fehlerrate absteigend
 - ParentDashboard zeigt Top-5-Schwachstellen — unabhängig von vorhandenen Session-Records
+- CI: `npm test --ci` läuft jetzt automatisch bei jedem PR (`.github/workflows/ci-cd.yml`, Job `test`)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ npm run test:coverage # Coverage
 |-------|--------|
 | `utils/constants.ts` | THEME_COLORS, DESIGN_TOKENS, STORAGE_KEYS, CHALLENGE_LEVELS |
 | `utils/theme.ts` | `getThemeColors(isDarkMode)` |
-| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `updateTaskStat` / `getTaskStats` / `getWeakTasks`, `updateStreakAfterSession` / `getStreakData` / `saveStreakData`, `FOUR_WEEKS_MS` |
+| `utils/storage.ts` | Storage-Helfer, `saveSessionRecord` / `getSessionRecords`, `recordTaskResult` / `getTaskStats` / `getWeakTasks`, `updateStreakAfterSession` / `getStreakData` / `saveStreakData`, `FOUR_WEEKS_MS` |
 | `utils/animations.ts` | `prefersReducedMotion()` — liest Accessibility-Einstellung |
 | `types/game.ts` | ThemeColors, GameState, Enums, SessionRecord |
 | `i18n/translations.ts` | DE/EN Übersetzungen, `TranslationStrings`-Interface |
@@ -159,7 +159,7 @@ npm run test:coverage # Coverage
 
 - `TaskStat` (`types/game.ts`): pro konkreter Aufgabe (num1/num2/operation) correctCount + errorCount + lastSeen
 - Storage Key: `app-task-stats` (separater Key, unabhängig von Session-Records)
-- `updateTaskStat()` in `utils/storage.ts`: Race-Condition-sicher via Promise-Queue
+- `recordTaskResult()` in `utils/storage.ts`: Race-Condition-sicher via Promise-Queue
 - In App.tsx wird `taskStats` als Ref gehalten und per `useEffect` aktualisiert
 - `DifficultyMode.PRACTICE`: 75% Chance schwache Aufgabe (Fehlerrate >30%, ≥3 Versuche), 25% zufällig; Aufgaben werden nach `effectiveMaxNumber` gefiltert (range-sicher)
 - `getWeakTasks(stats)` in `utils/storage.ts`: reine Funktion, filtert + sortiert nach Fehlerrate absteigend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@ npm run test:coverage # Coverage
 ## Aktueller Stand (2026-05-23)
 
 - Version: **1.3.5** / versionCode 24
-- Tests: 451 passed, 3 skipped, 14/14 Suites grün
-- Branches: `testing` vorn (`3435d57`); `staging` und `main` noch auf `1b551ea`
+- Tests: 454 passed, 3 skipped, 14/14 Suites grün
+- Branches: `testing` vorn (`d689c7c`); `staging` und `main` noch auf `1b551ea`
 - Offene Issues: #165, #160, #156, #146, #131, #100, #96
 - Security: 21 Vulnerabilities (alle über Expo-Tooling, build-time) → Issue #146
 
@@ -90,6 +90,7 @@ npm run test:coverage # Coverage
 
 | PR  | Was |
 |-----|-----|
+| #196 | fix: practiceModeFeedback im Übungsmodus in GameCard anzeigen + Tests |
 | #195 | CI: Jest-Test-Job zu ci-cd.yml hinzufügen (läuft jetzt automatisch bei PRs) |
 | #184 | Achievement & Badge System |
 | #192 | Adaptives Lernen – Übungsmodus (PRACTICE) mit Schwachstellen-Fokus (Issue #188) |

--- a/components/BadgeUnlockToast.tsx
+++ b/components/BadgeUnlockToast.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import { BADGE_DEFINITIONS, DESIGN_TOKENS } from '../utils/constants';
+import { ANIMATION_DURATIONS, prefersReducedMotion } from '../utils/animations';
+
+interface BadgeUnlockToastProps {
+  badgeIds: string[];
+  onDone: () => void;
+  badgeNewUnlockedLabel: string;
+}
+
+const DISPLAY_DURATION = 2400;
+
+export function BadgeUnlockToast({ badgeIds, onDone, badgeNewUnlockedLabel }: BadgeUnlockToastProps) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(40)).current;
+
+  useEffect(() => {
+    if (badgeIds.length === 0) return;
+
+    // Always reset to initial hidden state so repeated toasts animate correctly
+    opacity.setValue(0);
+    translateY.setValue(40);
+
+    const reduced = prefersReducedMotion();
+
+    if (reduced) {
+      opacity.setValue(1);
+      translateY.setValue(0);
+      const t = setTimeout(onDone, DISPLAY_DURATION);
+      return () => clearTimeout(t);
+    }
+
+    Animated.parallel([
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: ANIMATION_DURATIONS.NORMAL,
+        useNativeDriver: true,
+      }),
+      Animated.spring(translateY, {
+        toValue: 0,
+        useNativeDriver: true,
+        speed: 20,
+        bounciness: 8,
+      }),
+    ]).start();
+
+    const timer = setTimeout(() => {
+      Animated.parallel([
+        Animated.timing(opacity, {
+          toValue: 0,
+          duration: ANIMATION_DURATIONS.NORMAL,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: 30,
+          duration: ANIMATION_DURATIONS.NORMAL,
+          useNativeDriver: true,
+        }),
+      ]).start(() => onDone());
+    }, DISPLAY_DURATION);
+
+    return () => clearTimeout(timer);
+  }, [badgeIds, onDone, opacity, translateY]);
+
+  if (badgeIds.length === 0) return null;
+
+  const first = BADGE_DEFINITIONS.find(b => b.id === badgeIds[0]);
+  const icon = first?.icon ?? '🏅';
+  const extra = badgeIds.length > 1 ? ` +${badgeIds.length - 1}` : '';
+
+  return (
+    <Animated.View
+      style={[styles.toast, { opacity, transform: [{ translateY }] }]}
+      pointerEvents="none"
+    >
+      <Text style={styles.icon}>{icon}</Text>
+      <View style={styles.textGroup}>
+        <Text style={styles.label}>{badgeNewUnlockedLabel}</Text>
+        {extra ? <Text style={styles.extra}>{extra}</Text> : null}
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    bottom: 32,
+    left: 24,
+    right: 24,
+    backgroundColor: DESIGN_TOKENS.GRADIENT_PRIMARY[1],
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    elevation: 16,
+    shadowColor: '#764ba2',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.35,
+    shadowRadius: 12,
+    zIndex: 2000,
+  },
+  icon: {
+    fontSize: 28,
+  },
+  textGroup: {
+    flex: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: '#fff',
+  },
+  extra: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: 'rgba(255,255,255,0.75)',
+  },
+});

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -1,0 +1,309 @@
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  ScrollView,
+} from 'react-native';
+import { ThemeColors, Language } from '../types/game';
+import { BADGE_DEFINITIONS, BadgeCategory, DESIGN_TOKENS } from '../utils/constants';
+import { BadgeStore } from '../utils/storage';
+import { modalStyles } from '../styles/modalStyles';
+
+interface BadgesModalProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  badges: BadgeStore;
+  language: Language;
+  t: {
+    badges: string;
+    badgesSubtitle: string;
+    badgeLocked: string;
+    badgeUnlockedOn: string;
+    badgeCategoryStreak: string;
+    badgeCategoryPerformance: string;
+    badgeCategoryChallenge: string;
+    badgeCategoryExplorer: string;
+    badgeStreak3Name: string;
+    badgeStreak7Name: string;
+    badgeStreak30Name: string;
+    badgePerfect1Name: string;
+    badgePerfect5Name: string;
+    badgeAllOpsName: string;
+    badgeChallengeLevel3Name: string;
+    badgeChallengeLevel6Name: string;
+    badgeChallengeNoErrorsName: string;
+    badgeRange100Name: string;
+    badgeCreativeModeName: string;
+    badgeStreak3Desc: string;
+    badgeStreak7Desc: string;
+    badgeStreak30Desc: string;
+    badgePerfect1Desc: string;
+    badgePerfect5Desc: string;
+    badgeAllOpsDesc: string;
+    badgeChallengeLevel3Desc: string;
+    badgeChallengeLevel6Desc: string;
+    badgeChallengeNoErrorsDesc: string;
+    badgeRange100Desc: string;
+    badgeCreativeModeDesc: string;
+    ok: string;
+  };
+}
+
+const CATEGORY_ORDER: BadgeCategory[] = ['streak', 'performance', 'challenge', 'explorer'];
+
+function getBadgeName(id: string, t: BadgesModalProps['t']): string {
+  const map: Record<string, string> = {
+    streak_3: t.badgeStreak3Name,
+    streak_7: t.badgeStreak7Name,
+    streak_30: t.badgeStreak30Name,
+    perfect_1: t.badgePerfect1Name,
+    perfect_5: t.badgePerfect5Name,
+    all_operations: t.badgeAllOpsName,
+    challenge_level_3: t.badgeChallengeLevel3Name,
+    challenge_level_6: t.badgeChallengeLevel6Name,
+    challenge_no_errors: t.badgeChallengeNoErrorsName,
+    range_100: t.badgeRange100Name,
+    creative_mode: t.badgeCreativeModeName,
+  };
+  return map[id] ?? id;
+}
+
+function getBadgeDesc(id: string, t: BadgesModalProps['t']): string {
+  const map: Record<string, string> = {
+    streak_3: t.badgeStreak3Desc,
+    streak_7: t.badgeStreak7Desc,
+    streak_30: t.badgeStreak30Desc,
+    perfect_1: t.badgePerfect1Desc,
+    perfect_5: t.badgePerfect5Desc,
+    all_operations: t.badgeAllOpsDesc,
+    challenge_level_3: t.badgeChallengeLevel3Desc,
+    challenge_level_6: t.badgeChallengeLevel6Desc,
+    challenge_no_errors: t.badgeChallengeNoErrorsDesc,
+    range_100: t.badgeRange100Desc,
+    creative_mode: t.badgeCreativeModeDesc,
+  };
+  return map[id] ?? '';
+}
+
+function getCategoryLabel(cat: BadgeCategory, t: BadgesModalProps['t']): string {
+  const map: Record<BadgeCategory, string> = {
+    streak: t.badgeCategoryStreak,
+    performance: t.badgeCategoryPerformance,
+    challenge: t.badgeCategoryChallenge,
+    explorer: t.badgeCategoryExplorer,
+  };
+  return map[cat];
+}
+
+function formatUnlockDate(ts: number, language: Language): string {
+  try {
+    return new Intl.DateTimeFormat(language === 'de' ? 'de-DE' : 'en-US', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(new Date(ts));
+  } catch {
+    const d = new Date(ts);
+    return `${d.getDate().toString().padStart(2, '0')}.${(d.getMonth() + 1).toString().padStart(2, '0')}.${d.getFullYear()}`;
+  }
+}
+
+export function BadgesModal({ visible, onClose, colors, badges, language, t }: BadgesModalProps) {
+  const unlockedCount = Object.keys(badges).length;
+  const totalCount = BADGE_DEFINITIONS.length;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[styles.container, { backgroundColor: colors.settingsMenu }]}>
+          {/* Header */}
+          <View style={styles.header}>
+            <View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.badges}</Text>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+                {unlockedCount}/{totalCount} · {t.badgesSubtitle}
+              </Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={[styles.closeText, { color: colors.text }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Badge grid by category */}
+          <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
+            {CATEGORY_ORDER.map(cat => {
+              const defs = BADGE_DEFINITIONS.filter(b => b.category === cat);
+              return (
+                <View key={cat} style={styles.categorySection}>
+                  <Text style={[styles.categoryLabel, { color: colors.textSecondary }]}>
+                    {getCategoryLabel(cat, t).toUpperCase()}
+                  </Text>
+                  <View style={styles.grid}>
+                    {defs.map(def => {
+                      const unlockedAt = badges[def.id];
+                      const isUnlocked = Boolean(unlockedAt);
+                      return (
+                        <View
+                          key={def.id}
+                          style={[
+                            styles.badgeCard,
+                            { backgroundColor: colors.card, borderColor: colors.border },
+                            isUnlocked && styles.badgeCardUnlocked,
+                          ]}
+                        >
+                          <Text style={[styles.badgeIcon, !isUnlocked && styles.badgeIconLocked]}>
+                            {isUnlocked ? def.icon : '🔒'}
+                          </Text>
+                          <Text
+                            style={[
+                              styles.badgeName,
+                              { color: isUnlocked ? colors.text : colors.textSecondary },
+                            ]}
+                            numberOfLines={2}
+                          >
+                            {getBadgeName(def.id, t)}
+                          </Text>
+                          <Text
+                            style={[styles.badgeDesc, { color: colors.textSecondary }]}
+                            numberOfLines={2}
+                          >
+                            {getBadgeDesc(def.id, t)}
+                          </Text>
+                          {isUnlocked && (
+                            <Text style={styles.unlockedDate}>
+                              {t.badgeUnlockedOn} {formatUnlockDate(unlockedAt, language)}
+                            </Text>
+                          )}
+                        </View>
+                      );
+                    })}
+                  </View>
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          {/* Close button */}
+          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+            <Text style={styles.closeBtnText}>{t.ok}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 24,
+    padding: 20,
+    width: '92%',
+    maxWidth: 440,
+    maxHeight: '88%',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  subtitle: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+  },
+  closeButton: {
+    padding: 6,
+    minWidth: 36,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  scroll: {
+    maxHeight: 440,
+    marginBottom: 12,
+  },
+  categorySection: {
+    marginBottom: 14,
+  },
+  categoryLabel: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    letterSpacing: 0.8,
+    marginBottom: 8,
+    marginLeft: 2,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  badgeCard: {
+    width: '48%',
+    borderWidth: 1.5,
+    borderRadius: 14,
+    padding: 10,
+    alignItems: 'center',
+    opacity: 0.5,
+  },
+  badgeCardUnlocked: {
+    opacity: 1,
+    borderColor: ACTIVE_COLOR + '55',
+  },
+  badgeIcon: {
+    fontSize: 28,
+    marginBottom: 4,
+  },
+  badgeIconLocked: {
+    opacity: 0.4,
+  },
+  badgeName: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    marginBottom: 2,
+  },
+  badgeDesc: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 14,
+  },
+  unlockedDate: {
+    fontSize: 9,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: ACTIVE_COLOR,
+    marginTop: 4,
+    textAlign: 'center',
+  },
+  closeBtn: {
+    backgroundColor: ACTIVE_COLOR,
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  closeBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/GameCard.test.tsx
+++ b/components/GameCard.test.tsx
@@ -57,7 +57,7 @@ const defaultProps = {
   onChoiceClick: jest.fn(),
   onCheck: jest.fn(),
   onNext: jest.fn(),
-  t: { nextQuestion: 'Weiter →', check: 'Prüfen', encouragement: 'Du schaffst das! 💪' },
+  t: { nextQuestion: 'Weiter →', check: 'Prüfen', encouragement: 'Du schaffst das! 💪', practiceModeFeedback: 'Du übst deine schwierigen Aufgaben!' },
 };
 
 describe('GameCard - Button accessibility', () => {
@@ -392,5 +392,28 @@ describe('GameCard - Button accessibility', () => {
       // Check button present
       expect(getByText('Prüfen')).toBeTruthy();
     });
+  });
+});
+
+describe('GameCard - Practice mode encouragement text', () => {
+  it('shows encouragement text in SIMPLE mode', () => {
+    const { getByText } = render(
+      <GameCard {...defaultProps} gameState={{ ...baseGameState, difficultyMode: DifficultyMode.SIMPLE }} />
+    );
+    expect(getByText('Du schaffst das! 💪')).toBeTruthy();
+  });
+
+  it('shows practiceModeFeedback text in PRACTICE mode', () => {
+    const { getByText } = render(
+      <GameCard {...defaultProps} gameState={{ ...baseGameState, difficultyMode: DifficultyMode.PRACTICE }} />
+    );
+    expect(getByText('Du übst deine schwierigen Aufgaben!')).toBeTruthy();
+  });
+
+  it('shows encouragement text in CREATIVE mode', () => {
+    const { getByText } = render(
+      <GameCard {...defaultProps} gameState={{ ...baseGameState, difficultyMode: DifficultyMode.CREATIVE }} />
+    );
+    expect(getByText('Du schaffst das! 💪')).toBeTruthy();
   });
 });

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -8,7 +8,7 @@ import {
   Animated,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { ThemeColors, Operation, AnswerMode, GameState } from '../types/game';
+import { ThemeColors, Operation, AnswerMode, GameState, DifficultyMode } from '../types/game';
 import { DESIGN_TOKENS } from '../utils/constants';
 import { Numpad } from './Numpad';
 import { ProgressDots } from './ProgressDots';
@@ -31,6 +31,7 @@ interface GameCardProps {
     nextQuestion: string;
     check: string;
     encouragement: string;
+    practiceModeFeedback: string;
   };
 }
 
@@ -119,7 +120,7 @@ export function GameCard({
                 isAnswerChecked={gameState.isAnswerChecked}
                 checkLabel={t.check}
                 nextLabel={t.nextQuestion}
-                encouragement={t.encouragement}
+                encouragement={gameState.difficultyMode === DifficultyMode.PRACTICE ? t.practiceModeFeedback : t.encouragement}
               />
             )}
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,6 +18,7 @@ interface HeaderProps {
   score: number;
   currentTask: number;
   totalTasks: number;
+  currentStreak?: number;
   onShowMenu: () => void;
   t: {
     level: string;
@@ -33,6 +34,7 @@ export function Header({
   score,
   currentTask,
   totalTasks,
+  currentStreak,
   onShowMenu,
   t,
 }: HeaderProps) {
@@ -66,6 +68,11 @@ export function Header({
             <Text style={styles.scoreBadgeText}>⭐ {score}</Text>
           </LinearGradient>
         </>
+      )}
+      {!!currentStreak && currentStreak > 0 && (
+        <View style={styles.streakBadge}>
+          <Text style={styles.streakText}>🔥 {currentStreak}</Text>
+        </View>
       )}
       <TouchableOpacity
         onPress={onShowMenu}
@@ -124,5 +131,18 @@ const styles = StyleSheet.create({
   settingsButtonText: {
     fontSize: 24,
     fontWeight: 'normal',
+  },
+  streakBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 14,
+    backgroundColor: 'rgba(249,212,35,0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  streakText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#F59E0B',
   },
 });

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -1,0 +1,344 @@
+import React, { useState, useRef } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+  Animated,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { ThemeColors } from '../types/game';
+import { modalStyles } from '../styles/modalStyles';
+import { DESIGN_TOKENS } from '../utils/constants';
+import { prefersReducedMotion } from '../utils/animations';
+
+interface OnboardingModalProps {
+  visible: boolean;
+  onFinish: () => void;
+  colors: ThemeColors;
+  t: {
+    onboardingWelcomeTitle: string;
+    onboardingWelcomeBody: string;
+    onboardingDemoTitle: string;
+    onboardingDemoTooltip: string;
+    onboardingSettingsTitle: string;
+    onboardingSettingsBody: string;
+    onboardingReadyTitle: string;
+    onboardingReadyBody: string;
+    onboardingDemoRetry: string;
+    onboardingSettingsLabel: string;
+    onboardingNext: string;
+    onboardingStart: string;
+    onboardingSkip: string;
+  };
+}
+
+const DEMO_CHOICES = [5, 6, 8];
+const DEMO_CORRECT = 6;
+const TOTAL_STEPS = 4;
+
+export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModalProps) {
+  const [step, setStep] = useState(0);
+  const [demoAnswer, setDemoAnswer] = useState<number | null>(null);
+  const shakeAnim = useRef(new Animated.Value(0)).current;
+
+  const demoCorrect = demoAnswer === DEMO_CORRECT;
+  const demoWrong = demoAnswer !== null && demoAnswer !== DEMO_CORRECT;
+
+  const handleClose = () => {
+    setStep(0);
+    setDemoAnswer(null);
+    onFinish();
+  };
+
+  const handleNext = () => {
+    if (step < TOTAL_STEPS - 1) {
+      setStep(s => s + 1);
+    } else {
+      handleClose();
+    }
+  };
+
+  const handleDemoChoice = (choice: number) => {
+    if (demoAnswer !== null) return;
+    setDemoAnswer(choice);
+    if (choice !== DEMO_CORRECT) {
+      if (prefersReducedMotion()) {
+        setDemoAnswer(null);
+        return;
+      }
+      Animated.sequence([
+        Animated.timing(shakeAnim, { toValue: -8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 8, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: -5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 5, duration: 60, useNativeDriver: true }),
+        Animated.timing(shakeAnim, { toValue: 0, duration: 60, useNativeDriver: true }),
+      ]).start(() => setDemoAnswer(null));
+    }
+  };
+
+  const canProceedStep1 = step !== 1 || demoCorrect;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[modalStyles.content, styles.container, { backgroundColor: colors.settingsMenu }]}>
+
+          {/* Progress dots */}
+          <View style={styles.dotsRow}>
+            {Array.from({ length: TOTAL_STEPS }).map((_, i) => (
+              <View
+                key={i}
+                style={[
+                  styles.dot,
+                  i === step && styles.dotActive,
+                  { backgroundColor: i === step ? DESIGN_TOKENS.GRADIENT_PRIMARY[0] : colors.border },
+                ]}
+              />
+            ))}
+          </View>
+
+          {/* Step content */}
+          {step === 0 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🎉</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingWelcomeTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingWelcomeBody}</Text>
+            </View>
+          )}
+
+          {step === 1 && (
+            <View style={styles.stepContent}>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingDemoTitle}</Text>
+              <Animated.View style={[styles.demoCard, { backgroundColor: colors.card, transform: [{ translateX: shakeAnim }] }]}>
+                <Text style={[styles.demoEquation, { color: colors.text, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                  2 × 3 = ?
+                </Text>
+              </Animated.View>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>
+                ↑ {t.onboardingDemoTooltip}
+              </Text>
+              <View style={styles.choicesRow}>
+                {DEMO_CHOICES.map(choice => {
+                  const isSelected = demoAnswer === choice;
+                  const isCorrectChoice = choice === DEMO_CORRECT;
+                  let bg = colors.buttonInactive;
+                  let border = colors.border;
+                  let textColor = colors.text;
+                  if (isSelected && isCorrectChoice) {
+                    bg = '#ECFDF5';
+                    border = '#43e97b';
+                    textColor = '#059669';
+                  } else if (isSelected && !isCorrectChoice) {
+                    bg = '#FFF1F2';
+                    border = '#f857a6';
+                    textColor = '#be123c';
+                  }
+                  return (
+                    <TouchableOpacity
+                      key={choice}
+                      style={[styles.choiceButton, { backgroundColor: bg, borderColor: border }]}
+                      onPress={() => handleDemoChoice(choice)}
+                      disabled={demoAnswer !== null}
+                    >
+                      <Text style={[styles.choiceText, { color: textColor, fontFamily: DESIGN_TOKENS.FONT_NUMBER }]}>
+                        {choice}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+              {demoCorrect && (
+                <Text style={styles.feedbackCorrect}>✓</Text>
+              )}
+              {demoWrong && (
+                <Text style={[styles.body, { color: colors.textSecondary }]}>
+                  {t.onboardingDemoRetry}
+                </Text>
+              )}
+            </View>
+          )}
+
+          {step === 2 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>⚙️</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingSettingsTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingSettingsBody}</Text>
+              <LinearGradient
+                colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.menuHint}
+              >
+                <Text style={styles.menuHintText}>☰</Text>
+              </LinearGradient>
+              <Text style={[styles.tooltip, { color: colors.textSecondary }]}>{t.onboardingSettingsLabel}</Text>
+            </View>
+          )}
+
+          {step === 3 && (
+            <View style={styles.stepContent}>
+              <Text style={styles.emoji}>🚀</Text>
+              <Text style={[styles.title, { color: colors.text }]}>{t.onboardingReadyTitle}</Text>
+              <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingReadyBody}</Text>
+            </View>
+          )}
+
+          {/* Buttons */}
+          <View style={styles.buttonsRow}>
+            <TouchableOpacity style={styles.skipButton} onPress={handleClose}>
+              <Text style={[styles.skipText, { color: colors.textSecondary }]}>{t.onboardingSkip}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.nextButton, !canProceedStep1 && styles.nextButtonDisabled]}
+              onPress={handleNext}
+              disabled={!canProceedStep1}
+            >
+              <LinearGradient
+                colors={canProceedStep1 ? DESIGN_TOKENS.GRADIENT_PRIMARY : ['#ccc', '#ccc']}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                style={styles.nextButtonGradient}
+              >
+                <Text style={styles.nextButtonText}>
+                  {step === TOTAL_STEPS - 1 ? t.onboardingStart : t.onboardingNext}
+                </Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          </View>
+
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '88%',
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    paddingBottom: 20,
+  },
+  dotsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  dotActive: {
+    width: 24,
+  },
+  stepContent: {
+    alignItems: 'center',
+    minHeight: 200,
+    justifyContent: 'center',
+    gap: 12,
+    width: '100%',
+  },
+  emoji: {
+    fontSize: 48,
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  tooltip: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  demoCard: {
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+  },
+  demoEquation: {
+    fontSize: 32,
+  },
+  choicesRow: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 4,
+  },
+  choiceButton: {
+    width: 64,
+    height: 56,
+    borderRadius: 12,
+    borderWidth: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  choiceText: {
+    fontSize: 22,
+  },
+  feedbackCorrect: {
+    fontSize: 32,
+    color: '#059669',
+  },
+  menuHint: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  menuHintText: {
+    fontSize: 20,
+    color: '#fff',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  buttonsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 24,
+    gap: 12,
+  },
+  skipButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  skipText: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  nextButton: {
+    flex: 1,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  nextButtonDisabled: {
+    opacity: 0.5,
+  },
+  nextButtonGradient: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  nextButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -27,6 +27,9 @@ const t = {
   parentErrors: 'Fehler',
   parentWeakTasks: 'Schwachstellen (Top 5)',
   parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
+  parentCurrentStreak: 'Aktueller Streak',
+  parentLongestStreak: 'Längster Streak',
+  parentStreakDays: 'Tage',
   ok: 'OK',
 };
 

--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -8,10 +8,12 @@ import { FOUR_WEEKS_MS } from '../utils/storage';
 jest.mock('../utils/storage', () => ({
   ...jest.requireActual('../utils/storage'),
   getSessionRecords: jest.fn(),
+  getTaskStats: jest.fn(),
 }));
 
-import { getSessionRecords } from '../utils/storage';
+import { getSessionRecords, getTaskStats } from '../utils/storage';
 const mockGetSessionRecords = getSessionRecords as jest.Mock;
+const mockGetTaskStats = getTaskStats as jest.Mock;
 
 const t = {
   parentDashboard: 'Eltern-Dashboard',
@@ -23,6 +25,8 @@ const t = {
   parentYesterday: 'Gestern',
   parentCorrect: 'Richtig',
   parentErrors: 'Fehler',
+  parentWeakTasks: 'Schwachstellen (Top 5)',
+  parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
   ok: 'OK',
 };
 
@@ -45,6 +49,8 @@ describe('ParentDashboard', () => {
   beforeEach(() => {
     mockGetSessionRecords.mockClear();
     mockGetSessionRecords.mockResolvedValue([]);
+    mockGetTaskStats.mockClear();
+    mockGetTaskStats.mockResolvedValue([]);
   });
 
   it('shows empty state when no records', async () => {
@@ -117,6 +123,34 @@ describe('ParentDashboard', () => {
       <ParentDashboard visible={false} onClose={jest.fn()} colors={colors} t={t} />
     );
     expect(mockGetSessionRecords).not.toHaveBeenCalled();
+    expect(mockGetTaskStats).not.toHaveBeenCalled();
+  });
+
+  it('does not show weak tasks section when no weak stats', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    // Stats exist but error rate is only 20% → not weak
+    mockGetTaskStats.mockResolvedValue([
+      { num1: 3, num2: 4, operation: 'MULTIPLICATION', correctCount: 8, errorCount: 2, lastSeen: new Date().toISOString() },
+    ]);
+    const { queryByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(mockGetTaskStats).toHaveBeenCalled());
+    expect(queryByText(t.parentWeakTasks)).toBeNull();
+  });
+
+  it('shows weak task row when a task has high error rate', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    mockGetTaskStats.mockResolvedValue([
+      { num1: 7, num2: 8, operation: 'MULTIPLICATION', correctCount: 0, errorCount: 3, lastSeen: new Date().toISOString() },
+    ]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(t.parentWeakTasks)).toBeTruthy();
+      expect(getByText('7 × 8')).toBeTruthy();
+    });
   });
 
   it('calls onClose when OK button is pressed', async () => {

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -190,10 +190,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           {!loading && weakTasks.length > 0 && (
             <View style={[styles.weakSection, { borderColor: colors.border }]}>
               <Text style={[styles.weakTitle, { color: colors.textSecondary }]}>{t.parentWeakTasks}</Text>
-              {weakTasks.length === 0 ? (
-                <Text style={[styles.weakEmpty, { color: colors.textSecondary }]}>{t.parentWeakTasksEmpty}</Text>
-              ) : (
-                weakTasks.map((s, i) => {
+              {weakTasks.map((s, i) => {
                   const total = s.correctCount + s.errorCount;
                   const rate = total > 0 ? s.errorCount / total : 0;
                   return (
@@ -211,8 +208,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                       </Text>
                     </View>
                   );
-                })
-              )}
+                })}
             </View>
           )}
 

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -8,8 +8,8 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { ThemeColors, SessionRecord, Operation, DifficultyMode, TaskStat } from '../types/game';
-import { getSessionRecords, getTaskStats, getWeakTasks, FOUR_WEEKS_MS } from '../utils/storage';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode, StreakData, TaskStat } from '../types/game';
+import { getSessionRecords, getStreakData, getTaskStats, getWeakTasks, FOUR_WEEKS_MS } from '../utils/storage';
 import { DESIGN_TOKENS } from '../utils/constants';
 import { modalStyles } from '../styles/modalStyles';
 
@@ -34,6 +34,9 @@ interface ParentDashboardProps {
     parentYesterday: string;
     parentCorrect: string;
     parentErrors: string;
+    parentCurrentStreak: string;
+    parentLongestStreak: string;
+    parentStreakDays: string;
     parentWeakTasks: string;
     parentWeakTasksEmpty: string;
     ok: string;
@@ -92,14 +95,16 @@ function errorRateColor(rate: number): string {
 
 export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
   const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [streak, setStreak] = useState<StreakData>({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
   const [weakTasks, setWeakTasks] = useState<TaskStat[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setLoading(true);
-      Promise.all([getSessionRecords(), getTaskStats()]).then(([sessions, stats]) => {
-        setRecords(sessions);
+      Promise.all([getSessionRecords(), getStreakData(), getTaskStats()]).then(([data, streakData, stats]) => {
+        setRecords(data);
+        setStreak(streakData);
         setWeakTasks(getWeakTasks(stats).slice(0, 5));
         setLoading(false);
       });
@@ -141,13 +146,15 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           </View>
 
           {/* Summary bar */}
-          {records.length > 0 && (
+          {(records.length > 0 || streak.currentStreak > 0 || streak.longestStreak > 0) && (
             <View style={[styles.summaryBar, { borderColor: colors.border }]}>
-              <View style={styles.summaryItem}>
-                <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
-                <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
-              </View>
-              {avgErrorRate !== null && (
+              {records.length > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: colors.text }]}>{recentRecords.length}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentSessions}</Text>
+                </View>
+              )}
+              {records.length > 0 && avgErrorRate !== null && (
                 <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
               )}
               {avgErrorRate !== null && (
@@ -156,6 +163,24 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                     {Math.round(avgErrorRate * 100)}%
                   </Text>
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
+                </View>
+              )}
+              {streak.currentStreak > 0 && records.length > 0 && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {streak.currentStreak > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: '#F59E0B' }]}>🔥 {streak.currentStreak}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentCurrentStreak}</Text>
+                </View>
+              )}
+              {streak.longestStreak > 0 && (records.length > 0 || streak.currentStreak > 0) && (
+                <View style={[styles.summaryDivider, { backgroundColor: colors.border }]} />
+              )}
+              {streak.longestStreak > 0 && (
+                <View style={styles.summaryItem}>
+                  <Text style={[styles.summaryValue, { color: colors.text }]}>{streak.longestStreak}</Text>
+                  <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentLongestStreak}</Text>
                 </View>
               )}
             </View>

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -8,8 +8,8 @@ import {
   ScrollView,
   ActivityIndicator,
 } from 'react-native';
-import { ThemeColors, SessionRecord, Operation, DifficultyMode } from '../types/game';
-import { getSessionRecords, FOUR_WEEKS_MS } from '../utils/storage';
+import { ThemeColors, SessionRecord, Operation, DifficultyMode, TaskStat } from '../types/game';
+import { getSessionRecords, getTaskStats, getWeakTasks, FOUR_WEEKS_MS } from '../utils/storage';
 import { DESIGN_TOKENS } from '../utils/constants';
 import { modalStyles } from '../styles/modalStyles';
 
@@ -34,6 +34,8 @@ interface ParentDashboardProps {
     parentYesterday: string;
     parentCorrect: string;
     parentErrors: string;
+    parentWeakTasks: string;
+    parentWeakTasksEmpty: string;
     ok: string;
   };
 }
@@ -90,13 +92,15 @@ function errorRateColor(rate: number): string {
 
 export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
   const [records, setRecords] = useState<SessionRecord[]>([]);
+  const [weakTasks, setWeakTasks] = useState<TaskStat[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (visible) {
       setLoading(true);
-      getSessionRecords().then((data) => {
-        setRecords(data);
+      Promise.all([getSessionRecords(), getTaskStats()]).then(([sessions, stats]) => {
+        setRecords(sessions);
+        setWeakTasks(getWeakTasks(stats).slice(0, 5));
         setLoading(false);
       });
     }
@@ -153,6 +157,36 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                   </Text>
                   <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>{t.parentAvgError}</Text>
                 </View>
+              )}
+            </View>
+          )}
+
+          {/* Weak Tasks Section */}
+          {!loading && weakTasks.length > 0 && (
+            <View style={[styles.weakSection, { borderColor: colors.border }]}>
+              <Text style={[styles.weakTitle, { color: colors.textSecondary }]}>{t.parentWeakTasks}</Text>
+              {weakTasks.length === 0 ? (
+                <Text style={[styles.weakEmpty, { color: colors.textSecondary }]}>{t.parentWeakTasksEmpty}</Text>
+              ) : (
+                weakTasks.map((s, i) => {
+                  const total = s.correctCount + s.errorCount;
+                  const rate = total > 0 ? s.errorCount / total : 0;
+                  return (
+                    <View key={`${s.num1}-${s.num2}-${s.operation}-${i}`} style={styles.weakRow}>
+                      <Text style={[styles.weakTask, { color: colors.text }]}>
+                        {s.num1} {OP_SYMBOL[s.operation]} {s.num2}
+                      </Text>
+                      <View style={[styles.errorBadge, { backgroundColor: errorRateColor(rate) + '22' }]}>
+                        <Text style={[styles.errorBadgeText, { color: errorRateColor(rate) }]}>
+                          {Math.round(rate * 100)}%
+                        </Text>
+                      </View>
+                      <Text style={[styles.weakAttempts, { color: colors.textSecondary }]}>
+                        {total}×
+                      </Text>
+                    </View>
+                  );
+                })
               )}
             </View>
           )}
@@ -343,6 +377,41 @@ const styles = StyleSheet.create({
   },
   challengeBadge: {
     fontSize: 13,
+  },
+  weakSection: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 10,
+    marginBottom: 12,
+  },
+  weakTitle: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+  weakEmpty: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    fontStyle: 'italic',
+  },
+  weakRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    gap: 8,
+  },
+  weakTask: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+    flex: 1,
+  },
+  weakAttempts: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    minWidth: 28,
+    textAlign: 'right',
   },
   closeBtn: {
     backgroundColor: ACTIVE_COLOR,

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -23,6 +23,7 @@ interface SettingsMenuProps {
   difficultyMode: DifficultyMode;
   selectedOperations: Set<Operation>;
   numberRange: NumberRange;
+  weakTaskCount?: number;
   // Actions
   onToggleOperation: (op: Operation) => void;
   onChangeDifficultyMode: (mode: DifficultyMode) => void;
@@ -41,9 +42,11 @@ interface SettingsMenuProps {
     difficultyMode: string;
     simpleMode: string;
     creativeMode: string;
+    practiceMode: string;
     challenge: string;
     simpleModeInfo: string;
     creativeModeInfo: string;
+    practiceModeInfo: string;
     challengeInfo: string;
     numberRange: string;
     upTo10: string;
@@ -67,6 +70,7 @@ export function SettingsMenu({
   difficultyMode,
   selectedOperations,
   numberRange,
+  weakTaskCount,
   onToggleOperation,
   onChangeDifficultyMode,
   onSetNumberRange,
@@ -161,7 +165,7 @@ export function SettingsMenu({
         {/* Difficulty Mode Settings */}
         <View style={styles.settingsSection}>
           <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.difficultyMode}</Text>
-          <View style={styles.themeToggle}>
+          <View style={styles.difficultyGrid}>
             <TouchableOpacity
               style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonActive]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.SIMPLE)}
@@ -189,12 +193,22 @@ export function SettingsMenu({
                 {t.challenge}
               </Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonActive]}
+              onPress={() => onChangeDifficultyMode(DifficultyMode.PRACTICE)}
+            >
+              <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonTextActive]}>
+                {t.practiceMode}{weakTaskCount !== undefined && weakTaskCount > 0 ? ` (${weakTaskCount})` : ''}
+              </Text>
+            </TouchableOpacity>
           </View>
           <Text style={[styles.settingsModeInfo, { color: modeInfo }]}>
             {difficultyMode === DifficultyMode.SIMPLE
               ? t.simpleModeInfo
               : difficultyMode === DifficultyMode.CREATIVE
               ? t.creativeModeInfo
+              : difficultyMode === DifficultyMode.PRACTICE
+              ? t.practiceModeInfo
               : t.challengeInfo}
           </Text>
         </View>
@@ -378,6 +392,11 @@ const styles = StyleSheet.create({
   },
   themeToggle: {
     flexDirection: 'row',
+    gap: 8,
+  },
+  difficultyGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
     gap: 8,
   },
   themeButton: {

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -32,6 +32,7 @@ interface SettingsMenuProps {
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
   onOpenParentDashboard: () => void;
+  onResetOnboarding: () => void;
   onOpenBadges: () => void;
   // Translations
   t: {
@@ -62,6 +63,7 @@ interface SettingsMenuProps {
     support: string;
     about: string;
     settings: string;
+    resetOnboarding: string;
   };
 }
 
@@ -80,6 +82,7 @@ export function SettingsMenu({
   onOpenPersonalize,
   onOpenAbout,
   onOpenParentDashboard,
+  onResetOnboarding,
   onOpenBadges,
   t,
 }: SettingsMenuProps) {
@@ -286,6 +289,14 @@ export function SettingsMenu({
             <Text style={styles.settingsMenuLinkText}>{t.about}</Text>
           </TouchableOpacity>
         </View>
+
+        {/* Reset Onboarding */}
+        <TouchableOpacity
+          style={[styles.settingsSection, styles.resetOnboardingButton]}
+          onPress={() => { onResetOnboarding(); onHideMenu(); }}
+        >
+          <Text style={styles.resetOnboardingText}>{t.resetOnboarding}</Text>
+        </TouchableOpacity>
         </ScrollView>
       </Animated.View>
     </>
@@ -485,5 +496,16 @@ const styles = StyleSheet.create({
   },
   rangeButtonTextActive: {
     color: '#fff',
+  },
+  resetOnboardingButton: {
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: 'rgba(102,126,234,0.1)',
+  },
+  resetOnboardingText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    color: 'rgba(102,126,234,0.6)',
   },
 });

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -32,6 +32,7 @@ interface SettingsMenuProps {
   onOpenPersonalize: () => void;
   onOpenAbout: () => void;
   onOpenParentDashboard: () => void;
+  onOpenBadges: () => void;
   // Translations
   t: {
     operation: string;
@@ -56,6 +57,7 @@ interface SettingsMenuProps {
     personalize: string;
     parentDashboard: string;
     parentDashboardMenu: string;
+    badgesMenu: string;
     feedback: string;
     support: string;
     about: string;
@@ -78,6 +80,7 @@ export function SettingsMenu({
   onOpenPersonalize,
   onOpenAbout,
   onOpenParentDashboard,
+  onOpenBadges,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -122,6 +125,12 @@ export function SettingsMenu({
             onPress={() => { onOpenParentDashboard(); onHideMenu(); }}
           >
             <Text style={styles.personalizeButtonText}>{t.parentDashboardMenu}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.personalizeButton}
+            onPress={() => { onOpenBadges(); onHideMenu(); }}
+          >
+            <Text style={styles.personalizeButtonText}>{t.badgesMenu}</Text>
           </TouchableOpacity>
         </View>
 

--- a/hooks/useBadges.test.ts
+++ b/hooks/useBadges.test.ts
@@ -186,25 +186,25 @@ describe('advanceStreak', () => {
   }
 
   it('starts streak at 1 on first ever play', () => {
-    const result = advanceStreak({ currentStreak: 0, lastPlayedDay: '' });
+    const result = advanceStreak({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
     expect(result.currentStreak).toBe(1);
-    expect(result.lastPlayedDay).toBe(isoToday());
+    expect(result.lastPlayedDate).toBe(isoToday());
   });
 
   it('does not increase streak when called twice on same day', () => {
     const today = isoToday();
-    const result = advanceStreak({ currentStreak: 5, lastPlayedDay: today });
+    const result = advanceStreak({ currentStreak: 5, lastPlayedDate: today, longestStreak: 5 });
     expect(result.currentStreak).toBe(5);
   });
 
   it('increments streak on consecutive day', () => {
-    const result = advanceStreak({ currentStreak: 4, lastPlayedDay: isoYesterday() });
+    const result = advanceStreak({ currentStreak: 4, lastPlayedDate: isoYesterday(), longestStreak: 4 });
     expect(result.currentStreak).toBe(5);
-    expect(result.lastPlayedDay).toBe(isoToday());
+    expect(result.lastPlayedDate).toBe(isoToday());
   });
 
   it('resets streak to 1 after a gap', () => {
-    const result = advanceStreak({ currentStreak: 10, lastPlayedDay: '2020-01-01' });
+    const result = advanceStreak({ currentStreak: 10, lastPlayedDate: '2020-01-01', longestStreak: 10 });
     expect(result.currentStreak).toBe(1);
   });
 });

--- a/hooks/useBadges.test.ts
+++ b/hooks/useBadges.test.ts
@@ -1,0 +1,210 @@
+import { getStreakDays, countPerfectSessions, hasAllOperationsPerfect, computeNewlyUnlocked, advanceStreak } from './useBadges';
+import { DifficultyMode, NumberRange, Operation } from '../types/game';
+import type { SessionRecord } from '../types/game';
+import type { BadgeStore } from '../utils/storage';
+
+function makeRecord(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: Math.random().toString(),
+    timestamp: Date.now(),
+    operations: [Operation.MULTIPLICATION],
+    totalTasks: 10,
+    correctTasks: 10,
+    errors: 0,
+    errorRate: 0,
+    difficultyMode: DifficultyMode.SIMPLE,
+    numberRange: NumberRange.RANGE_10,
+    ...overrides,
+  };
+}
+
+function daysAgo(n: number): number {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(12, 0, 0, 0);
+  return d.getTime();
+}
+
+describe('getStreakDays', () => {
+  it('returns 0 for empty records', () => {
+    expect(getStreakDays([])).toBe(0);
+  });
+
+  it('returns 1 when only today has a session', () => {
+    const records = [makeRecord({ timestamp: daysAgo(0) })];
+    expect(getStreakDays(records)).toBe(1);
+  });
+
+  it('counts consecutive days ending today', () => {
+    const records = [
+      makeRecord({ timestamp: daysAgo(0) }),
+      makeRecord({ timestamp: daysAgo(1) }),
+      makeRecord({ timestamp: daysAgo(2) }),
+    ];
+    expect(getStreakDays(records)).toBe(3);
+  });
+
+  it('breaks streak when a day is missing', () => {
+    const records = [
+      makeRecord({ timestamp: daysAgo(0) }),
+      // day 1 missing
+      makeRecord({ timestamp: daysAgo(2) }),
+    ];
+    expect(getStreakDays(records)).toBe(1);
+  });
+
+  it('returns 0 when most recent session was yesterday only', () => {
+    const records = [makeRecord({ timestamp: daysAgo(1) })];
+    expect(getStreakDays(records)).toBe(0);
+  });
+});
+
+describe('countPerfectSessions', () => {
+  it('counts sessions where correctTasks === totalTasks in non-challenge mode', () => {
+    const records = [
+      makeRecord({ correctTasks: 10, totalTasks: 10 }),
+      makeRecord({ correctTasks: 8,  totalTasks: 10 }),
+      makeRecord({ correctTasks: 10, totalTasks: 10 }),
+    ];
+    expect(countPerfectSessions(records)).toBe(2);
+  });
+
+  it('excludes challenge sessions', () => {
+    const records = [
+      makeRecord({ correctTasks: 10, totalTasks: 10, difficultyMode: DifficultyMode.CHALLENGE }),
+    ];
+    expect(countPerfectSessions(records)).toBe(0);
+  });
+
+  it('excludes sessions with fewer than 10 tasks', () => {
+    const records = [makeRecord({ correctTasks: 5, totalTasks: 5 })];
+    expect(countPerfectSessions(records)).toBe(0);
+  });
+});
+
+describe('hasAllOperationsPerfect', () => {
+  it('returns false when not all ops have a perfect session', () => {
+    const records = [
+      makeRecord({ operations: [Operation.ADDITION],       correctTasks: 10 }),
+      makeRecord({ operations: [Operation.SUBTRACTION],    correctTasks: 10 }),
+      makeRecord({ operations: [Operation.MULTIPLICATION], correctTasks: 10 }),
+      // division missing
+    ];
+    expect(hasAllOperationsPerfect(records)).toBe(false);
+  });
+
+  it('returns true when all 4 operations have a perfect session', () => {
+    const records = [
+      makeRecord({ operations: [Operation.ADDITION],       correctTasks: 10 }),
+      makeRecord({ operations: [Operation.SUBTRACTION],    correctTasks: 10 }),
+      makeRecord({ operations: [Operation.MULTIPLICATION], correctTasks: 10 }),
+      makeRecord({ operations: [Operation.DIVISION],       correctTasks: 10 }),
+    ];
+    expect(hasAllOperationsPerfect(records)).toBe(true);
+  });
+});
+
+describe('computeNewlyUnlocked', () => {
+  const existing: BadgeStore = {};
+
+  it('unlocks range_100 when record uses RANGE_100', () => {
+    const record = makeRecord({ numberRange: NumberRange.RANGE_100 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('range_100');
+  });
+
+  it('unlocks creative_mode when record is creative', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CREATIVE });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('creative_mode');
+  });
+
+  it('unlocks challenge_no_errors for challenge with 0 errors', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CHALLENGE, errors: 0 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('challenge_no_errors');
+  });
+
+  it('does not unlock challenge_no_errors when errors > 0', () => {
+    const record = makeRecord({ difficultyMode: DifficultyMode.CHALLENGE, errors: 1 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).not.toContain('challenge_no_errors');
+  });
+
+  it('unlocks challenge_level_3 when challengeHighScore reaches level 3 (score=10)', () => {
+    const record = makeRecord();
+    const ids = computeNewlyUnlocked(record, [record], 10, existing);
+    expect(ids).toContain('challenge_level_3');
+    expect(ids).not.toContain('challenge_level_6');
+  });
+
+  it('unlocks challenge_level_6 when challengeHighScore reaches level 6 (score=30)', () => {
+    const record = makeRecord();
+    const ids = computeNewlyUnlocked(record, [record], 30, existing);
+    expect(ids).toContain('challenge_level_3');
+    expect(ids).toContain('challenge_level_6');
+  });
+
+  it('unlocks perfect_1 on first perfect session', () => {
+    const record = makeRecord({ timestamp: daysAgo(0), correctTasks: 10, totalTasks: 10 });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing);
+    expect(ids).toContain('perfect_1');
+  });
+
+  it('does not re-unlock already earned badges', () => {
+    const record = makeRecord({ numberRange: NumberRange.RANGE_100 });
+    const alreadyHas: BadgeStore = { range_100: Date.now() - 1000 };
+    const ids = computeNewlyUnlocked(record, [record], 0, alreadyHas);
+    expect(ids).not.toContain('range_100');
+  });
+
+  it('unlocks streak_3 after 3 consecutive days (via persisted streak)', () => {
+    const record = makeRecord({ timestamp: daysAgo(0) });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing, 3);
+    expect(ids).toContain('streak_3');
+    expect(ids).not.toContain('streak_7');
+  });
+
+  it('unlocks streak_30 when persisted streak is 30 (bypasses 28-day prune)', () => {
+    const record = makeRecord({ timestamp: daysAgo(0) });
+    const ids = computeNewlyUnlocked(record, [record], 0, existing, 30);
+    expect(ids).toContain('streak_3');
+    expect(ids).toContain('streak_7');
+    expect(ids).toContain('streak_30');
+  });
+});
+
+describe('advanceStreak', () => {
+  function isoToday(): string {
+    const d = new Date();
+    return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+  }
+  function isoYesterday(): string {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+  }
+
+  it('starts streak at 1 on first ever play', () => {
+    const result = advanceStreak({ currentStreak: 0, lastPlayedDay: '' });
+    expect(result.currentStreak).toBe(1);
+    expect(result.lastPlayedDay).toBe(isoToday());
+  });
+
+  it('does not increase streak when called twice on same day', () => {
+    const today = isoToday();
+    const result = advanceStreak({ currentStreak: 5, lastPlayedDay: today });
+    expect(result.currentStreak).toBe(5);
+  });
+
+  it('increments streak on consecutive day', () => {
+    const result = advanceStreak({ currentStreak: 4, lastPlayedDay: isoYesterday() });
+    expect(result.currentStreak).toBe(5);
+    expect(result.lastPlayedDay).toBe(isoToday());
+  });
+
+  it('resets streak to 1 after a gap', () => {
+    const result = advanceStreak({ currentStreak: 10, lastPlayedDay: '2020-01-01' });
+    expect(result.currentStreak).toBe(1);
+  });
+});

--- a/hooks/useBadges.ts
+++ b/hooks/useBadges.ts
@@ -4,16 +4,14 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { SessionRecord, Operation, DifficultyMode, NumberRange } from '../types/game';
+import { SessionRecord, Operation, DifficultyMode, NumberRange, StreakData } from '../types/game';
 import {
   getBadges,
   saveBadges,
   getSessionRecords,
   getChallengeHighScore,
   getStreakData,
-  saveStreakData,
   BadgeStore,
-  StreakData,
 } from '../utils/storage';
 import { getChallengeLevelNumber } from '../utils/constants';
 
@@ -116,11 +114,13 @@ function yesterdayISODate(): string {
 
 export function advanceStreak(current: StreakData): StreakData {
   const today = todayISODate();
-  if (current.lastPlayedDay === today) return current;
-  if (current.lastPlayedDay === yesterdayISODate()) {
-    return { currentStreak: current.currentStreak + 1, lastPlayedDay: today };
-  }
-  return { currentStreak: 1, lastPlayedDay: today };
+  if (current.lastPlayedDate === today) return current;
+  const newStreak = current.lastPlayedDate === yesterdayISODate() ? current.currentStreak + 1 : 1;
+  return {
+    currentStreak: newStreak,
+    lastPlayedDate: today,
+    longestStreak: Math.max(newStreak, current.longestStreak),
+  };
 }
 
 // --- hook ---
@@ -145,15 +145,12 @@ export function useBadges() {
       getStreakData(),
     ]);
 
-    const updatedStreak = advanceStreak(streakData);
-    await saveStreakData(updatedStreak);
-
     const newIds = computeNewlyUnlocked(
       record,
       allRecords,
       challengeHighScore,
       existing,
-      updatedStreak.currentStreak,
+      streakData.currentStreak,
     );
     if (newIds.length === 0) return;
 

--- a/hooks/useBadges.ts
+++ b/hooks/useBadges.ts
@@ -1,0 +1,175 @@
+/**
+ * useBadges Hook
+ * Manages achievement badge state, persistence, and unlock logic.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { SessionRecord, Operation, DifficultyMode, NumberRange } from '../types/game';
+import {
+  getBadges,
+  saveBadges,
+  getSessionRecords,
+  getChallengeHighScore,
+  getStreakData,
+  saveStreakData,
+  BadgeStore,
+  StreakData,
+} from '../utils/storage';
+import { getChallengeLevelNumber } from '../utils/constants';
+
+// --- pure badge-condition logic (exported for unit tests) ---
+
+export function getStreakDays(records: SessionRecord[]): number {
+  if (records.length === 0) return 0;
+
+  const uniqueDays = new Set<string>();
+  for (const r of records) {
+    const d = new Date(r.timestamp);
+    uniqueDays.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`);
+  }
+
+  let streak = 0;
+  const cursor = new Date();
+  while (true) {
+    const key = `${cursor.getFullYear()}-${cursor.getMonth()}-${cursor.getDate()}`;
+    if (!uniqueDays.has(key)) break;
+    streak++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
+  return streak;
+}
+
+export function countPerfectSessions(records: SessionRecord[]): number {
+  return records.filter(
+    r =>
+      r.difficultyMode !== DifficultyMode.CHALLENGE &&
+      r.totalTasks >= 10 &&
+      r.correctTasks === r.totalTasks,
+  ).length;
+}
+
+export function hasAllOperationsPerfect(records: SessionRecord[]): boolean {
+  const ops: Operation[] = [
+    Operation.ADDITION,
+    Operation.SUBTRACTION,
+    Operation.MULTIPLICATION,
+    Operation.DIVISION,
+  ];
+  return ops.every(op =>
+    records.some(
+      r =>
+        r.difficultyMode !== DifficultyMode.CHALLENGE &&
+        r.totalTasks >= 10 &&
+        r.correctTasks === r.totalTasks &&
+        r.operations.includes(op),
+    ),
+  );
+}
+
+// streakDays is optional: if provided it overrides the in-records computation,
+// allowing the persistent streak counter to bypass the 28-day session record prune limit.
+export function computeNewlyUnlocked(
+  record: SessionRecord,
+  allRecords: SessionRecord[],
+  challengeHighScore: number,
+  existing: BadgeStore,
+  streakDays?: number,
+): string[] {
+  const result: string[] = [];
+  const unlock = (id: string) => {
+    if (!existing[id]) result.push(id);
+  };
+
+  const streak = streakDays ?? getStreakDays(allRecords);
+  if (streak >= 3)  unlock('streak_3');
+  if (streak >= 7)  unlock('streak_7');
+  if (streak >= 30) unlock('streak_30');
+
+  const perfects = countPerfectSessions(allRecords);
+  if (perfects >= 1) unlock('perfect_1');
+  if (perfects >= 5) unlock('perfect_5');
+  if (hasAllOperationsPerfect(allRecords)) unlock('all_operations');
+
+  const levelNum = getChallengeLevelNumber(challengeHighScore);
+  if (levelNum >= 3) unlock('challenge_level_3');
+  if (levelNum >= 6) unlock('challenge_level_6');
+  if (record.difficultyMode === DifficultyMode.CHALLENGE && record.errors === 0) {
+    unlock('challenge_no_errors');
+  }
+
+  if (record.numberRange === NumberRange.RANGE_100) unlock('range_100');
+  if (record.difficultyMode === DifficultyMode.CREATIVE) unlock('creative_mode');
+
+  return result;
+}
+
+function todayISODate(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+}
+
+function yesterdayISODate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
+}
+
+export function advanceStreak(current: StreakData): StreakData {
+  const today = todayISODate();
+  if (current.lastPlayedDay === today) return current;
+  if (current.lastPlayedDay === yesterdayISODate()) {
+    return { currentStreak: current.currentStreak + 1, lastPlayedDay: today };
+  }
+  return { currentStreak: 1, lastPlayedDay: today };
+}
+
+// --- hook ---
+
+export function useBadges() {
+  const [badges, setBadges] = useState<BadgeStore>({});
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [newlyUnlocked, setNewlyUnlocked] = useState<string[]>([]);
+
+  useEffect(() => {
+    getBadges().then(b => {
+      setBadges(b);
+      setIsLoaded(true);
+    });
+  }, []);
+
+  const checkAndUnlock = useCallback(async (record: SessionRecord) => {
+    const [existing, allRecords, challengeHighScore, streakData] = await Promise.all([
+      getBadges(),
+      getSessionRecords(),
+      getChallengeHighScore(),
+      getStreakData(),
+    ]);
+
+    const updatedStreak = advanceStreak(streakData);
+    await saveStreakData(updatedStreak);
+
+    const newIds = computeNewlyUnlocked(
+      record,
+      allRecords,
+      challengeHighScore,
+      existing,
+      updatedStreak.currentStreak,
+    );
+    if (newIds.length === 0) return;
+
+    const now = Date.now();
+    const updated: BadgeStore = { ...existing };
+    for (const id of newIds) {
+      updated[id] = now;
+    }
+    await saveBadges(updated);
+    setBadges(updated);
+    setNewlyUnlocked(newIds);
+  }, []);
+
+  const clearNewlyUnlocked = useCallback(() => {
+    setNewlyUnlocked([]);
+  }, []);
+
+  return { badges, isLoaded, newlyUnlocked, checkAndUnlock, clearNewlyUnlocked };
+}

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -3,8 +3,8 @@
  * Manages all game state and logic
  */
 
-import { useState, useMemo } from 'react';
-import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord } from '../types/game';
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { GameMode, Operation, AnswerMode, DifficultyMode, GameState, NumberRange, ChallengeState, SessionRecord, TaskStat } from '../types/game';
 import { TOTAL_TASKS, MAX_CHOICE_GENERATION_ATTEMPTS, MAX_RANDOM_ANSWER, CHALLENGE_MAX_LIVES, getChallengeLevel, getChallengeLevelNumber } from '../utils/constants';
 
 interface UseGameLogicProps {
@@ -17,6 +17,8 @@ interface UseGameLogicProps {
   numberRange: NumberRange;
   challengeHighScore?: number;
   onChallengeHighScoreChange?: (score: number) => void;
+  taskStats?: TaskStat[];
+  onTaskResult?: (num1: number, num2: number, operation: Operation, isCorrect: boolean) => void;
 }
 
 /**
@@ -141,7 +143,13 @@ export function useGameLogic({
   numberRange,
   challengeHighScore = 0,
   onChallengeHighScoreChange,
+  taskStats,
+  onTaskResult,
 }: UseGameLogicProps) {
+  const taskStatsRef = useRef<TaskStat[]>(taskStats ?? []);
+  useEffect(() => {
+    taskStatsRef.current = taskStats ?? [];
+  }, [taskStats]);
   // Helper: Get max number based on number range
   const getMaxNumber = (range: NumberRange = numberRange) => {
     switch (range) {
@@ -237,14 +245,50 @@ export function useGameLogic({
   };
 
   // Generate a new question with proper number generation for each operation
-  const generateQuestion = (mode: GameMode = gameState.gameMode, operationSet: Set<Operation> = gameState.selectedOperations, overrideMaxNumber?: number) => {
-    // Pick a random operation from selected operations
-    const operations = Array.from(operationSet);
-    const selectedOp = operations[Math.floor(Math.random() * operations.length)];
+  const generateQuestion = (mode: GameMode = gameState.gameMode, operationSet: Set<Operation> = gameState.selectedOperations, overrideMaxNumber?: number, difficultyOverride?: DifficultyMode) => {
+    const effectiveDifficulty = difficultyOverride ?? gameState.difficultyMode;
 
     let newNum1: number;
     let newNum2: number;
     const effectiveMaxNumber = overrideMaxNumber ?? maxNumber;
+
+    // In PRACTICE mode: 75% chance to pick a weak task
+    let selectedOp: Operation;
+    if (effectiveDifficulty === DifficultyMode.PRACTICE) {
+      const maxNum = effectiveMaxNumber;
+      const weak = taskStatsRef.current.filter(s => {
+        const total = s.correctCount + s.errorCount;
+        if (total < 3 || s.errorCount / total <= 0.3) return false;
+        if (!operationSet.has(s.operation)) return false;
+        // Ensure stored task numbers are valid for current range
+        if (s.operation === Operation.ADDITION) return s.num1 + s.num2 <= maxNum;
+        if (s.operation === Operation.MULTIPLICATION) return s.num1 * s.num2 <= maxNum;
+        return s.num1 <= maxNum && s.num2 <= maxNum;
+      });
+      if (weak.length > 0 && Math.random() < 0.75) {
+        const task = weak[Math.floor(Math.random() * weak.length)];
+        newNum1 = task.num1;
+        newNum2 = task.num2;
+        selectedOp = task.operation;
+        setGameState((prev) => ({
+          ...prev,
+          num1: newNum1,
+          num2: newNum2,
+          operation: selectedOp,
+          userAnswer: '',
+          questionPart: 2,
+          answerMode: AnswerMode.INPUT,
+          lastAnswerCorrect: null,
+          isAnswerChecked: false,
+          selectedChoice: null,
+        }));
+        return;
+      }
+    }
+
+    // Normal random generation
+    const operations = Array.from(operationSet);
+    selectedOp = operations[Math.floor(Math.random() * operations.length)];
 
     // Generate appropriate numbers based on operation
     // IMPORTANT: ALL numbers (operands AND results) must be within numberRange
@@ -327,7 +371,7 @@ export function useGameLogic({
     // In CREATIVE and CHALLENGE modes, randomize answer mode each question
     // NUMBER_SEQUENCE only available when asking for result (questionPart === 2)
     let newAnswerMode = gameState.answerMode;
-    if (gameState.difficultyMode === DifficultyMode.CREATIVE || gameState.difficultyMode === DifficultyMode.CHALLENGE) {
+    if (effectiveDifficulty === DifficultyMode.CREATIVE || effectiveDifficulty === DifficultyMode.CHALLENGE) {
       const availableModes =
         newQuestionPart === 2
           ? [AnswerMode.INPUT, AnswerMode.MULTIPLE_CHOICE, AnswerMode.NUMBER_SEQUENCE]
@@ -404,6 +448,8 @@ export function useGameLogic({
     } else {
       isCorrect = gameState.selectedChoice === correctAnswer;
     }
+
+    onTaskResult?.(gameState.num1, gameState.num2, gameState.operation, isCorrect);
 
     const newScore = isCorrect ? gameState.score + 1 : gameState.score;
     const challengeGameOver =
@@ -661,8 +707,8 @@ export function useGameLogic({
       return;
     }
 
-    if (newMode === DifficultyMode.SIMPLE) {
-      // Simple: Normal tasks with keypad input
+    if (newMode === DifficultyMode.SIMPLE || newMode === DifficultyMode.PRACTICE) {
+      // Simple / Practice: Normal tasks with keypad input
       newGameMode = GameMode.NORMAL;
       newAnswerMode = AnswerMode.INPUT;
     } else {
@@ -686,7 +732,7 @@ export function useGameLogic({
       selectedChoice: null,
       challengeState: undefined,
     }));
-    setTimeout(() => generateQuestion(newGameMode), 0);
+    setTimeout(() => generateQuestion(newGameMode, undefined, undefined, newMode), 0);
   };
 
   // Generate multiple choice options

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -17,8 +17,10 @@ export interface TranslationStrings {
   difficultyMode: string;
   simpleMode: string;
   creativeMode: string;
+  practiceMode: string;
   simpleModeInfo: string;
   creativeModeInfo: string;
+  practiceModeInfo: string;
   gameMode: string;
   operation: string;
   addition: string;
@@ -94,6 +96,8 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  parentWeakTasks: string;
+  parentWeakTasksEmpty: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -109,8 +113,10 @@ export const translations: Record<Language, TranslationStrings> = {
     difficultyMode: 'DIFFICULTY',
     simpleMode: 'Simple',
     creativeMode: 'Creative',
+    practiceMode: 'Practice',
     simpleModeInfo: 'Enter the result via keypad',
     creativeModeInfo: 'Random input methods and question types',
+    practiceModeInfo: 'Practicing your difficult tasks right now!',
     gameMode: 'GAME MODE',
     operation: 'OPERATION',
     addition: 'Addition',
@@ -186,6 +192,8 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    parentWeakTasks: 'Weak Areas (Top 5)',
+    parentWeakTasksEmpty: 'No weak areas identified yet.',
   },
   de: {
     // Settings Menu
@@ -199,8 +207,10 @@ export const translations: Record<Language, TranslationStrings> = {
     difficultyMode: 'SCHWIERIGKEIT',
     simpleMode: 'Einfach',
     creativeMode: 'Kreativ',
+    practiceMode: 'Übung',
     simpleModeInfo: 'Das Ergebnis wird über die Tastatur eingegeben',
     creativeModeInfo: 'Zufällige Eingabemethoden und Fragetypen',
+    practiceModeInfo: 'Du übst gerade deine schwierigen Aufgaben!',
     gameMode: 'SPIELMODUS',
     operation: 'RECHENART',
     addition: 'Addition',
@@ -276,5 +286,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    parentWeakTasks: 'Schwachstellen (Top 5)',
+    parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
   },
 };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -132,6 +132,21 @@ export interface TranslationStrings {
   badgeRange100Desc: string;
   badgeCreativeModeDesc: string;
   badgeNewUnlocked: string;
+  // Onboarding
+  onboardingWelcomeTitle: string;
+  onboardingWelcomeBody: string;
+  onboardingDemoTitle: string;
+  onboardingDemoTooltip: string;
+  onboardingSettingsTitle: string;
+  onboardingSettingsBody: string;
+  onboardingReadyTitle: string;
+  onboardingReadyBody: string;
+  onboardingDemoRetry: string;
+  onboardingSettingsLabel: string;
+  onboardingNext: string;
+  onboardingStart: string;
+  onboardingSkip: string;
+  resetOnboarding: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -262,6 +277,21 @@ export const translations: Record<Language, TranslationStrings> = {
     badgeRange100Desc: 'Played with numbers up to 100',
     badgeCreativeModeDesc: 'Played in Creative Mode',
     badgeNewUnlocked: 'New badge unlocked!',
+    // Onboarding
+    onboardingWelcomeTitle: 'Welcome to 1×1 Trainer!',
+    onboardingWelcomeBody: 'Practice multiplication, division, addition and subtraction — fun and easy!',
+    onboardingDemoTitle: 'Try it out!',
+    onboardingDemoTooltip: 'Enter your answer here',
+    onboardingSettingsTitle: 'Everything Adjustable',
+    onboardingSettingsBody: 'Tap the menu button to change the operation, difficulty and number range.',
+    onboardingReadyTitle: "You're ready!",
+    onboardingReadyBody: 'Have fun practicing!',
+    onboardingDemoRetry: 'Not quite — try again!',
+    onboardingSettingsLabel: '↑ Settings',
+    onboardingNext: 'Next',
+    onboardingStart: 'Start',
+    onboardingSkip: 'Skip',
+    resetOnboarding: 'Restart tutorial',
   },
   de: {
     // Settings Menu
@@ -390,5 +420,20 @@ export const translations: Record<Language, TranslationStrings> = {
     badgeRange100Desc: 'Mit Zahlen bis 100 gespielt',
     badgeCreativeModeDesc: 'Im Kreativmodus gespielt',
     badgeNewUnlocked: 'Neues Abzeichen freigeschaltet!',
+    // Onboarding
+    onboardingWelcomeTitle: 'Willkommen beim 1×1 Trainer!',
+    onboardingWelcomeBody: 'Übe Multiplikation, Division, Addition und Subtraktion – Spaß und einfach!',
+    onboardingDemoTitle: 'Probiere es aus!',
+    onboardingDemoTooltip: 'Gib deine Antwort hier ein',
+    onboardingSettingsTitle: 'Alles einstellbar',
+    onboardingSettingsBody: 'Tippe auf den Menü-Button, um Rechenart, Schwierigkeit und Zahlenbereich zu ändern.',
+    onboardingReadyTitle: 'Du bist bereit!',
+    onboardingReadyBody: 'Viel Spaß beim Üben!',
+    onboardingDemoRetry: 'Nicht ganz – tippe nochmal!',
+    onboardingSettingsLabel: '↑ Einstellungen',
+    onboardingNext: 'Weiter',
+    onboardingStart: 'Loslegen',
+    onboardingSkip: 'Überspringen',
+    resetOnboarding: 'Tutorial zurücksetzen',
   },
 };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -97,6 +97,12 @@ export interface TranslationStrings {
   parentYesterday: string;
   parentCorrect: string;
   parentErrors: string;
+  parentCurrentStreak: string;
+  parentLongestStreak: string;
+  parentStreakDays: string;
+  streakWarningTitle: string;
+  streakWarningMessage: string;
+  streakWarningButton: string;
   parentWeakTasks: string;
   parentWeakTasksEmpty: string;
   // Badges
@@ -242,6 +248,12 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Yesterday',
     parentCorrect: 'Correct',
     parentErrors: 'Errors',
+    parentCurrentStreak: 'Current Streak',
+    parentLongestStreak: 'Longest Streak',
+    parentStreakDays: 'Days',
+    streakWarningTitle: 'Don\'t break your streak!',
+    streakWarningMessage: 'Play a quick round today to keep your {days}-day streak going!',
+    streakWarningButton: 'Let\'s go!',
     parentWeakTasks: 'Weak Areas (Top 5)',
     parentWeakTasksEmpty: 'No weak areas identified yet.',
     // Badges
@@ -385,6 +397,12 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
+    parentCurrentStreak: 'Aktueller Streak',
+    parentLongestStreak: 'Längster Streak',
+    parentStreakDays: 'Tage',
+    streakWarningTitle: 'Brich deinen Streak nicht!',
+    streakWarningMessage: 'Spiel heute eine Runde, um deinen {days}-Tage-Streak zu halten!',
+    streakWarningButton: 'Los geht\'s!',
     parentWeakTasks: 'Schwachstellen (Top 5)',
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
     // Badges

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -61,6 +61,7 @@ export interface TranslationStrings {
   newRound: string;
   continueGame: string;
   encouragement: string; // Motivational text shown below the numpad during input
+  practiceModeFeedback: string; // Shown instead of encouragement in PRACTICE mode
   // Results Modal
   great: string;
   youSolved: string;
@@ -214,6 +215,7 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Settings',
     ok: 'OK',
     encouragement: 'You can do it! 💪',
+    practiceModeFeedback: 'Practising your difficult tasks!',
     // Parent Dashboard
     parentDashboard: 'Parent Dashboard',
     parentDashboardMenu: 'Parent Dashboard (Beta)',
@@ -341,6 +343,7 @@ export const translations: Record<Language, TranslationStrings> = {
     settings: 'Einstellungen',
     ok: 'OK',
     encouragement: 'Du schaffst das! 💪',
+    practiceModeFeedback: 'Du übst deine schwierigen Aufgaben!',
     // Parent Dashboard
     parentDashboard: 'Eltern-Dashboard',
     parentDashboardMenu: 'Eltern-Dashboard (Beta)',

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -98,6 +98,39 @@ export interface TranslationStrings {
   parentErrors: string;
   parentWeakTasks: string;
   parentWeakTasksEmpty: string;
+  // Badges
+  badges: string;
+  badgesMenu: string;
+  badgesSubtitle: string;
+  badgeLocked: string;
+  badgeUnlockedOn: string;
+  badgeCategoryStreak: string;
+  badgeCategoryPerformance: string;
+  badgeCategoryChallenge: string;
+  badgeCategoryExplorer: string;
+  badgeStreak3Name: string;
+  badgeStreak7Name: string;
+  badgeStreak30Name: string;
+  badgePerfect1Name: string;
+  badgePerfect5Name: string;
+  badgeAllOpsName: string;
+  badgeChallengeLevel3Name: string;
+  badgeChallengeLevel6Name: string;
+  badgeChallengeNoErrorsName: string;
+  badgeRange100Name: string;
+  badgeCreativeModeName: string;
+  badgeStreak3Desc: string;
+  badgeStreak7Desc: string;
+  badgeStreak30Desc: string;
+  badgePerfect1Desc: string;
+  badgePerfect5Desc: string;
+  badgeAllOpsDesc: string;
+  badgeChallengeLevel3Desc: string;
+  badgeChallengeLevel6Desc: string;
+  badgeChallengeNoErrorsDesc: string;
+  badgeRange100Desc: string;
+  badgeCreativeModeDesc: string;
+  badgeNewUnlocked: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -194,6 +227,39 @@ export const translations: Record<Language, TranslationStrings> = {
     parentErrors: 'Errors',
     parentWeakTasks: 'Weak Areas (Top 5)',
     parentWeakTasksEmpty: 'No weak areas identified yet.',
+    // Badges
+    badges: 'Achievements',
+    badgesMenu: 'Achievements',
+    badgesSubtitle: 'Collect badges by reaching milestones',
+    badgeLocked: 'Locked',
+    badgeUnlockedOn: 'Unlocked',
+    badgeCategoryStreak: 'Streaks',
+    badgeCategoryPerformance: 'Performance',
+    badgeCategoryChallenge: 'Challenge',
+    badgeCategoryExplorer: 'Explorer',
+    badgeStreak3Name: 'On Fire!',
+    badgeStreak7Name: 'Hot Streak',
+    badgeStreak30Name: 'Unstoppable',
+    badgePerfect1Name: 'Perfectionist',
+    badgePerfect5Name: 'Star Player',
+    badgeAllOpsName: 'All-Rounder',
+    badgeChallengeLevel3Name: 'Rising Star',
+    badgeChallengeLevel6Name: 'Champion',
+    badgeChallengeNoErrorsName: 'Flawless',
+    badgeRange100Name: 'Big Numbers',
+    badgeCreativeModeName: 'Creative Mind',
+    badgeStreak3Desc: 'Played 3 days in a row',
+    badgeStreak7Desc: 'Played 7 days in a row',
+    badgeStreak30Desc: 'Played 30 days in a row',
+    badgePerfect1Desc: 'First perfect round (10/10)',
+    badgePerfect5Desc: '5 perfect rounds',
+    badgeAllOpsDesc: 'Perfect round with all 4 operations',
+    badgeChallengeLevel3Desc: 'Reached Challenge Level 3',
+    badgeChallengeLevel6Desc: 'Reached Challenge Level 6',
+    badgeChallengeNoErrorsDesc: 'Completed a challenge without errors',
+    badgeRange100Desc: 'Played with numbers up to 100',
+    badgeCreativeModeDesc: 'Played in Creative Mode',
+    badgeNewUnlocked: 'New badge unlocked!',
   },
   de: {
     // Settings Menu
@@ -288,5 +354,38 @@ export const translations: Record<Language, TranslationStrings> = {
     parentErrors: 'Fehler',
     parentWeakTasks: 'Schwachstellen (Top 5)',
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
+    // Badges
+    badges: 'Abzeichen',
+    badgesMenu: 'Abzeichen',
+    badgesSubtitle: 'Sammle Abzeichen durch Meilensteine',
+    badgeLocked: 'Gesperrt',
+    badgeUnlockedOn: 'Freigeschaltet',
+    badgeCategoryStreak: 'Serien',
+    badgeCategoryPerformance: 'Leistung',
+    badgeCategoryChallenge: 'Herausforderung',
+    badgeCategoryExplorer: 'Entdecker',
+    badgeStreak3Name: 'Auf Kurs!',
+    badgeStreak7Name: 'Heiße Serie',
+    badgeStreak30Name: 'Unaufhaltsam',
+    badgePerfect1Name: 'Perfektionist',
+    badgePerfect5Name: 'Superstar',
+    badgeAllOpsName: 'Allrounder',
+    badgeChallengeLevel3Name: 'Aufsteiger',
+    badgeChallengeLevel6Name: 'Champion',
+    badgeChallengeNoErrorsName: 'Fehlerlos',
+    badgeRange100Name: 'Große Zahlen',
+    badgeCreativeModeName: 'Kreativkopf',
+    badgeStreak3Desc: '3 Tage in Folge gespielt',
+    badgeStreak7Desc: '7 Tage in Folge gespielt',
+    badgeStreak30Desc: '30 Tage in Folge gespielt',
+    badgePerfect1Desc: 'Erste perfekte Runde (10/10)',
+    badgePerfect5Desc: '5 perfekte Runden',
+    badgeAllOpsDesc: 'Perfekte Runde mit allen 4 Rechenarten',
+    badgeChallengeLevel3Desc: 'Herausforderung Stufe 3 erreicht',
+    badgeChallengeLevel6Desc: 'Herausforderung Stufe 6 erreicht',
+    badgeChallengeNoErrorsDesc: 'Herausforderung ohne Fehler abgeschlossen',
+    badgeRange100Desc: 'Mit Zahlen bis 100 gespielt',
+    badgeCreativeModeDesc: 'Im Kreativmodus gespielt',
+    badgeNewUnlocked: 'Neues Abzeichen freigeschaltet!',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -89,6 +89,11 @@ export interface SessionRecord {
   numberRange: NumberRange;
 }
 
+export interface AchievementBadge {
+  id: string;
+  unlockedAt: number;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/types/game.ts
+++ b/types/game.ts
@@ -26,6 +26,7 @@ export enum DifficultyMode {
   SIMPLE = 'SIMPLE',
   CREATIVE = 'CREATIVE',
   CHALLENGE = 'CHALLENGE',
+  PRACTICE = 'PRACTICE',
 }
 
 export enum NumberRange {
@@ -65,6 +66,15 @@ export interface GameState {
   totalSolvedTasks: number; // Track total tasks solved for motivation message
   selectedChoice: number | null; // For multiple choice and number sequence modes
   challengeState?: ChallengeState; // Challenge mode state
+}
+
+export interface TaskStat {
+  num1: number;
+  num2: number;
+  operation: Operation;
+  correctCount: number;
+  errorCount: number;
+  lastSeen: string; // ISO date
 }
 
 export interface SessionRecord {

--- a/types/game.ts
+++ b/types/game.ts
@@ -94,6 +94,12 @@ export interface AchievementBadge {
   unlockedAt: number;
 }
 
+export interface StreakData {
+  currentStreak: number;
+  lastPlayedDate: string; // YYYY-MM-DD (local date)
+  longestStreak: number;
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -24,7 +24,31 @@ export const STORAGE_KEYS = {
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
   TASK_STATS: 'app-task-stats',
+  BADGES: 'app-badges',
+  STREAK: 'app-streak',
 } as const;
+
+export type BadgeCategory = 'streak' | 'performance' | 'challenge' | 'explorer';
+
+export interface BadgeDefinition {
+  id: string;
+  icon: string;
+  category: BadgeCategory;
+}
+
+export const BADGE_DEFINITIONS: BadgeDefinition[] = [
+  { id: 'streak_3',             icon: '🔥',    category: 'streak' },
+  { id: 'streak_7',             icon: '🔥🔥',  category: 'streak' },
+  { id: 'streak_30',            icon: '🔥🔥🔥', category: 'streak' },
+  { id: 'perfect_1',            icon: '⭐',    category: 'performance' },
+  { id: 'perfect_5',            icon: '🌟',    category: 'performance' },
+  { id: 'all_operations',       icon: '💎',    category: 'performance' },
+  { id: 'challenge_level_3',    icon: '🏆',    category: 'challenge' },
+  { id: 'challenge_level_6',    icon: '👑',    category: 'challenge' },
+  { id: 'challenge_no_errors',  icon: '❤️',    category: 'challenge' },
+  { id: 'range_100',            icon: '🔢',    category: 'explorer' },
+  { id: 'creative_mode',        icon: '🎨',    category: 'explorer' },
+];
 
 // Challenge Mode Configuration
 export const CHALLENGE_MAX_LIVES = 3;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  ONBOARDING_DONE: 'app-onboarding-done',
   TASK_STATS: 'app-task-stats',
   BADGES: 'app-badges',
   STREAK: 'app-streak',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const STORAGE_KEYS = {
   NUMBER_RANGE: 'app-number-range',
   CHALLENGE_HIGHSCORE: 'app-challenge-highscore',
   PARENT_STATS: 'app-parent-stats',
+  TASK_STATS: 'app-task-stats',
 } as const;
 
 // Challenge Mode Configuration

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,6 +23,9 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getOnboardingDone,
+  setOnboardingDone,
+  resetOnboarding,
   getTaskStats,
   saveTaskStats,
   recordTaskResult,
@@ -643,5 +646,41 @@ describe('getWeakTasks', () => {
     const stats = [makeStat(7, 8, 1, 1)]; // 50% error, 2 attempts
     expect(getWeakTasks(stats, 2, 0.4)).toHaveLength(1);
     expect(getWeakTasks(stats, 3, 0.4)).toHaveLength(0);
+  });
+});
+
+describe('storage.ts - Onboarding helpers', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('getOnboardingDone returns false when key is absent', async () => {
+    expect(await getOnboardingDone()).toBe(false);
+  });
+
+  it('getOnboardingDone returns false when value is "pending"', async () => {
+    mockStore['app-onboarding-done'] = 'pending';
+    expect(await getOnboardingDone()).toBe(false);
+  });
+
+  it('setOnboardingDone persists true and getOnboardingDone returns true', async () => {
+    await setOnboardingDone();
+    expect(mockStore['app-onboarding-done']).toBe('true');
+    expect(await getOnboardingDone()).toBe(true);
+  });
+
+  it('resetOnboarding stores "pending" so getOnboardingDone returns false', async () => {
+    await setOnboardingDone();
+    await resetOnboarding();
+    expect(mockStore['app-onboarding-done']).toBe('pending');
+    expect(await getOnboardingDone()).toBe(false);
   });
 });

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,8 +23,12 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getTaskStats,
+  saveTaskStats,
+  recordTaskResult,
+  getWeakTasks,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -535,5 +539,109 @@ describe('Session Records Storage', () => {
     const [retrieved] = await getSessionRecords();
     expect(retrieved.errorRate).toBe(0.3);
     expect(retrieved.errors).toBe(3);
+  });
+});
+
+describe('TaskStat Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return empty array when nothing stored', async () => {
+    expect(await getTaskStats()).toEqual([]);
+  });
+
+  it('should return empty array for corrupted JSON', async () => {
+    mockStore['app-task-stats'] = '{invalid}';
+    expect(await getTaskStats()).toEqual([]);
+  });
+
+  it('should filter out invalid entries on read', async () => {
+    const bad = { num1: 'x', num2: 2, operation: 'MULTIPLICATION', correctCount: 1, errorCount: 0, lastSeen: 'now' };
+    const good: TaskStat = { num1: 3, num2: 4, operation: Operation.MULTIPLICATION, correctCount: 2, errorCount: 1, lastSeen: new Date().toISOString() };
+    mockStore['app-task-stats'] = JSON.stringify([bad, good]);
+    const result = await getTaskStats();
+    expect(result).toHaveLength(1);
+    expect(result[0].num1).toBe(3);
+  });
+
+  it('should save and retrieve task stats', async () => {
+    const stat: TaskStat = { num1: 7, num2: 8, operation: Operation.MULTIPLICATION, correctCount: 1, errorCount: 2, lastSeen: '2026-01-01T00:00:00.000Z' };
+    await saveTaskStats([stat]);
+    const result = await getTaskStats();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(stat);
+  });
+
+  it('recordTaskResult creates new entry for unknown task', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({ num1: 3, num2: 4, operation: Operation.MULTIPLICATION, correctCount: 0, errorCount: 1 });
+  });
+
+  it('recordTaskResult increments existing entry', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, true);
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(1);
+    expect(stats[0].correctCount).toBe(1);
+    expect(stats[0].errorCount).toBe(2);
+  });
+
+  it('recordTaskResult keeps separate entries for different tasks', async () => {
+    await recordTaskResult(3, 4, Operation.MULTIPLICATION, false);
+    await recordTaskResult(3, 5, Operation.MULTIPLICATION, true);
+    const stats = await getTaskStats();
+    expect(stats).toHaveLength(2);
+  });
+});
+
+describe('getWeakTasks', () => {
+  const makeStat = (num1: number, num2: number, correct: number, error: number): TaskStat => ({
+    num1, num2, operation: Operation.MULTIPLICATION,
+    correctCount: correct, errorCount: error,
+    lastSeen: new Date().toISOString(),
+  });
+
+  it('returns only tasks with > 30% error rate and >= 3 attempts', () => {
+    const stats = [
+      makeStat(7, 8, 0, 3),  // 100% error, 3 attempts → weak
+      makeStat(3, 4, 8, 2),  // 20% error → not weak
+      makeStat(6, 7, 1, 2),  // 67% error, only 3 attempts → weak
+      makeStat(9, 6, 5, 0),  // 0% error → not weak
+      makeStat(2, 3, 1, 1),  // 50% error, 2 attempts → not enough attempts
+    ];
+    const result = getWeakTasks(stats);
+    expect(result).toHaveLength(2);
+    expect(result.map(s => `${s.num1}×${s.num2}`)).toContain('7×8');
+    expect(result.map(s => `${s.num1}×${s.num2}`)).toContain('6×7');
+  });
+
+  it('sorts by error rate descending', () => {
+    const stats = [
+      makeStat(6, 7, 1, 2),  // 67%
+      makeStat(7, 8, 0, 3),  // 100%
+      makeStat(5, 6, 1, 4),  // 80%
+    ];
+    const result = getWeakTasks(stats);
+    expect(result[0]).toMatchObject({ num1: 7, num2: 8 }); // 100%
+    expect(result[1]).toMatchObject({ num1: 5, num2: 6 }); // 80%
+    expect(result[2]).toMatchObject({ num1: 6, num2: 7 }); // 67%
+  });
+
+  it('respects custom minAttempts and minErrorRate', () => {
+    const stats = [makeStat(7, 8, 1, 1)]; // 50% error, 2 attempts
+    expect(getWeakTasks(stats, 2, 0.4)).toHaveLength(1);
+    expect(getWeakTasks(stats, 3, 0.4)).toHaveLength(0);
   });
 });

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -23,6 +23,10 @@ import {
   getChallengeHighScore,
   saveSessionRecord,
   getSessionRecords,
+  getStreakData,
+  saveStreakData,
+  updateStreakAfterSession,
+  getLocalDateString,
   getOnboardingDone,
   setOnboardingDone,
   resetOnboarding,
@@ -31,7 +35,7 @@ import {
   recordTaskResult,
   getWeakTasks,
 } from './storage';
-import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
+import { Operation, ThemeMode, Language, NumberRange, DifficultyMode, SessionRecord, StreakData, TaskStat } from '../types/game';
 
 // Mock react-native Platform
 jest.mock('react-native', () => ({
@@ -545,6 +549,23 @@ describe('Session Records Storage', () => {
   });
 });
 
+describe('getLocalDateString()', () => {
+  it('should return YYYY-MM-DD format for today', () => {
+    const result = getLocalDateString();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('should return YYYY-MM-DD for a given date', () => {
+    const d = new Date(2024, 0, 5); // Jan 5, 2024
+    expect(getLocalDateString(d)).toBe('2024-01-05');
+  });
+
+  it('should pad month and day with leading zeros', () => {
+    const d = new Date(2024, 2, 9); // Mar 9, 2024
+    expect(getLocalDateString(d)).toBe('2024-03-09');
+  });
+});
+
 describe('TaskStat Storage', () => {
   let mockStore: { [key: string]: string };
 
@@ -618,11 +639,11 @@ describe('getWeakTasks', () => {
 
   it('returns only tasks with > 30% error rate and >= 3 attempts', () => {
     const stats = [
-      makeStat(7, 8, 0, 3),  // 100% error, 3 attempts → weak
-      makeStat(3, 4, 8, 2),  // 20% error → not weak
-      makeStat(6, 7, 1, 2),  // 67% error, only 3 attempts → weak
-      makeStat(9, 6, 5, 0),  // 0% error → not weak
-      makeStat(2, 3, 1, 1),  // 50% error, 2 attempts → not enough attempts
+      makeStat(7, 8, 0, 3),
+      makeStat(3, 4, 8, 2),
+      makeStat(6, 7, 1, 2),
+      makeStat(9, 6, 5, 0),
+      makeStat(2, 3, 1, 1),
     ];
     const result = getWeakTasks(stats);
     expect(result).toHaveLength(2);
@@ -632,18 +653,18 @@ describe('getWeakTasks', () => {
 
   it('sorts by error rate descending', () => {
     const stats = [
-      makeStat(6, 7, 1, 2),  // 67%
-      makeStat(7, 8, 0, 3),  // 100%
-      makeStat(5, 6, 1, 4),  // 80%
+      makeStat(6, 7, 1, 2),
+      makeStat(7, 8, 0, 3),
+      makeStat(5, 6, 1, 4),
     ];
     const result = getWeakTasks(stats);
-    expect(result[0]).toMatchObject({ num1: 7, num2: 8 }); // 100%
-    expect(result[1]).toMatchObject({ num1: 5, num2: 6 }); // 80%
-    expect(result[2]).toMatchObject({ num1: 6, num2: 7 }); // 67%
+    expect(result[0]).toMatchObject({ num1: 7, num2: 8 });
+    expect(result[1]).toMatchObject({ num1: 5, num2: 6 });
+    expect(result[2]).toMatchObject({ num1: 6, num2: 7 });
   });
 
   it('respects custom minAttempts and minErrorRate', () => {
-    const stats = [makeStat(7, 8, 1, 1)]; // 50% error, 2 attempts
+    const stats = [makeStat(7, 8, 1, 1)];
     expect(getWeakTasks(stats, 2, 0.4)).toHaveLength(1);
     expect(getWeakTasks(stats, 3, 0.4)).toHaveLength(0);
   });
@@ -682,5 +703,167 @@ describe('storage.ts - Onboarding helpers', () => {
     await resetOnboarding();
     expect(mockStore['app-onboarding-done']).toBe('pending');
     expect(await getOnboardingDone()).toBe(false);
+  });
+});
+
+describe('Streak Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns default when nothing stored', async () => {
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('returns saved streak data', async () => {
+    const data: StreakData = { currentStreak: 5, lastPlayedDate: '2024-06-15', longestStreak: 10 };
+    await saveStreakData(data);
+    const result = await getStreakData();
+    expect(result).toEqual(data);
+  });
+
+  it('returns default for corrupted JSON', async () => {
+    mockStore['app-streak'] = '{invalid}';
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('rejects null currentStreak', async () => {
+    mockStore['app-streak'] = '{"currentStreak":null,"lastPlayedDate":"2024-01-01","longestStreak":0}';
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('rejects negative currentStreak', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: -1, lastPlayedDate: '2024-01-01', longestStreak: 0 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('rejects non-integer streak value', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 1.5, lastPlayedDate: '2024-01-01', longestStreak: 3 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('rejects invalid date format', async () => {
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 1, lastPlayedDate: '01-01-2024', longestStreak: 1 });
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+
+  it('rejects null longestStreak', async () => {
+    mockStore['app-streak'] = '{"currentStreak":1,"lastPlayedDate":"2024-01-01","longestStreak":null}';
+    const result = await getStreakData();
+    expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
+  });
+});
+
+describe('updateStreakAfterSession()', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => { mockStore[key] = value; });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('should start streak at 1 for first session', async () => {
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.lastPlayedDate).toBe(getLocalDateString());
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it('should not change streak when already played today', async () => {
+    const today = getLocalDateString();
+    mockStore['app-streak'] = JSON.stringify({ currentStreak: 3, lastPlayedDate: today, longestStreak: 5 });
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it('should increment streak for consecutive day', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15); // Jun 15
+    jest.setSystemTime(today);
+
+    const yesterday = new Date(2024, 5, 14);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 4,
+      lastPlayedDate: getLocalDateString(yesterday),
+      longestStreak: 4,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(5);
+    expect(result.longestStreak).toBe(5);
+    expect(result.lastPlayedDate).toBe('2024-06-15');
+  });
+
+  it('should reset streak to 1 after a gap', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const twoDaysAgo = new Date(2024, 5, 13);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 10,
+      lastPlayedDate: getLocalDateString(twoDaysAgo),
+      longestStreak: 10,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(10);
+    expect(result.lastPlayedDate).toBe('2024-06-15');
+  });
+
+  it('should update longestStreak when new streak exceeds it', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const yesterday = new Date(2024, 5, 14);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 7,
+      lastPlayedDate: getLocalDateString(yesterday),
+      longestStreak: 7,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(8);
+    expect(result.longestStreak).toBe(8);
+  });
+
+  it('should not decrease longestStreak after reset', async () => {
+    jest.useFakeTimers();
+    const today = new Date(2024, 5, 15);
+    jest.setSystemTime(today);
+
+    const threeDaysAgo = new Date(2024, 5, 12);
+    mockStore['app-streak'] = JSON.stringify({
+      currentStreak: 3,
+      lastPlayedDate: getLocalDateString(threeDaysAgo),
+      longestStreak: 15,
+    });
+
+    const result = await updateStreakAfterSession();
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(15);
   });
 });

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat, StreakData } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -209,7 +209,6 @@ export const setOnboardingDone = async (): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'true');
 };
 
-// Stores 'pending' so migration logic is skipped on next launch
 export const resetOnboarding = async (): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'pending');
 };
@@ -312,30 +311,70 @@ export const saveBadges = async (badges: BadgeStore): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.BADGES, JSON.stringify(badges));
 };
 
-// Persistent streak counter – decoupled from the 28-day session record window
-export interface StreakData {
-  currentStreak: number;
-  lastPlayedDay: string; // YYYY-MM-DD
+// Streak storage helpers
+
+export function getLocalDateString(date?: Date): string {
+  const d = date ?? new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+const STREAK_DEFAULT: StreakData = { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
+
+function isNonNegInt(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && Number.isInteger(v);
+}
+
+function isLocalDateString(v: unknown): v is string {
+  return typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v);
 }
 
 export const getStreakData = async (): Promise<StreakData> => {
   const value = await getStorageItem(STORAGE_KEYS.STREAK);
-  if (!value) return { currentStreak: 0, lastPlayedDay: '' };
+  if (!value) return STREAK_DEFAULT;
   try {
     const parsed = JSON.parse(value);
     if (
-      typeof parsed === 'object' && parsed !== null &&
-      typeof parsed.currentStreak === 'number' &&
-      typeof parsed.lastPlayedDay === 'string'
+      isNonNegInt(parsed.currentStreak) &&
+      isLocalDateString(parsed.lastPlayedDate) &&
+      isNonNegInt(parsed.longestStreak)
     ) {
       return parsed as StreakData;
     }
-  } catch { /* ignore */ }
-  return { currentStreak: 0, lastPlayedDay: '' };
+  } catch {
+    // fall through
+  }
+  return STREAK_DEFAULT;
 };
 
 export const saveStreakData = async (data: StreakData): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.STREAK, JSON.stringify(data));
+};
+
+export const updateStreakAfterSession = async (): Promise<StreakData> => {
+  const today = getLocalDateString();
+  const data = await getStreakData();
+
+  if (data.lastPlayedDate === today) {
+    return data;
+  }
+
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yesterdayStr = getLocalDateString(yesterday);
+
+  const newStreak = data.lastPlayedDate === yesterdayStr ? data.currentStreak + 1 : 1;
+
+  const updated: StreakData = {
+    currentStreak: newStreak,
+    lastPlayedDate: today,
+    longestStreak: Math.max(newStreak, data.longestStreak),
+  };
+
+  await saveStreakData(updated);
+  return updated;
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -198,6 +198,22 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
 };
 
+// Returns true when onboarding is done (value = 'true').
+// Returns false for null (never seen) or 'pending' (explicitly reset).
+export const getOnboardingDone = async (): Promise<boolean> => {
+  const value = await getStorageItem(STORAGE_KEYS.ONBOARDING_DONE);
+  return value === 'true';
+};
+
+export const setOnboardingDone = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'true');
+};
+
+// Stores 'pending' so migration logic is skipped on next launch
+export const resetOnboarding = async (): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'pending');
+};
+
 function isValidTaskStat(r: unknown): r is TaskStat {
   if (!r || typeof r !== 'object') return false;
   const obj = r as Record<string, unknown>;

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -271,6 +271,57 @@ export const getWeakTasks = (stats: TaskStat[], minAttempts = 3, minErrorRate = 
     });
 };
 
+// Badge storage – maps badgeId → unlock timestamp
+export type BadgeStore = Record<string, number>;
+
+export const getBadges = async (): Promise<BadgeStore> => {
+  const value = await getStorageItem(STORAGE_KEYS.BADGES);
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const validated: BadgeStore = {};
+      for (const [key, val] of Object.entries(parsed)) {
+        if (typeof val === 'number' && Number.isFinite(val)) {
+          validated[key] = val;
+        }
+      }
+      return validated;
+    }
+  } catch { /* ignore */ }
+  return {};
+};
+
+export const saveBadges = async (badges: BadgeStore): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.BADGES, JSON.stringify(badges));
+};
+
+// Persistent streak counter – decoupled from the 28-day session record window
+export interface StreakData {
+  currentStreak: number;
+  lastPlayedDay: string; // YYYY-MM-DD
+}
+
+export const getStreakData = async (): Promise<StreakData> => {
+  const value = await getStorageItem(STORAGE_KEYS.STREAK);
+  if (!value) return { currentStreak: 0, lastPlayedDay: '' };
+  try {
+    const parsed = JSON.parse(value);
+    if (
+      typeof parsed === 'object' && parsed !== null &&
+      typeof parsed.currentStreak === 'number' &&
+      typeof parsed.lastPlayedDay === 'string'
+    ) {
+      return parsed as StreakData;
+    }
+  } catch { /* ignore */ }
+  return { currentStreak: 0, lastPlayedDay: '' };
+};
+
+export const saveStreakData = async (data: StreakData): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.STREAK, JSON.stringify(data));
+};
+
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.NUMBER_RANGE, range);
 };

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord } from '../types/game';
+import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -196,6 +196,79 @@ export const saveSessionRecord = async (record: SessionRecord): Promise<void> =>
   const records = await getSessionRecords();
   records.push(record);
   await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
+};
+
+function isValidTaskStat(r: unknown): r is TaskStat {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.num1 === 'number' &&
+    typeof obj.num2 === 'number' &&
+    typeof obj.operation === 'string' && VALID_OPERATIONS.has(obj.operation) &&
+    typeof obj.correctCount === 'number' &&
+    typeof obj.errorCount === 'number' &&
+    typeof obj.lastSeen === 'string'
+  );
+}
+
+export const getTaskStats = async (): Promise<TaskStat[]> => {
+  const value = await getStorageItem(STORAGE_KEYS.TASK_STATS);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidTaskStat);
+  } catch {
+    return [];
+  }
+};
+
+export const saveTaskStats = async (stats: TaskStat[]): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.TASK_STATS, JSON.stringify(stats));
+};
+
+let taskStatsQueue: Promise<void> = Promise.resolve();
+
+export const recordTaskResult = async (
+  num1: number,
+  num2: number,
+  operation: Operation,
+  isCorrect: boolean,
+): Promise<void> => {
+  taskStatsQueue = taskStatsQueue.then(async () => {
+    const stats = await getTaskStats();
+    const existing = stats.find(s => s.num1 === num1 && s.num2 === num2 && s.operation === operation);
+    if (existing) {
+      if (isCorrect) existing.correctCount++;
+      else existing.errorCount++;
+      existing.lastSeen = new Date().toISOString();
+    } else {
+      stats.push({
+        num1,
+        num2,
+        operation,
+        correctCount: isCorrect ? 1 : 0,
+        errorCount: isCorrect ? 0 : 1,
+        lastSeen: new Date().toISOString(),
+      });
+    }
+    await saveTaskStats(stats);
+  });
+  return taskStatsQueue;
+};
+
+export const getWeakTasks = (stats: TaskStat[], minAttempts = 3, minErrorRate = 0.3): TaskStat[] => {
+  return stats
+    .filter(s => {
+      const total = s.correctCount + s.errorCount;
+      const rate = total > 0 ? s.errorCount / total : 0;
+      return total >= minAttempts && rate > minErrorRate;
+    })
+    .sort((a, b) => {
+      const rateA = a.errorCount / (a.correctCount + a.errorCount);
+      const rateB = b.errorCount / (b.correctCount + b.errorCount);
+      return rateB - rateA;
+    });
 };
 
 export const saveNumberRange = async (range: NumberRange): Promise<void> => {


### PR DESCRIPTION
## Zusammenfassung

9 Commits von `testing` → `staging` (squash-merge wird beim Merge gewählt).

### Enthaltene PRs

| PR | Feature |
|----|---------|
| #192 | Adaptives Lernen – Übungsmodus mit Schwachstellen-Fokus |
| #184 | Achievement & Badge System |
| #195 | Jest-Tests automatisch in CI ausführen |
| #196 | `practiceModeFeedback` im Übungsmodus anzeigen (Fix) |
| #199 | Copilot-Review-Fixes für OnboardingModal |
| #200 | Täglicher Streak-Tracker |
| #197 | CLAUDE.md-Update (nach #196) |

### Neue Dateien
- `components/BadgeUnlockToast.tsx`
- `components/BadgesModal.tsx`
- `components/OnboardingModal.tsx`
- `hooks/useBadges.ts` + `hooks/useBadges.test.ts`

### Test plan
- [ ] CI (code-quality, Jest, build-web) grün
- [ ] Keine Merge-Konflikte mit staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)