### PR TITLE
fix(#203): Settings kompakter, Badges erklärbar, 'Streak' → 'Serie'

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   View,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { ThemeColors, DifficultyMode, ChallengeState } from '../types/game';
@@ -24,6 +25,10 @@ interface HeaderProps {
     level: string;
     task: string;
     points: string;
+    streakInfoTitle: string;
+    streakInfoBody: string;
+    scoreInfoTitle: string;
+    scoreInfoBody: string;
   };
 }
 
@@ -59,20 +64,29 @@ export function Header({
               {currentTask}/{totalTasks}
             </Text>
           </View>
-          <LinearGradient
-            colors={DESIGN_TOKENS.GRADIENT_GOLD}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 0 }}
-            style={styles.scoreBadge}
+          <TouchableOpacity
+            onPress={() => Alert.alert(t.scoreInfoTitle, t.scoreInfoBody)}
+            activeOpacity={0.7}
           >
-            <Text style={styles.scoreBadgeText}>⭐ {score}</Text>
-          </LinearGradient>
+            <LinearGradient
+              colors={DESIGN_TOKENS.GRADIENT_GOLD}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={styles.scoreBadge}
+            >
+              <Text style={styles.scoreBadgeText}>⭐ {score}</Text>
+            </LinearGradient>
+          </TouchableOpacity>
         </>
       )}
       {!!currentStreak && currentStreak > 0 && (
-        <View style={styles.streakBadge}>
+        <TouchableOpacity
+          onPress={() => Alert.alert(t.streakInfoTitle, `${currentStreak} ${t.streakInfoBody}`)}
+          activeOpacity={0.7}
+          style={styles.streakBadge}
+        >
           <Text style={styles.streakText}>🔥 {currentStreak}</Text>
-        </View>
+        </TouchableOpacity>
       )}
       <TouchableOpacity
         onPress={onShowMenu}

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -366,11 +366,14 @@ const styles = StyleSheet.create({
   },
   topButtonsSection: {
     gap: 8,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
   },
   personalizeButton: {
-    width: '100%',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
+    flex: 1,
+    minWidth: '45%',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     backgroundColor: 'transparent',
     borderWidth: 2,

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -103,6 +103,10 @@ export interface TranslationStrings {
   streakWarningTitle: string;
   streakWarningMessage: string;
   streakWarningButton: string;
+  streakInfoTitle: string;
+  streakInfoBody: string;
+  scoreInfoTitle: string;
+  scoreInfoBody: string;
   parentWeakTasks: string;
   parentWeakTasksEmpty: string;
   // Badges
@@ -254,6 +258,10 @@ export const translations: Record<Language, TranslationStrings> = {
     streakWarningTitle: 'Don\'t break your streak!',
     streakWarningMessage: 'Play a quick round today to keep your {days}-day streak going!',
     streakWarningButton: 'Let\'s go!',
+    streakInfoTitle: 'Streak',
+    streakInfoBody: 'days played in a row. Keep it up!',
+    scoreInfoTitle: 'Score',
+    scoreInfoBody: 'Your score for this round',
     parentWeakTasks: 'Weak Areas (Top 5)',
     parentWeakTasksEmpty: 'No weak areas identified yet.',
     // Badges
@@ -397,12 +405,16 @@ export const translations: Record<Language, TranslationStrings> = {
     parentYesterday: 'Gestern',
     parentCorrect: 'Richtig',
     parentErrors: 'Fehler',
-    parentCurrentStreak: 'Aktueller Streak',
-    parentLongestStreak: 'Längster Streak',
+    parentCurrentStreak: 'Aktuelle Serie',
+    parentLongestStreak: 'Längste Serie',
     parentStreakDays: 'Tage',
-    streakWarningTitle: 'Brich deinen Streak nicht!',
-    streakWarningMessage: 'Spiel heute eine Runde, um deinen {days}-Tage-Streak zu halten!',
+    streakWarningTitle: 'Brich deine Serie nicht!',
+    streakWarningMessage: 'Spiel heute eine Runde, um deine {days}-Tage-Serie zu halten!',
     streakWarningButton: 'Los geht\'s!',
+    streakInfoTitle: 'Serie',
+    streakInfoBody: 'Tage in Folge gespielt. Weiter so!',
+    scoreInfoTitle: 'Punkte',
+    scoreInfoBody: 'Dein Punktestand in dieser Runde',
     parentWeakTasks: 'Schwachstellen (Top 5)',
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
     // Badges


### PR DESCRIPTION
## Fixes #203 – User Feedback

### Änderungen

**1. Settings-Menü kompakter (Nexus 6 / kleine Screens)**
- Die 3 oberen Buttons (Anpassen, Eltern-Dashboard, Abzeichen) sind jetzt in einem 2-Spalten-Layout angeordnet statt gestapelt
- Weniger vertikaler Platzbedarf → untere Buttons verschwinden nicht mehr am Bildschirmrand

**2. ⭐ und 🔥 Icons erklärbar**
- Score-Badge (⭐) und Streak-Badge (🔥) im Header sind jetzt tippbar
- Tap zeigt eine kurze Erklärung via Alert: was die Zahl bedeutet

**3. „Streak" → „Serie" (Deutsch)**
- `parentCurrentStreak`: „Aktuelle Serie"
- `parentLongestStreak`: „Längste Serie"
- `streakWarningTitle`: „Brich deine Serie nicht!"
- `streakWarningMessage`: „…{days}-Tage-Serie…"
- Englisch bleibt unverändert („Streak")

## Test plan
- [ ] Settings-Menü auf kleinem Screen öffnen → 2 Buttons nebeneinander oben
- [ ] ⭐-Badge antippen → Alert mit Punktestand-Erklärung
- [ ] 🔥-Badge antippen → Alert mit Serien-Erklärung inkl. Anzahl Tage
- [ ] Sprache Deutsch → alle „Streak"-Texte zeigen „Serie"
- [ ] 475 Tests grün (`npm test`)

https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE)_