### PR TITLE
test(#160): React 19 act()-Warning in usePreferences.test.tsx beheben

### DIFF
--- a/hooks/usePreferences.test.tsx
+++ b/hooks/usePreferences.test.tsx
@@ -78,10 +78,13 @@ describe('usePreferences Hook', () => {
   });
 
   describe('Initialization and Loading', () => {
-    it('should start with isLoaded as false', () => {
+    it('should start with isLoaded as false', async () => {
       const { result } = renderHook(() => usePreferences());
 
       expect(result.current.isLoaded).toBe(false);
+      // Flush pending async state updates so React 19 doesn't warn about
+      // setState calls outside act() during test cleanup
+      await act(async () => {});
     });
 
     it('should set isLoaded to true after loading preferences', async () => {


### PR DESCRIPTION
## Fixes #160 – React 19 act() Warnings

### Ursache

Genau **1 Test** war verantwortlich für alle 4 Warnings pro Testlauf:

```
should start with isLoaded as false
```

Dieser Test war **synchron** (`() =>` statt `async () =>`). Dadurch liefen die async State-Updates aus `loadPreferences()` – `setOperations` (Zeile 56), `setNumberRange` (66), `setChallengeHighScore` (70), `setIsLoaded` (72) – nach Testende im Jest-Cleanup-Bereich ab, ausserhalb jedes `act()`-Kontexts.

### Fix

Ein einziger Test geändert:
- `() =>` → `async () =>`
- `await act(async () => {})` am Ende flusht alle offenen Microtasks innerhalb des Testlebenszyklus

### Ergebnis

```
0 × console.error (vorher: 4 × "not wrapped in act")
475 Tests grün, 14 Suites, keine Änderungen an Produktionscode
```

## Test plan
- [ ] `npm test` → 0 `act()`-Warnings, 475 Tests grün

https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE)_