### PR TITLE
feat(#190): Visuelle Themes / App-Skins (5 Farbthemes)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -86,7 +86,7 @@ export default function App() {
 
   // Use custom hooks
   const preferences = usePreferences();
-  const theme = useTheme(preferences.themeMode);
+  const theme = useTheme(preferences.themeMode, preferences.themeName);
   const badgeSystem = useBadges();
   const game = useGameLogic({
     initialOperation: preferences.operation,
@@ -198,9 +198,9 @@ export default function App() {
   // Set body background color dynamically on web
   useEffect(() => {
     if (typeof document !== 'undefined') {
-      document.body.style.backgroundColor = isDarkMode ? '#0F1419' : '#F0F4FF';
+      document.body.style.backgroundColor = colors.background;
     }
-  }, [isDarkMode]);
+  }, [colors.background]);
 
   // Load streak data and show warning when appropriate
   useEffect(() => {
@@ -380,6 +380,8 @@ export default function App() {
         onLanguageChange={preferences.setLanguage}
         themeMode={theme.themeMode}
         onThemeModeChange={preferences.setThemeMode}
+        themeName={preferences.themeName}
+        onThemeNameChange={preferences.setThemeName}
       />
 
       <AboutModal

--- a/components/BadgesModal.tsx
+++ b/components/BadgesModal.tsx
@@ -115,6 +115,7 @@ function formatUnlockDate(ts: number, language: Language): string {
 export function BadgesModal({ visible, onClose, colors, badges, language, t }: BadgesModalProps) {
   const unlockedCount = Object.keys(badges).length;
   const totalCount = BADGE_DEFINITIONS.length;
+  const activeColor = colors.gradientPrimary[0];
 
   return (
     <Modal visible={visible} transparent animationType="fade">
@@ -152,7 +153,7 @@ export function BadgesModal({ visible, onClose, colors, badges, language, t }: B
                           style={[
                             styles.badgeCard,
                             { backgroundColor: colors.card, borderColor: colors.border },
-                            isUnlocked && styles.badgeCardUnlocked,
+                            isUnlocked && [styles.badgeCardUnlocked, { borderColor: activeColor + '55' }],
                           ]}
                         >
                           <Text style={[styles.badgeIcon, !isUnlocked && styles.badgeIconLocked]}>
@@ -174,7 +175,7 @@ export function BadgesModal({ visible, onClose, colors, badges, language, t }: B
                             {getBadgeDesc(def.id, t)}
                           </Text>
                           {isUnlocked && (
-                            <Text style={styles.unlockedDate}>
+                            <Text style={[styles.unlockedDate, { color: activeColor }]}>
                               {t.badgeUnlockedOn} {formatUnlockDate(unlockedAt, language)}
                             </Text>
                           )}
@@ -188,7 +189,7 @@ export function BadgesModal({ visible, onClose, colors, badges, language, t }: B
           </ScrollView>
 
           {/* Close button */}
-          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+          <TouchableOpacity style={[styles.closeBtn, { backgroundColor: activeColor }]} onPress={onClose}>
             <Text style={styles.closeBtnText}>{t.ok}</Text>
           </TouchableOpacity>
         </View>
@@ -196,8 +197,6 @@ export function BadgesModal({ visible, onClose, colors, badges, language, t }: B
     </Modal>
   );
 }
-
-const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
 
 const styles = StyleSheet.create({
   container: {
@@ -267,7 +266,6 @@ const styles = StyleSheet.create({
   },
   badgeCardUnlocked: {
     opacity: 1,
-    borderColor: ACTIVE_COLOR + '55',
   },
   badgeIcon: {
     fontSize: 28,
@@ -291,12 +289,10 @@ const styles = StyleSheet.create({
   unlockedDate: {
     fontSize: 9,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: ACTIVE_COLOR,
     marginTop: 4,
     textAlign: 'center',
   },
   closeBtn: {
-    backgroundColor: ACTIVE_COLOR,
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     paddingVertical: 12,
     alignItems: 'center',

--- a/components/Chip.tsx
+++ b/components/Chip.tsx
@@ -13,12 +13,13 @@ interface ChipProps {
 }
 
 export function Chip({ label, active, onPress, colors, disabled = false, size = 'md' }: ChipProps) {
+  const activeColor = colors.gradientPrimary[0];
   return (
     <TouchableOpacity
       style={[
         styles.chip,
         { backgroundColor: colors.buttonInactive, borderColor: colors.border },
-        active && styles.chipActive,
+        active && { backgroundColor: activeColor, borderColor: activeColor },
         disabled && { opacity: 0.6 },
         size === 'sm' && styles.chipSm,
       ]}
@@ -39,8 +40,6 @@ export function Chip({ label, active, onPress, colors, disabled = false, size = 
   );
 }
 
-const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0]; // #667eea
-
 const styles = StyleSheet.create({
   chip: {
     flex: 1,
@@ -51,10 +50,6 @@ const styles = StyleSheet.create({
     borderColor: '#dde3ff',
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  chipActive: {
-    backgroundColor: ACTIVE_COLOR,
-    borderColor: ACTIVE_COLOR,
   },
   chipSm: {
     paddingVertical: 6,

--- a/components/GameCard.test.tsx
+++ b/components/GameCard.test.tsx
@@ -22,6 +22,7 @@ const mockColors: ThemeColors = {
   buttonInactiveText: '#666',
   settingsOverlay: 'rgba(0,0,0,0.5)',
   settingsMenu: '#fff',
+  gradientPrimary: ['#667eea', '#764ba2'],
 };
 
 const baseGameState: GameState = {

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -52,7 +52,7 @@ export function GameCard({
   const getGradientColors = (): readonly [string, string] => {
     if (gameState.lastAnswerCorrect === true) return DESIGN_TOKENS.GRADIENT_CORRECT;
     if (gameState.lastAnswerCorrect === false) return DESIGN_TOKENS.GRADIENT_INCORRECT;
-    return DESIGN_TOKENS.GRADIENT_PRIMARY;
+    return colors.gradientPrimary;
   };
 
   const getResult = () => {
@@ -121,6 +121,7 @@ export function GameCard({
                 checkLabel={t.check}
                 nextLabel={t.nextQuestion}
                 encouragement={gameState.difficultyMode === DifficultyMode.PRACTICE ? t.practiceModeFeedback : t.encouragement}
+                gradientPrimary={colors.gradientPrimary}
               />
             )}
 
@@ -152,6 +153,7 @@ export function GameCard({
                   label={gameState.isAnswerChecked ? t.nextQuestion : t.check}
                   onPress={gameState.isAnswerChecked ? onNext : onCheck}
                   disabled={gameState.selectedChoice === null && !gameState.isAnswerChecked}
+                  gradientPrimary={colors.gradientPrimary}
                 />
               </View>
             )}
@@ -186,6 +188,7 @@ export function GameCard({
                   label={gameState.isAnswerChecked ? t.nextQuestion : t.check}
                   onPress={gameState.isAnswerChecked ? onNext : onCheck}
                   disabled={gameState.selectedChoice === null && !gameState.isAnswerChecked}
+                  gradientPrimary={colors.gradientPrimary}
                 />
               </View>
             )}
@@ -202,10 +205,12 @@ function GradientCheckButton({
   label,
   onPress,
   disabled,
+  gradientPrimary,
 }: {
   label: string;
   onPress: () => void;
   disabled: boolean;
+  gradientPrimary: readonly [string, string];
 }) {
   if (disabled) {
     return (
@@ -217,7 +222,7 @@ function GradientCheckButton({
   return (
     <TouchableOpacity onPress={onPress} activeOpacity={0.85}>
       <LinearGradient
-        colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+        colors={gradientPrimary}
         start={{ x: 0, y: 0 }}
         end={{ x: 1, y: 0 }}
         style={styles.checkButton}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -59,7 +59,7 @@ export function Header({
       ) : (
         <>
           <View style={styles.progressContainer}>
-            <ProgressBar current={currentTask - 1} total={totalTasks} />
+            <ProgressBar current={currentTask - 1} total={totalTasks} gradientColors={colors.gradientPrimary} />
             <Text style={[styles.progressLabel, { color: colors.textSecondary }]}>
               {currentTask}/{totalTasks}
             </Text>

--- a/components/Numpad.tsx
+++ b/components/Numpad.tsx
@@ -19,6 +19,7 @@ interface NumpadProps {
   checkLabel: string;
   nextLabel: string;
   encouragement: string;
+  gradientPrimary: readonly [string, string];
 }
 
 export function Numpad({
@@ -29,6 +30,7 @@ export function Numpad({
   checkLabel,
   nextLabel,
   encouragement,
+  gradientPrimary,
 }: NumpadProps) {
   const canCheck = userAnswer !== '' || isAnswerChecked;
   const pulseAnim = useRef(new Animated.Value(1)).current;
@@ -79,7 +81,7 @@ export function Numpad({
             {canCheck ? (
               <TouchableOpacity onPress={onCheck} activeOpacity={0.85} style={{ flex: 1 }}>
                 <LinearGradient
-                  colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+                  colors={gradientPrimary}
                   start={{ x: 0, y: 0 }}
                   end={{ x: 1, y: 0 }}
                   style={styles.checkButton}

--- a/components/OnboardingModal.tsx
+++ b/components/OnboardingModal.tsx
@@ -93,7 +93,7 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
                 style={[
                   styles.dot,
                   i === step && styles.dotActive,
-                  { backgroundColor: i === step ? DESIGN_TOKENS.GRADIENT_PRIMARY[0] : colors.border },
+                  { backgroundColor: i === step ? colors.gradientPrimary[0] : colors.border },
                 ]}
               />
             ))}
@@ -166,7 +166,7 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
               <Text style={[styles.title, { color: colors.text }]}>{t.onboardingSettingsTitle}</Text>
               <Text style={[styles.body, { color: colors.textSecondary }]}>{t.onboardingSettingsBody}</Text>
               <LinearGradient
-                colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+                colors={colors.gradientPrimary}
                 start={{ x: 0, y: 0 }}
                 end={{ x: 1, y: 0 }}
                 style={styles.menuHint}
@@ -196,7 +196,7 @@ export function OnboardingModal({ visible, onFinish, colors, t }: OnboardingModa
               disabled={!canProceedStep1}
             >
               <LinearGradient
-                colors={canProceedStep1 ? DESIGN_TOKENS.GRADIENT_PRIMARY : ['#ccc', '#ccc']}
+                colors={canProceedStep1 ? colors.gradientPrimary : ['#ccc', '#ccc']}
                 start={{ x: 0, y: 0 }}
                 end={{ x: 1, y: 0 }}
                 style={styles.nextButtonGradient}

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -290,7 +290,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
 
           {/* Content */}
           {loading ? (
-            <ActivityIndicator style={styles.loader} color={DESIGN_TOKENS.GRADIENT_PRIMARY[0]} />
+            <ActivityIndicator style={styles.loader} color={colors.gradientPrimary[0]} />
           ) : records.length === 0 ? (
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>{t.parentNoData}</Text>
           ) : (
@@ -303,7 +303,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
                     data={chartData}
                     valueKey="sessions"
                     maxValue={maxSessions}
-                    getBarColor={() => ACTIVE_COLOR}
+                    getBarColor={() => colors.gradientPrimary[0]}
                     colors={colors}
                   />
                   <Text style={[styles.chartTitle, styles.chartTitleSpaced, { color: colors.textSecondary }]}>
@@ -374,7 +374,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           )}
 
           {/* Close button */}
-          <TouchableOpacity style={styles.closeBtn} onPress={onClose}>
+          <TouchableOpacity style={[styles.closeBtn, { backgroundColor: colors.gradientPrimary[0] }]} onPress={onClose}>
             <Text style={styles.closeBtnText}>{t.ok}</Text>
           </TouchableOpacity>
         </View>
@@ -382,8 +382,6 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
     </Modal>
   );
 }
-
-const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0];
 
 const styles = StyleSheet.create({
   container: {
@@ -578,7 +576,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
   },
   closeBtn: {
-    backgroundColor: ACTIVE_COLOR,
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     paddingVertical: 12,
     alignItems: 'center',

--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -6,9 +6,9 @@ import {
   StyleSheet,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { ThemeColors, Language, ThemeMode } from '../types/game';
+import { ThemeColors, Language, ThemeMode, ThemeName } from '../types/game';
 import { translations } from '../i18n/translations';
-import { DESIGN_TOKENS } from '../utils/constants';
+import { THEMES } from '../utils/constants';
 import { Chip } from './Chip';
 
 interface PersonalizeModalProps {
@@ -19,6 +19,8 @@ interface PersonalizeModalProps {
   onLanguageChange: (language: Language) => void;
   themeMode: ThemeMode;
   onThemeModeChange: (mode: ThemeMode) => void;
+  themeName: ThemeName;
+  onThemeNameChange: (name: ThemeName) => void;
 }
 
 export function PersonalizeModal({
@@ -29,6 +31,8 @@ export function PersonalizeModal({
   onLanguageChange,
   themeMode,
   onThemeModeChange,
+  themeName,
+  onThemeNameChange,
 }: PersonalizeModalProps) {
   const t = translations[language];
 
@@ -44,7 +48,7 @@ export function PersonalizeModal({
 
       <View style={[styles.settingsMenu, { backgroundColor: colors.settingsMenu }]}>
         <LinearGradient
-          colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+          colors={colors.gradientPrimary}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 0 }}
           style={styles.settingsMenuHeader}
@@ -78,6 +82,38 @@ export function PersonalizeModal({
               onPress={() => onThemeModeChange('system')}
               colors={colors}
             />
+          </View>
+        </View>
+
+        <View style={[styles.settingsDivider, { backgroundColor: colors.border }]} />
+
+        <View style={styles.settingsSection}>
+          <Text style={[styles.settingsSectionTitle, { color: colors.textSecondary }]}>
+            {t.colorTheme}
+          </Text>
+          <View style={styles.themeGrid}>
+            {(Object.keys(THEMES) as ThemeName[]).map((name) => {
+              const themeData = THEMES[name];
+              const isActive = themeName === name;
+              return (
+                <TouchableOpacity
+                  key={name}
+                  style={[styles.themeSwatchWrapper, isActive && styles.themeSwatchActive]}
+                  onPress={() => onThemeNameChange(name)}
+                  activeOpacity={0.75}
+                >
+                  <LinearGradient
+                    colors={themeData.LIGHT.GRADIENT_PRIMARY}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={styles.themeSwatch}
+                  />
+                  <Text style={[styles.themeLabel, { color: colors.text }]}>
+                    {themeData.label}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
           </View>
         </View>
 
@@ -122,7 +158,7 @@ const styles = StyleSheet.create({
     top: 60,
     right: 16,
     left: 16,
-    borderRadius: DESIGN_TOKENS.NUMPAD_BORDER_RADIUS,
+    borderRadius: 28,
     elevation: 12,
     shadowColor: '#667eea',
     shadowOffset: { width: 0, height: 4 },
@@ -140,7 +176,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_UI,
+    fontFamily: 'Nunito_700Bold',
     color: '#fff',
     letterSpacing: 0.3,
   },
@@ -150,7 +186,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuCloseButtonText: {
     fontSize: 18,
-    fontFamily: DESIGN_TOKENS.FONT_UI,
+    fontFamily: 'Nunito_700Bold',
     color: '#fff',
   },
   settingsSection: {
@@ -159,7 +195,7 @@ const styles = StyleSheet.create({
   },
   settingsSectionTitle: {
     fontSize: 11,
-    fontFamily: DESIGN_TOKENS.FONT_UI,
+    fontFamily: 'Nunito_700Bold',
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.08,
@@ -171,5 +207,32 @@ const styles = StyleSheet.create({
   settingsDivider: {
     height: 1,
     marginVertical: 2,
+  },
+  themeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  themeSwatchWrapper: {
+    alignItems: 'center',
+    gap: 4,
+    padding: 4,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  themeSwatchActive: {
+    borderColor: '#667eea',
+  },
+  themeSwatch: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+  },
+  themeLabel: {
+    fontSize: 10,
+    fontFamily: 'Nunito_700Bold',
+    textAlign: 'center',
+    maxWidth: 52,
   },
 });

--- a/components/PersonalizeModal.tsx
+++ b/components/PersonalizeModal.tsx
@@ -8,7 +8,7 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { ThemeColors, Language, ThemeMode, ThemeName } from '../types/game';
 import { translations } from '../i18n/translations';
-import { THEMES } from '../utils/constants';
+import { THEMES, DESIGN_TOKENS } from '../utils/constants';
 import { Chip } from './Chip';
 
 interface PersonalizeModalProps {
@@ -95,10 +95,14 @@ export function PersonalizeModal({
             {(Object.keys(THEMES) as ThemeName[]).map((name) => {
               const themeData = THEMES[name];
               const isActive = themeName === name;
+              const swatchBorderColor = themeData.LIGHT.GRADIENT_PRIMARY[0];
               return (
                 <TouchableOpacity
                   key={name}
-                  style={[styles.themeSwatchWrapper, isActive && styles.themeSwatchActive]}
+                  style={[
+                    styles.themeSwatchWrapper,
+                    isActive && { borderColor: swatchBorderColor },
+                  ]}
                   onPress={() => onThemeNameChange(name)}
                   activeOpacity={0.75}
                 >
@@ -158,7 +162,7 @@ const styles = StyleSheet.create({
     top: 60,
     right: 16,
     left: 16,
-    borderRadius: 28,
+    borderRadius: DESIGN_TOKENS.NUMPAD_BORDER_RADIUS,
     elevation: 12,
     shadowColor: '#667eea',
     shadowOffset: { width: 0, height: 4 },
@@ -176,7 +180,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuTitle: {
     fontSize: 18,
-    fontFamily: 'Nunito_700Bold',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
     letterSpacing: 0.3,
   },
@@ -186,7 +190,7 @@ const styles = StyleSheet.create({
   },
   settingsMenuCloseButtonText: {
     fontSize: 18,
-    fontFamily: 'Nunito_700Bold',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#fff',
   },
   settingsSection: {
@@ -195,7 +199,7 @@ const styles = StyleSheet.create({
   },
   settingsSectionTitle: {
     fontSize: 11,
-    fontFamily: 'Nunito_700Bold',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.08,
@@ -221,9 +225,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: 'transparent',
   },
-  themeSwatchActive: {
-    borderColor: '#667eea',
-  },
   themeSwatch: {
     width: 44,
     height: 44,
@@ -231,7 +232,7 @@ const styles = StyleSheet.create({
   },
   themeLabel: {
     fontSize: 10,
-    fontFamily: 'Nunito_700Bold',
+    fontFamily: DESIGN_TOKENS.FONT_UI,
     textAlign: 'center',
     maxWidth: 52,
   },

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -6,9 +6,10 @@ import { DESIGN_TOKENS } from '../utils/constants';
 interface ProgressBarProps {
   current: number;
   total: number;
+  gradientColors?: readonly [string, string];
 }
 
-export function ProgressBar({ current, total }: ProgressBarProps) {
+export function ProgressBar({ current, total, gradientColors }: ProgressBarProps) {
   const widthAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -34,7 +35,7 @@ export function ProgressBar({ current, total }: ProgressBarProps) {
         ]}
       >
         <LinearGradient
-          colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+          colors={gradientColors ?? DESIGN_TOKENS.GRADIENT_PRIMARY}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 0 }}
           style={StyleSheet.absoluteFill}

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -91,6 +91,9 @@ export function SettingsMenu({
   const buttonText = colors.buttonInactiveText;
   const sectionTitle = colors.textSecondary;
   const modeInfo = colors.textSecondary;
+  const activeColor = colors.gradientPrimary[0];
+  const activeStyle = { backgroundColor: activeColor, borderColor: activeColor };
+
   return (
     <>
       <TouchableOpacity
@@ -100,7 +103,7 @@ export function SettingsMenu({
       />
       <Animated.View style={[styles.settingsMenu, { maxHeight: screenHeight - 80, backgroundColor: colors.settingsMenu }, menuAnimatedStyle]}>
         <LinearGradient
-          colors={DESIGN_TOKENS.GRADIENT_PRIMARY}
+          colors={colors.gradientPrimary}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 0 }}
           style={styles.settingsMenuHeader}
@@ -118,22 +121,22 @@ export function SettingsMenu({
         {/* Personalize Button */}
         <View style={[styles.settingsSection, styles.topButtonsSection]}>
           <TouchableOpacity
-            style={styles.personalizeButton}
+            style={[styles.personalizeButton, { borderColor: activeColor }]}
             onPress={() => { onOpenPersonalize(); onHideMenu(); }}
           >
-            <Text style={styles.personalizeButtonText}>{t.personalize}</Text>
+            <Text style={[styles.personalizeButtonText, { color: activeColor }]}>{t.personalize}</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.personalizeButton}
+            style={[styles.personalizeButton, { borderColor: activeColor }]}
             onPress={() => { onOpenParentDashboard(); onHideMenu(); }}
           >
-            <Text style={styles.personalizeButtonText}>{t.parentDashboardMenu}</Text>
+            <Text style={[styles.personalizeButtonText, { color: activeColor }]}>{t.parentDashboardMenu}</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={styles.personalizeButton}
+            style={[styles.personalizeButton, { borderColor: activeColor }]}
             onPress={() => { onOpenBadges(); onHideMenu(); }}
           >
-            <Text style={styles.personalizeButtonText}>{t.badgesMenu}</Text>
+            <Text style={[styles.personalizeButtonText, { color: activeColor }]}>{t.badgesMenu}</Text>
           </TouchableOpacity>
         </View>
 
@@ -157,7 +160,7 @@ export function SettingsMenu({
                   style={[
                     styles.operationButton,
                     { backgroundColor: buttonBg, borderColor: buttonBorder },
-                    isActive && styles.operationButtonActive,
+                    isActive && activeStyle,
                     isChallenge && { opacity: 0.6 },
                   ]}
                   onPress={() => onToggleOperation(op)}
@@ -179,7 +182,7 @@ export function SettingsMenu({
           <Text style={[styles.settingsSectionTitle, { color: sectionTitle }]}>{t.difficultyMode}</Text>
           <View style={styles.difficultyGrid}>
             <TouchableOpacity
-              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.SIMPLE && activeStyle]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.SIMPLE)}
             >
               <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.SIMPLE && styles.themeButtonTextActive]}>
@@ -187,7 +190,7 @@ export function SettingsMenu({
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CREATIVE && activeStyle]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.CREATIVE)}
             >
               <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.CREATIVE && styles.themeButtonTextActive]}>
@@ -195,7 +198,7 @@ export function SettingsMenu({
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CHALLENGE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.CHALLENGE && activeStyle]}
               onPress={() => {
                 onChangeDifficultyMode(DifficultyMode.CHALLENGE);
                 onHideMenu();
@@ -206,7 +209,7 @@ export function SettingsMenu({
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonActive]}
+              style={[styles.themeButton, { backgroundColor: buttonBg, borderColor: buttonBorder }, difficultyMode === DifficultyMode.PRACTICE && activeStyle]}
               onPress={() => onChangeDifficultyMode(DifficultyMode.PRACTICE)}
             >
               <Text style={[styles.themeButtonText, { color: buttonText }, difficultyMode === DifficultyMode.PRACTICE && styles.themeButtonTextActive]}>
@@ -245,7 +248,7 @@ export function SettingsMenu({
                   style={[
                     styles.rangeButton,
                     { backgroundColor: buttonBg, borderColor: buttonBorder },
-                    isActive && styles.rangeButtonActive,
+                    isActive && activeStyle,
                     isChallengeMode && { opacity: 0.6 },
                   ]}
                   onPress={() => onSetNumberRange(range)}
@@ -271,7 +274,7 @@ export function SettingsMenu({
               onHideMenu();
             }}
           >
-            <Text style={styles.settingsMenuLinkText}>{t.feedback}</Text>
+            <Text style={[styles.settingsMenuLinkText, { color: activeColor }]}>{t.feedback}</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.settingsMenuLinkFlex}
@@ -280,13 +283,13 @@ export function SettingsMenu({
               onHideMenu();
             }}
           >
-            <Text style={styles.settingsMenuLinkText}>{t.support}</Text>
+            <Text style={[styles.settingsMenuLinkText, { color: activeColor }]}>{t.support}</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.settingsMenuLinkFlex}
             onPress={onOpenAbout}
           >
-            <Text style={styles.settingsMenuLinkText}>{t.about}</Text>
+            <Text style={[styles.settingsMenuLinkText, { color: activeColor }]}>{t.about}</Text>
           </TouchableOpacity>
         </View>
 
@@ -302,8 +305,6 @@ export function SettingsMenu({
     </>
   );
 }
-
-const ACTIVE_COLOR = DESIGN_TOKENS.GRADIENT_PRIMARY[0]; // #667eea
 
 const styles = StyleSheet.create({
   settingsOverlay: {
@@ -362,7 +363,6 @@ const styles = StyleSheet.create({
   settingsMenuLinkText: {
     fontSize: 13,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: ACTIVE_COLOR,
   },
   topButtonsSection: {
     gap: 8,
@@ -377,13 +377,11 @@ const styles = StyleSheet.create({
     borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
     backgroundColor: 'transparent',
     borderWidth: 2,
-    borderColor: ACTIVE_COLOR,
     alignItems: 'center',
   },
   personalizeButtonText: {
     fontSize: 14,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: ACTIVE_COLOR,
   },
   settingsSection: {
     paddingHorizontal: 16,
@@ -432,17 +430,13 @@ const styles = StyleSheet.create({
     borderColor: '#dde3ff',
     alignItems: 'center',
   },
-  themeButtonActive: {
-    backgroundColor: ACTIVE_COLOR,
-    borderColor: ACTIVE_COLOR,
+  themeButtonTextActive: {
+    color: '#fff',
   },
   themeButtonText: {
     fontSize: 12,
     fontFamily: DESIGN_TOKENS.FONT_UI,
     color: '#2d2b55',
-  },
-  themeButtonTextActive: {
-    color: '#fff',
   },
   operationGrid: {
     flexDirection: 'row',
@@ -459,10 +453,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: '#dde3ff',
     alignItems: 'center',
-  },
-  operationButtonActive: {
-    backgroundColor: ACTIVE_COLOR,
-    borderColor: ACTIVE_COLOR,
   },
   operationButtonText: {
     fontSize: 12,
@@ -487,10 +477,6 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: '#dde3ff',
     alignItems: 'center',
-  },
-  rangeButtonActive: {
-    backgroundColor: ACTIVE_COLOR,
-    borderColor: ACTIVE_COLOR,
   },
   rangeButtonText: {
     fontSize: 12,

--- a/hooks/usePreferences.test.tsx
+++ b/hooks/usePreferences.test.tsx
@@ -356,6 +356,59 @@ describe('usePreferences Hook', () => {
     });
   });
 
+  describe('Theme Name Management', () => {
+    it('should default to sunset when no saved theme name', async () => {
+      mockGetThemeName.mockResolvedValue(null);
+
+      const { result } = renderHook(() => usePreferences());
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+
+      expect(result.current.themeName).toBe('sunset');
+    });
+
+    it('should load a saved theme name on mount', async () => {
+      mockGetThemeName.mockResolvedValue('ocean');
+
+      const { result } = renderHook(() => usePreferences());
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+
+      expect(result.current.themeName).toBe('ocean');
+    });
+
+    it('should call saveThemeName when themeName changes after load', async () => {
+      const { result } = renderHook(() => usePreferences());
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+
+      act(() => {
+        result.current.setThemeName('forest');
+      });
+
+      await waitFor(() => {
+        expect(mockSaveThemeName).toHaveBeenCalledWith('forest');
+      });
+    });
+
+    it('should not call saveThemeName before isLoaded', async () => {
+      const { result } = renderHook(() => usePreferences());
+
+      expect(result.current.isLoaded).toBe(false);
+      expect(mockSaveThemeName).not.toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+    });
+  });
+
   describe('Operation Selection', () => {
     it('should load saved operations', async () => {
       mockGetOperations.mockResolvedValue([Operation.ADDITION, Operation.MULTIPLICATION]);

--- a/hooks/usePreferences.test.tsx
+++ b/hooks/usePreferences.test.tsx
@@ -18,6 +18,8 @@ import {
   saveLanguage,
   getTheme,
   saveTheme,
+  getThemeName,
+  saveThemeName,
   getOperations,
   saveOperations,
   getTotalTasks,
@@ -35,6 +37,8 @@ jest.mock('../utils/storage', () => ({
   saveLanguage: jest.fn(),
   getTheme: jest.fn(),
   saveTheme: jest.fn(),
+  getThemeName: jest.fn(),
+  saveThemeName: jest.fn(),
   getOperations: jest.fn(),
   saveOperations: jest.fn(),
   getTotalTasks: jest.fn(),
@@ -55,6 +59,8 @@ describe('usePreferences Hook', () => {
   const mockSaveLanguage = saveLanguage as jest.MockedFunction<typeof saveLanguage>;
   const mockGetTheme = getTheme as jest.MockedFunction<typeof getTheme>;
   const mockSaveTheme = saveTheme as jest.MockedFunction<typeof saveTheme>;
+  const mockGetThemeName = getThemeName as jest.MockedFunction<typeof getThemeName>;
+  const mockSaveThemeName = saveThemeName as jest.MockedFunction<typeof saveThemeName>;
   const mockGetOperations = getOperations as jest.MockedFunction<typeof getOperations>;
   const mockSaveOperations = saveOperations as jest.MockedFunction<typeof saveOperations>;
   const mockGetTotalTasks = getTotalTasks as jest.MockedFunction<typeof getTotalTasks>;
@@ -70,6 +76,7 @@ describe('usePreferences Hook', () => {
     // Set default mock implementations
     mockGetLanguage.mockResolvedValue(null);
     mockGetTheme.mockResolvedValue(null);
+    mockGetThemeName.mockResolvedValue(null);
     mockGetOperations.mockResolvedValue([Operation.MULTIPLICATION]);
     mockGetTotalTasks.mockResolvedValue(null);
     mockGetNumberRange.mockResolvedValue(NumberRange.RANGE_100); // Now returns RANGE_100 by default

--- a/hooks/usePreferences.ts
+++ b/hooks/usePreferences.ts
@@ -4,12 +4,14 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Language, ThemeMode, Operation, NumberRange } from '../types/game';
+import { Language, ThemeMode, ThemeName, Operation, NumberRange } from '../types/game';
 import {
   getLanguage,
   saveLanguage,
   getTheme,
   saveTheme,
+  getThemeName,
+  saveThemeName,
   getOperations,
   saveOperations,
   getTotalTasks,
@@ -24,6 +26,7 @@ import { getDeviceLanguage } from '../utils/language';
 export function usePreferences() {
   const [language, setLanguage] = useState<Language>('en');
   const [themeMode, setThemeMode] = useState<ThemeMode>('light');
+  const [themeName, setThemeName] = useState<ThemeName>('sunset');
   const [operations, setOperations] = useState<Operation[]>([Operation.MULTIPLICATION]);
   const [numberRange, setNumberRange] = useState<NumberRange>(NumberRange.RANGE_100);
   const [totalSolvedTasks, setTotalSolvedTasks] = useState(0);
@@ -49,6 +52,12 @@ export function usePreferences() {
         const savedTheme = await getTheme();
         if (savedTheme) {
           setThemeMode(savedTheme);
+        }
+
+        // Load theme name
+        const savedThemeName = await getThemeName();
+        if (savedThemeName) {
+          setThemeName(savedThemeName);
         }
 
         // Load operations
@@ -92,6 +101,13 @@ export function usePreferences() {
       saveTheme(themeMode);
     }
   }, [themeMode, isLoaded]);
+
+  // Auto-save theme name
+  useEffect(() => {
+    if (isLoaded) {
+      saveThemeName(themeName);
+    }
+  }, [themeName, isLoaded]);
 
   // Auto-save operations
   useEffect(() => {
@@ -140,6 +156,8 @@ export function usePreferences() {
     setLanguage,
     themeMode,
     setThemeMode,
+    themeName,
+    setThemeName,
     operation: operations.length > 0
       ? operations[0]
       : Operation.MULTIPLICATION, // First selected operation as primary

--- a/hooks/useTheme.test.ts
+++ b/hooks/useTheme.test.ts
@@ -27,6 +27,7 @@ jest.mock('../utils/theme', () => ({
     textSecondary: isDarkMode ? '#9CA3AF' : '#6B7280',
     settingsOverlay: 'rgba(0,0,0,0.5)',
     settingsMenu: isDarkMode ? '#1F2937' : '#FFFFFF',
+    gradientPrimary: ['#667eea', '#764ba2'],
   })),
 }));
 

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -5,10 +5,10 @@
 
 import { useState, useEffect } from 'react';
 import { Platform } from 'react-native';
-import { ThemeMode, ThemeColors } from '../types/game';
+import { ThemeMode, ThemeName, ThemeColors } from '../types/game';
 import { getThemeColors } from '../utils/theme';
 
-export function useTheme(initialTheme: ThemeMode = 'light') {
+export function useTheme(initialTheme: ThemeMode = 'light', themeName: ThemeName = 'sunset') {
   const [themeMode, setThemeMode] = useState<ThemeMode>(initialTheme);
   const [systemDarkMode, setSystemDarkMode] = useState(false);
 
@@ -33,7 +33,7 @@ export function useTheme(initialTheme: ThemeMode = 'light') {
   const isDarkMode = themeMode === 'dark' || (themeMode === 'system' && systemDarkMode);
 
   // Get theme colors
-  const colors: ThemeColors = getThemeColors(isDarkMode);
+  const colors: ThemeColors = getThemeColors(isDarkMode, themeName);
 
   return {
     themeMode,

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -111,6 +111,7 @@ export interface TranslationStrings {
   parentWeakTasksEmpty: string;
   chartSessions: string;
   chartErrorRate: string;
+  colorTheme: string;
   // Badges
   badges: string;
   badgesMenu: string;
@@ -268,6 +269,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentWeakTasksEmpty: 'No weak areas identified yet.',
     chartSessions: 'Sessions · 14 days',
     chartErrorRate: 'Error rate · 14 days',
+    colorTheme: 'COLOR THEME',
     // Badges
     badges: 'Achievements',
     badgesMenu: 'Achievements',
@@ -423,6 +425,7 @@ export const translations: Record<Language, TranslationStrings> = {
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
     chartSessions: 'Einheiten · 14 Tage',
     chartErrorRate: 'Fehlerquote · 14 Tage',
+    colorTheme: 'FARBTHEMA',
     // Badges
     badges: 'Abzeichen',
     badgesMenu: 'Abzeichen',

--- a/types/game.ts
+++ b/types/game.ts
@@ -45,6 +45,7 @@ export interface ChallengeState {
 }
 
 export type ThemeMode = 'light' | 'dark' | 'system';
+export type ThemeName = 'sunset' | 'ocean' | 'space' | 'forest' | 'candy';
 export type Language = 'en' | 'de';
 
 export interface GameState {
@@ -112,4 +113,5 @@ export interface ThemeColors {
   buttonInactiveText: string;
   settingsOverlay: string;
   settingsMenu: string;
+  gradientPrimary: readonly [string, string];
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,7 +2,7 @@
  * Application Constants for 1x1 Trainer
  */
 
-import { GameMode, NumberRange, Operation } from '../types/game';
+import { GameMode, NumberRange, Operation, ThemeName } from '../types/game';
 
 export const APP_VERSION = '1.3.6';
 export const APP_NAME = '1×1 Trainer';
@@ -17,6 +17,7 @@ export const MAX_RANDOM_ANSWER = 100;
 export const STORAGE_KEYS = {
   LANGUAGE: 'app-language',
   THEME: 'app-theme',
+  THEME_NAME: 'app-theme-name',
   OPERATION: 'app-operation',
   OPERATIONS: 'app-operations',
   TOTAL_TASKS: 'app-total-tasks',
@@ -128,6 +129,147 @@ export const THEME_COLORS = {
     SETTINGS_MENU: '#FFFFFF',
   },
 } as const;
+
+type ThemeVariant = {
+  BACKGROUND: string;
+  TEXT: string;
+  TEXT_SECONDARY: string;
+  BORDER: string;
+  CARD: string;
+  CARD_CORRECT: string;
+  CARD_INCORRECT: string;
+  BUTTON_INACTIVE: string;
+  BUTTON_INACTIVE_TEXT: string;
+  SETTINGS_OVERLAY: string;
+  SETTINGS_MENU: string;
+  GRADIENT_PRIMARY: readonly [string, string];
+};
+
+const SHARED_LIGHT = {
+  TEXT: '#0F172A',
+  TEXT_SECONDARY: '#475569',
+  CARD_CORRECT: '#ECFDF5',
+  CARD_INCORRECT: '#FFF1F2',
+  SETTINGS_OVERLAY: 'rgba(15,23,42,0.6)',
+  SETTINGS_MENU: '#FFFFFF',
+  CARD: '#FFFFFF',
+} as const;
+
+const SHARED_DARK = {
+  TEXT: '#E8EAED',
+  TEXT_SECONDARY: '#9AA0A6',
+  CARD_CORRECT: '#10B981',
+  CARD_INCORRECT: '#EF4444',
+  SETTINGS_OVERLAY: 'rgba(15,20,25,0.8)',
+} as const;
+
+export const THEMES: Record<ThemeName, { label: string; LIGHT: ThemeVariant; DARK: ThemeVariant }> = {
+  sunset: {
+    label: '🍊 Sunset',
+    LIGHT: {
+      ...SHARED_LIGHT,
+      BACKGROUND: '#F0F4FF',
+      BORDER: '#CBD5E1',
+      BUTTON_INACTIVE: '#F1F5F9',
+      BUTTON_INACTIVE_TEXT: '#475569',
+      GRADIENT_PRIMARY: ['#667eea', '#764ba2'],
+    },
+    DARK: {
+      ...SHARED_DARK,
+      BACKGROUND: '#0F1419',
+      BORDER: '#2D3748',
+      CARD: '#1A202C',
+      BUTTON_INACTIVE: '#1E293B',
+      BUTTON_INACTIVE_TEXT: '#94A3B8',
+      SETTINGS_MENU: '#1A202C',
+      GRADIENT_PRIMARY: ['#667eea', '#764ba2'],
+    },
+  },
+  ocean: {
+    label: '🌊 Ocean',
+    LIGHT: {
+      ...SHARED_LIGHT,
+      BACKGROUND: '#F0FAFF',
+      BORDER: '#BAE6FD',
+      BUTTON_INACTIVE: '#E0F2FE',
+      BUTTON_INACTIVE_TEXT: '#0369A1',
+      GRADIENT_PRIMARY: ['#06b6d4', '#0284c7'],
+    },
+    DARK: {
+      ...SHARED_DARK,
+      BACKGROUND: '#062637',
+      BORDER: '#0C4A6E',
+      CARD: '#0C3549',
+      BUTTON_INACTIVE: '#0C3549',
+      BUTTON_INACTIVE_TEXT: '#7DD3FC',
+      SETTINGS_MENU: '#0C3549',
+      GRADIENT_PRIMARY: ['#06b6d4', '#0284c7'],
+    },
+  },
+  space: {
+    label: '🚀 Space',
+    LIGHT: {
+      ...SHARED_LIGHT,
+      BACKGROUND: '#F5F3FF',
+      BORDER: '#C4B5FD',
+      BUTTON_INACTIVE: '#EDE9FE',
+      BUTTON_INACTIVE_TEXT: '#5B21B6',
+      GRADIENT_PRIMARY: ['#8B5CF6', '#4F46E5'],
+    },
+    DARK: {
+      ...SHARED_DARK,
+      BACKGROUND: '#0E0B1F',
+      BORDER: '#3730A3',
+      CARD: '#1A1435',
+      BUTTON_INACTIVE: '#1A1435',
+      BUTTON_INACTIVE_TEXT: '#A78BFA',
+      SETTINGS_MENU: '#1A1435',
+      GRADIENT_PRIMARY: ['#8B5CF6', '#4F46E5'],
+    },
+  },
+  forest: {
+    label: '🌿 Forest',
+    LIGHT: {
+      ...SHARED_LIGHT,
+      BACKGROUND: '#F0FFF4',
+      BORDER: '#86EFAC',
+      BUTTON_INACTIVE: '#DCFCE7',
+      BUTTON_INACTIVE_TEXT: '#15803D',
+      GRADIENT_PRIMARY: ['#22c55e', '#15803d'],
+    },
+    DARK: {
+      ...SHARED_DARK,
+      BACKGROUND: '#0A1F10',
+      BORDER: '#166534',
+      CARD: '#132A1A',
+      BUTTON_INACTIVE: '#132A1A',
+      BUTTON_INACTIVE_TEXT: '#86EFAC',
+      SETTINGS_MENU: '#132A1A',
+      GRADIENT_PRIMARY: ['#22c55e', '#15803d'],
+    },
+  },
+  candy: {
+    label: '🩷 Candy',
+    LIGHT: {
+      ...SHARED_LIGHT,
+      BACKGROUND: '#FFF0F7',
+      BORDER: '#F9A8D4',
+      BUTTON_INACTIVE: '#FCE7F3',
+      BUTTON_INACTIVE_TEXT: '#BE185D',
+      GRADIENT_PRIMARY: ['#ec4899', '#f43f5e'],
+    },
+    DARK: {
+      ...SHARED_DARK,
+      BACKGROUND: '#1F0A14',
+      BORDER: '#831843',
+      CARD: '#2D1020',
+      BUTTON_INACTIVE: '#2D1020',
+      BUTTON_INACTIVE_TEXT: '#F9A8D4',
+      SETTINGS_MENU: '#2D1020',
+      GRADIENT_PRIMARY: ['#ec4899', '#f43f5e'],
+    },
+  },
+};
 
 export const DESIGN_TOKENS = {
   GRADIENT_PRIMARY:        ['#667eea', '#764ba2'] as const,

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,7 +6,7 @@
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { STORAGE_KEYS } from './constants';
-import { ThemeMode, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat, StreakData } from '../types/game';
+import { ThemeMode, ThemeName, Language, Operation, NumberRange, DifficultyMode, SessionRecord, TaskStat, StreakData } from '../types/game';
 
 /**
  * Get a value from storage (platform-safe)
@@ -75,6 +75,18 @@ export const saveTheme = async (theme: ThemeMode): Promise<void> => {
 export const getTheme = async (): Promise<ThemeMode | null> => {
   const value = await getStorageItem(STORAGE_KEYS.THEME);
   if (value === 'light' || value === 'dark' || value === 'system') {
+    return value;
+  }
+  return null;
+};
+
+export const saveThemeName = async (themeName: ThemeName): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.THEME_NAME, themeName);
+};
+
+export const getThemeName = async (): Promise<ThemeName | null> => {
+  const value = await getStorageItem(STORAGE_KEYS.THEME_NAME);
+  if (value === 'sunset' || value === 'ocean' || value === 'space' || value === 'forest' || value === 'candy') {
     return value;
   }
   return null;

--- a/utils/theme.test.ts
+++ b/utils/theme.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { getThemeColors } from './theme';
-import { THEME_COLORS } from './constants';
+import { THEME_COLORS, THEMES } from './constants';
 
 describe('theme.ts - Theme Color Selection', () => {
   describe('Dark Mode Colors', () => {
@@ -23,6 +23,7 @@ describe('theme.ts - Theme Color Selection', () => {
         buttonInactiveText: THEME_COLORS.DARK.BUTTON_INACTIVE_TEXT,
         settingsOverlay: THEME_COLORS.DARK.SETTINGS_OVERLAY,
         settingsMenu: THEME_COLORS.DARK.SETTINGS_MENU,
+        gradientPrimary: THEMES.sunset.DARK.GRADIENT_PRIMARY,
       });
     });
 
@@ -62,6 +63,7 @@ describe('theme.ts - Theme Color Selection', () => {
         buttonInactiveText: THEME_COLORS.LIGHT.BUTTON_INACTIVE_TEXT,
         settingsOverlay: THEME_COLORS.LIGHT.SETTINGS_OVERLAY,
         settingsMenu: THEME_COLORS.LIGHT.SETTINGS_MENU,
+        gradientPrimary: THEMES.sunset.LIGHT.GRADIENT_PRIMARY,
       });
     });
 
@@ -114,22 +116,52 @@ describe('theme.ts - Theme Color Selection', () => {
       expect(colors).toHaveProperty('buttonInactiveText');
       expect(colors).toHaveProperty('settingsOverlay');
       expect(colors).toHaveProperty('settingsMenu');
+      expect(colors).toHaveProperty('gradientPrimary');
     });
 
-    it('should return valid color strings for all properties', () => {
+    it('should return valid color strings for string properties', () => {
       const lightColors = getThemeColors(false);
       const darkColors = getThemeColors(true);
 
-      // Check all colors are strings
-      Object.values(lightColors).forEach((color) => {
-        expect(typeof color).toBe('string');
-        expect(color.length).toBeGreaterThan(0);
+      const stringKeys: (keyof typeof lightColors)[] = [
+        'background', 'text', 'textSecondary', 'border', 'card',
+        'cardCorrect', 'cardIncorrect', 'buttonInactive', 'buttonInactiveText',
+        'settingsOverlay', 'settingsMenu',
+      ];
+
+      stringKeys.forEach((key) => {
+        expect(typeof lightColors[key]).toBe('string');
+        expect((lightColors[key] as string).length).toBeGreaterThan(0);
+        expect(typeof darkColors[key]).toBe('string');
+        expect((darkColors[key] as string).length).toBeGreaterThan(0);
       });
 
-      Object.values(darkColors).forEach((color) => {
-        expect(typeof color).toBe('string');
-        expect(color.length).toBeGreaterThan(0);
-      });
+      expect(Array.isArray(lightColors.gradientPrimary)).toBe(true);
+      expect(lightColors.gradientPrimary).toHaveLength(2);
+    });
+  });
+
+  describe('Theme Name Support', () => {
+    it('should default to sunset theme when no theme name given', () => {
+      const colors = getThemeColors(false);
+      expect(colors.gradientPrimary).toEqual(['#667eea', '#764ba2']);
+    });
+
+    it('should return ocean theme colors when themeName is ocean', () => {
+      const colors = getThemeColors(false, 'ocean');
+      expect(colors.background).toBe('#F0FAFF');
+      expect(colors.gradientPrimary).toEqual(['#06b6d4', '#0284c7']);
+    });
+
+    it('should return forest dark theme', () => {
+      const colors = getThemeColors(true, 'forest');
+      expect(colors.background).toBe('#0A1F10');
+      expect(colors.gradientPrimary).toEqual(['#22c55e', '#15803d']);
+    });
+
+    it('should fall back to sunset for invalid theme name', () => {
+      const colors = getThemeColors(false, 'invalid' as any);
+      expect(colors.gradientPrimary).toEqual(['#667eea', '#764ba2']);
     });
   });
 

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -2,40 +2,24 @@
  * Theme utilities for 1x1 Trainer
  */
 
-import { ThemeColors } from '../types/game';
-import { THEME_COLORS } from './constants';
+import { ThemeColors, ThemeName } from '../types/game';
+import { THEMES } from './constants';
 
-/**
- * Get theme colors based on dark mode state
- */
-export const getThemeColors = (isDarkMode: boolean): ThemeColors => {
-  if (isDarkMode) {
-    return {
-      background: THEME_COLORS.DARK.BACKGROUND,
-      text: THEME_COLORS.DARK.TEXT,
-      textSecondary: THEME_COLORS.DARK.TEXT_SECONDARY,
-      border: THEME_COLORS.DARK.BORDER,
-      card: THEME_COLORS.DARK.CARD,
-      cardCorrect: THEME_COLORS.DARK.CARD_CORRECT,
-      cardIncorrect: THEME_COLORS.DARK.CARD_INCORRECT,
-      buttonInactive: THEME_COLORS.DARK.BUTTON_INACTIVE,
-      buttonInactiveText: THEME_COLORS.DARK.BUTTON_INACTIVE_TEXT,
-      settingsOverlay: THEME_COLORS.DARK.SETTINGS_OVERLAY,
-      settingsMenu: THEME_COLORS.DARK.SETTINGS_MENU,
-    };
-  } else {
-    return {
-      background: THEME_COLORS.LIGHT.BACKGROUND,
-      text: THEME_COLORS.LIGHT.TEXT,
-      textSecondary: THEME_COLORS.LIGHT.TEXT_SECONDARY,
-      border: THEME_COLORS.LIGHT.BORDER,
-      card: THEME_COLORS.LIGHT.CARD,
-      cardCorrect: THEME_COLORS.LIGHT.CARD_CORRECT,
-      cardIncorrect: THEME_COLORS.LIGHT.CARD_INCORRECT,
-      buttonInactive: THEME_COLORS.LIGHT.BUTTON_INACTIVE,
-      buttonInactiveText: THEME_COLORS.LIGHT.BUTTON_INACTIVE_TEXT,
-      settingsOverlay: THEME_COLORS.LIGHT.SETTINGS_OVERLAY,
-      settingsMenu: THEME_COLORS.LIGHT.SETTINGS_MENU,
-    };
-  }
+export const getThemeColors = (isDarkMode: boolean, themeName: ThemeName = 'sunset'): ThemeColors => {
+  const theme = THEMES[themeName] ?? THEMES.sunset;
+  const variant = isDarkMode ? theme.DARK : theme.LIGHT;
+  return {
+    background: variant.BACKGROUND,
+    text: variant.TEXT,
+    textSecondary: variant.TEXT_SECONDARY,
+    border: variant.BORDER,
+    card: variant.CARD,
+    cardCorrect: variant.CARD_CORRECT,
+    cardIncorrect: variant.CARD_INCORRECT,
+    buttonInactive: variant.BUTTON_INACTIVE,
+    buttonInactiveText: variant.BUTTON_INACTIVE_TEXT,
+    settingsOverlay: variant.SETTINGS_OVERLAY,
+    settingsMenu: variant.SETTINGS_MENU,
+    gradientPrimary: variant.GRADIENT_PRIMARY,
+  };
 };


### PR DESCRIPTION
## Fixes #190 – Visuelle Themes / App-Skins

Ergänzt das bestehende Hell-/Dunkel-System um 5 wählbare Farbthemes.

### Was neu ist

**5 Themes** – je Light- und Dark-Variante:

| Theme | Gradient | Charakter |
|-------|----------|-----------|
| 🍊 Sunset | `#667eea → #764ba2` | Standard (bisheriges Design) |
| 🌊 Ocean | `#06b6d4 → #0284c7` | Kühl, entspannt |
| 🚀 Space | `#8B5CF6 → #4F46E5` | Mystisch, intensiv |
| 🌿 Forest | `#22c55e → #15803d` | Natürlich, beruhigend |
| 🩷 Candy | `#ec4899 → #f43f5e` | Verspielt, bunt |

### Theme-Wahl

- Neuer Abschnitt in `PersonalizeModal` mit Gradient-Swatches
- Aktives Theme wird mit Rahmen markiert
- Beschriftung `FARBTHEMA` / `COLOR THEME` (i18n)
- Theme persistiert über App-Neustart (`app-theme-name` Storage Key)

### Technische Umsetzung

- `ThemeName` Typ in `types/game.ts`
- `gradientPrimary: readonly [string, string]` zu `ThemeColors` hinzugefügt
- `THEMES: Record<ThemeName, { label, LIGHT, DARK }>` in `utils/constants.ts`
- `getThemeColors(isDarkMode, themeName?)` in `utils/theme.ts`
- `saveThemeName` / `getThemeName` in `utils/storage.ts`
- `themeName` / `setThemeName` in `usePreferences` + `useTheme`
- Alle Komponenten mit `colors`-Prop nutzen `colors.gradientPrimary` statt hartkodiertem `DESIGN_TOKENS.GRADIENT_PRIMARY`
- Hell-/Dunkel-Modus weiterhin unabhängig vom Theme

### Akzeptanzkriterien

- [x] 5 Themes implementiert (4+ gefordert)
- [x] Theme-Wahl in Settings mit visueller Vorschau (Gradient-Swatch)
- [x] Theme persistiert über App-Neustart
- [x] Hell-/Dunkel-Modus gilt unabhängig vom Theme
- [x] Bestehende Tests bleiben grün (481 passed, 14/14 Suites)

## Test plan
- [ ] PersonalizeModal öffnen → 5 Farbswatches sichtbar
- [ ] Theme wechseln → Gradient in Header, Buttons, Numpad ändert sich
- [ ] App neu starten → gewähltes Theme bleibt erhalten
- [ ] Hell-/Dunkel umschalten → Theme bleibt, nur Helligkeit wechselt
- [ ] `npm test` → 481 Tests grün

https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcLcBRGKQTiXFqv9VNd8sE)_