### PR TITLE
ci: Standards Audit Listener + fix flaky ParentDashboard test

### DIFF
--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,0 +1,38 @@
+name: Standards Audit
+
+# Konsumiert die zentralen Reusable Workflows aus project-templates
+# (S540d/project-templates#7 – Cross-Project-Standardisierung).
+# Läuft bei:
+#   - PRs (Audits gaten Code-Änderungen)
+#   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
+#   - manuell (workflow_dispatch)
+#
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – S540d/project-templates#7, Punkt 1).
+
+on:
+  pull_request:
+    branches: [main, staging, testing]
+  repository_dispatch:
+    types: [weekly-self-audit]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    with:
+      fail_on_findings: true
+
+  gitignore-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    with:
+      fail_on_missing: true
+
+  # Rein informativ: der Audit-Step im Reusable Workflow ist intern non-blocking
+  # (läuft auch bei Abweichungen grün durch). Ein job-level continue-on-error ist
+  # auf uses:-Jobs nicht erlaubt – die Non-Blocking-Semantik muss daher im Template
+  # bleiben; security-scan und gitignore-audit (fail_on_*: true) gaten den Merge.
+  dev-standards-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ public/screenshot*.png
 public/screenshot2.png
 public/favicon-new.png
 playstore-screenshots/
+
+# Security – Pflicht-Einträge (Issue #7 / reusable-gitignore-audit)
+.env.local

--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -78,7 +78,7 @@ describe('ParentDashboard', () => {
   });
 
   it('shows session count in summary bar', async () => {
-    mockGetSessionRecords.mockResolvedValue([makeRecord(), makeRecord()]);
+    mockGetSessionRecords.mockResolvedValue([makeRecord({ errors: 0 }), makeRecord({ errors: 0 })]);
     const { getByText } = render(
       <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
     );


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds the central Standards Audit listener from project-templates#7 (reusable workflows: security-scan, gitignore-audit, dev-standards-audit, all pinned to @v1)
- Adds missing `.env.local` entry to `.gitignore` (required by reusable-gitignore-audit)
- **Fixes failing Jest test** `ParentDashboard › shows session count in summary bar`: `makeRecord()` defaults to `errors: 2`, which caused `getByText('2')` to find 3 DOM nodes (session count + 2× error count per record). Fix: pass `errors: 0` in this specific test.

Supersedes PR #216 (same changes + test fix).

## Test plan

- [ ] CI Jest tests pass (previously 1 failing)
- [ ] security-scan / gitignore-audit / dev-standards-audit workflows run green

https://claude.ai/code/session_01Xf5drJRdyWbJikyZuU9eq2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xf5drJRdyWbJikyZuU9eq2)_