### PR TITLE
ci: Standards Audit Listener + fix flaky ParentDashboard test

### DIFF
--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -79,11 +79,12 @@ describe('ParentDashboard', () => {
 
   it('shows session count in summary bar', async () => {
     mockGetSessionRecords.mockResolvedValue([makeRecord({ errors: 0 }), makeRecord({ errors: 0 })]);
-    const { getByText } = render(
+    const { getAllByText, getByText } = render(
       <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
     );
     await waitFor(() => {
-      expect(getByText('2')).toBeTruthy();
+      // use getAllByText because chart axis labels may also render '2' on the 2nd of a month
+      expect(getAllByText('2').length).toBeGreaterThan(0);
       expect(getByText(t.parentSessions)).toBeTruthy();
     });
   });


### PR DESCRIPTION
Supersedes #216.

## Was ist drin

- `.github/workflows/standards-audit.yml` – Standards-Audit-Listener aus `S540d/project-templates#7` (reusable-security-scan, reusable-gitignore-audit, reusable-dev-standards-audit, alle @v1 gepinnt)
- `.gitignore` – Pflicht-Eintrag `.env.local` (gitignore-audit)
- `components/ParentDashboard.test.tsx` – Flaky-Test-Fix: `getByText('2')` → `getAllByText('2')`, da `MiniBarChart`-Achsenlabels ebenfalls „2" rendern wenn der aktuelle Tag der 2. des Monats ist

## Test plan
- [ ] `npm test` läuft grün durch (15/15 Suites)
- [ ] Standards-Audit-Workflow triggert bei PRs auf `main`/`staging`/`testing`

---
_Generated by [Claude Code](https://claude.ai/code/session_019vBMKU73sfmw49uPE2MzuC)_