### PR TITLE
ci: lokale Checks ausrollen (Issue #7) – gitignore-Audit, .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig – kanonische Basis für alle Projekte (Issue #7)
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,0 +1,38 @@
+name: Standards Audit
+
+# Konsumiert die zentralen Reusable Workflows aus project-templates
+# (S540d/project-templates#7 – Cross-Project-Standardisierung).
+# Läuft bei:
+#   - PRs (Audits gaten Code-Änderungen)
+#   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
+#   - manuell (workflow_dispatch)
+#
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – S540d/project-templates#7, Punkt 1).
+
+on:
+  pull_request:
+    branches: [main, staging, testing]
+  repository_dispatch:
+    types: [weekly-self-audit]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    with:
+      fail_on_findings: true
+
+  gitignore-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    with:
+      fail_on_missing: true
+
+  # Rein informativ: der Audit-Step im Reusable Workflow ist intern non-blocking
+  # (läuft auch bei Abweichungen grün durch). Ein job-level continue-on-error ist
+  # auf uses:-Jobs nicht erlaubt – die Non-Blocking-Semantik muss daher im Template
+  # bleiben; security-scan und gitignore-audit (fail_on_*: true) gaten den Merge.
+  dev-standards-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ public/screenshot*.png
 public/screenshot2.png
 public/favicon-new.png
 playstore-screenshots/
+
+# Security – Pflicht-Einträge (Issue #7 / reusable-gitignore-audit)
+.env.local

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -99,11 +99,15 @@ fi
 # GITIGNORE AUDIT: Pflicht-Einträge (spiegelt reusable-gitignore-audit.yml)
 # ============================================================================
 echo "Checking .gitignore for required entries..."
+if [ ! -f .gitignore ]; then
+  echo "❌ ERROR: .gitignore not found — create it and add the required entries."
+  exit 1
+fi
 GITIGNORE_PROBLEMS=0
 set -f
 REQUIRED_GITIGNORE_ENTRIES=".env .env.local credentials.json *.jks *.keystore *.p12 *.p8 docs/private/"
 for entry in $REQUIRED_GITIGNORE_ENTRIES; do
-  if ! grep -Fq "$entry" .gitignore 2>/dev/null; then
+  if ! grep -Fxq "$entry" .gitignore 2>/dev/null; then
     echo "❌ ERROR: Missing required .gitignore entry: '$entry'"
     GITIGNORE_PROBLEMS=1
   fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -95,4 +95,23 @@ if echo "$STAGED_ALL" | grep -qE "\.(keystore|jks)$"; then
   exit 1
 fi
 
+# ============================================================================
+# GITIGNORE AUDIT: Pflicht-Einträge (spiegelt reusable-gitignore-audit.yml)
+# ============================================================================
+echo "Checking .gitignore for required entries..."
+GITIGNORE_PROBLEMS=0
+set -f
+REQUIRED_GITIGNORE_ENTRIES=".env .env.local credentials.json *.jks *.keystore *.p12 *.p8 docs/private/"
+for entry in $REQUIRED_GITIGNORE_ENTRIES; do
+  if ! grep -Fq "$entry" .gitignore 2>/dev/null; then
+    echo "❌ ERROR: Missing required .gitignore entry: '$entry'"
+    GITIGNORE_PROBLEMS=1
+  fi
+done
+set +f
+if [ "$GITIGNORE_PROBLEMS" -ne 0 ]; then
+  echo "Add the missing entries to .gitignore before committing."
+  exit 1
+fi
+
 echo "✅ Pre-commit checks passed!"


### PR DESCRIPTION
## Was

Rollout der lokalen Checks aus project-templates#7 (Pilot: EnergyPriceGermany PR #319).

| Check | Vorher | Nachher |
|---|---|---|
| `.gitignore` Pflicht-Einträge | ❌ nur CI | ✅ pre-commit |
| `.editorconfig` | ❌ fehlte | ✅ aus `project-templates/dev-standards/base/` |

> pre-push entfällt mangels Prettier-Setup in diesem Repo.

## Details

- `.husky/pre-commit`: gitignore-Audit-Block ergänzt (8 Pflichteinträge, `set -f`/`set +f` gegen sh-Glob-Expansion)
- `.editorconfig`: aus `project-templates/dev-standards/base/` übernommen