### PR TITLE
ci: pr-review.yml contents: read → write (Autofix-Job benötigt Push-Rechte)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
   statuses: write
 
 jobs:


### PR DESCRIPTION
## Summary
- \`pr-review.yml\` hatte \`contents: read\` — der Autofix-Job im reusable Workflow braucht aber \`contents: write\` um \`[auto]\`-Commits auf den PR-Branch zu pushen
- Ohne diese Änderung schlägt der \`pr-review\`-Workflow mit einem Workflow-File-Issue fehl

## Test plan
- [ ] Nächster PR triggert \`PR Review (Claude)\` erfolgreich
- [ ] Autofix-Job kann Commits pushen

🤖 Generated with [Claude Code](https://claude.com/claude-code)