### PR TITLE
fix: Sounds sofort stoppen wenn deaktiviert (Issue #241)

### DIFF
--- a/hooks/useSounds.test.ts
+++ b/hooks/useSounds.test.ts
@@ -68,6 +68,19 @@ describe('useSounds – web platform', () => {
     act(() => { result.current.playSound('correct'); });
     expect(AudioContextMock).toHaveBeenCalledTimes(1);
   });
+
+  it('stops playing after soundEnabled changes from true to false', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useSounds(enabled, 80),
+      { initialProps: { enabled: true } }
+    );
+    act(() => { result.current.playSound('correct'); });
+    expect(AudioContextMock).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    act(() => { result.current.playSound('correct'); });
+    expect(AudioContextMock).toHaveBeenCalledTimes(1); // no additional call
+  });
 });
 
 type MockPlayer = { play: jest.Mock; pause: jest.Mock; seekTo: jest.Mock; remove: jest.Mock; volume: number };
@@ -118,6 +131,20 @@ describe('useSounds – native platform', () => {
     unmount();
     for (const p of players) {
       expect(p.remove).toHaveBeenCalled();
+    }
+  });
+
+  it('pauses all native players when soundEnabled changes to false', () => {
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) => useSounds(enabled, 80),
+      { initialProps: { enabled: true } }
+    );
+    const players = mockCreateAudioPlayer.mock.results.map((r) => r.value as MockPlayer);
+
+    act(() => { rerender({ enabled: false }); });
+
+    for (const p of players) {
+      expect(p.pause).toHaveBeenCalled();
     }
   });
 });

--- a/hooks/useSounds.ts
+++ b/hooks/useSounds.ts
@@ -51,7 +51,14 @@ export function useSounds(soundEnabled: boolean, soundVolume: number) {
   const enabledRef = useRef(soundEnabled);
   const volumeRef = useRef(soundVolume);
 
-  useEffect(() => { enabledRef.current = soundEnabled; }, [soundEnabled]);
+  useEffect(() => {
+    enabledRef.current = soundEnabled;
+    if (!soundEnabled && Platform.OS !== 'web') {
+      for (const p of Object.values(playerRefs.current)) {
+        try { p?.pause(); } catch { /* ignore */ }
+      }
+    }
+  }, [soundEnabled]);
   useEffect(() => { volumeRef.current = soundVolume; }, [soundVolume]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Wenn Sounds über die Einstellungen deaktiviert werden, spielen laufende Töne (Native/expo-audio) noch zu Ende.

## Lösung

`useSounds.ts`: Pausiert alle nativen Audio-Player sofort wenn `soundEnabled` auf `false` wechselt – via dem bestehenden `useEffect` für `enabledRef`.

Web-Töne sind zu kurz (80–200 ms) um das als Problem wahrzunehmen; die Änderung gilt daher nur für `Platform.OS !== 'web'`.

## Änderungen

- `hooks/useSounds.ts` – `pause()` auf alle Player aufrufen wenn sounds deaktiviert werden
- `hooks/useSounds.test.ts` – Test für `true → false` Toggle (Web & Native)

## Test

- [ ] Sounds ein → Aufgabe beantworten → direkt auf „Aus" tippen → kein Ton mehr hörbar
- [ ] Sounds aus → Aufgabe beantworten → kein Ton
- [ ] CI grün

Closes #241

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqXaGKTnCftdEEDMAzF7k)_