### PR TITLE
feat: Orientation-Einschränkung entfernen für Tablet/Foldable-Support (Issue #235)

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "1x1 Trainer",
     "slug": "1x1-trainer",
     "version": "1.3.8",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,


### PR DESCRIPTION
## Problem

Google Play meldet eine Warnung wegen `"orientation": "portrait"` in `app.json` – verhindert Landscape-Modus auf Tablets und Foldables.

## Lösung

Ändert `orientation` von `"portrait"` auf `"default"` in `app.json`.

## Änderungen

- `app.json` – `"orientation": "portrait"` → `"orientation": "default"`

## Offene Punkte

Responsive Layout-Anpassungen (kein Overflow auf breiten Screens) sind im Issue als separate Arbeit beschrieben und können in einem Follow-up angegangen werden. Diese minimale Änderung behebt die Play-Store-Warnung.

## Test

- [ ] App dreht sich auf Tablet/Emulator in Landscape
- [ ] Kein offensichtlicher Layout-Overflow auf breiten Screens
- [ ] CI grün

Closes #235

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqXaGKTnCftdEEDMAzF7k)_