### PR TITLE
build: app.config.js für APP_PACKAGE env-var beim lokalen Build (Issue #233)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -30,7 +30,7 @@ if [ -n "$STAGED_TS_FILES" ]; then
 fi
 
 # Check version consistency if package.json or app.json changed
-if git diff --cached --name-only | grep -E "(package\.json|app\.json|App\.tsx|build\.gradle\.kts)" >/dev/null; then
+if git diff --cached --name-only | grep -E "(package\.json|app\.json|app\.config\.js|App\.tsx|build\.gradle\.kts)" >/dev/null; then
   echo "Checking version consistency..."
 
   PACKAGE_VERSION=$(node -p "require('./package.json').version" 2>/dev/null)

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,11 @@
+const base = require('./app.json');
+
+module.exports = {
+  expo: {
+    ...base.expo,
+    android: {
+      ...base.expo.android,
+      package: process.env.APP_PACKAGE || base.expo.android.package,
+    },
+  },
+};


### PR DESCRIPTION
## Problem

Lokaler AAB-Build erfordert manuelles Editieren von `app.json` (package `com.devsven` → `com.sven4321`), was durch den pre-commit Hook nach dem Build wieder rückgängig gemacht werden muss.

## Lösung (Option B aus Issue)

Neue `app.config.js` liest `android.package` aus der `APP_PACKAGE` Umgebungsvariable – fällt auf den `app.json`-Platzhalter zurück wenn nicht gesetzt. Analog zum bestehenden CI-Workflow.

Lokaler Build damit ohne manuelles Editieren:
```bash
APP_PACKAGE=com.sven4321.trainer1x1 npx expo prebuild --platform android --clean
cd android && ./gradlew bundleRelease
```

## Änderungen

- `app.config.js` (neu) – dynamische Konfiguration mit `APP_PACKAGE` env-var
- `.husky/pre-commit` – `app.config.js` in Versionsabgleich-Trigger aufgenommen

## Hinweise

- `app.json` bleibt unverändert (Platzhalter `com.devsven.x1x1trainer`)
- Pre-commit Hook prüft weiterhin nur `app.json` auf `com.sven*` – `app.config.js` enthält nur die env-var-Referenz, keinen Hardcode
- Versions-Konsistenzcheck liest weiterhin aus `app.json`

## Test

- [ ] `npx expo prebuild` ohne env-var nutzt `com.devsven.x1x1trainer` ✓
- [ ] `APP_PACKAGE=com.sven4321.trainer1x1 npx expo prebuild` nutzt Store-Package ✓
- [ ] CI grün

Closes #233

---
_Generated by [Claude Code](https://claude.ai/code/session_018uqXaGKTnCftdEEDMAzF7k)_