### PR TITLE
feat: multi-profile support for child profiles (#187)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import { OnboardingModal } from './components/OnboardingModal';
 import { BadgesModal } from './components/BadgesModal';
 import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
+import { ProfilePickerModal } from './components/ProfilePickerModal';
 import {
   saveSessionRecord,
   getStreakData,
@@ -50,9 +51,12 @@ import {
   setOnboardingDone,
   resetOnboarding,
   getStorageItem,
+  migrateToProfiles,
+  getProfiles,
+  setActiveProfileId,
 } from './utils/storage';
 import { useSounds } from './hooks/useSounds';
-import { SessionRecord, StreakData, TaskStat, Operation } from './types/game';
+import { ChildProfile, SessionRecord, StreakData, TaskStat, Operation } from './types/game';
 import { useBadges } from './hooks/useBadges';
 import {
   ANIMATION_DURATIONS,
@@ -75,6 +79,7 @@ export default function App() {
   const [personalizeVisible, setPersonalizeVisible] = useState(false);
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [badgesVisible, setBadgesVisible] = useState(false);
+  const [profilePickerVisible, setProfilePickerVisible] = useState(false);
   const [showMotivation, setShowMotivation] = useState(false);
   const [motivationScore, setMotivationScore] = useState(0);
   const [streakData, setStreakData] = useState<StreakData>({
@@ -85,6 +90,14 @@ export default function App() {
   const [streakWarningVisible, setStreakWarningVisible] = useState(false);
   const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
+
+  // Profile state
+  const [activeProfile, setActiveProfile] = useState<ChildProfile | null>(null);
+  const [profiles, setProfiles] = useState<ChildProfile[]>([]);
+  // Ref so callbacks always see the current profileId without stale closures
+  const activeProfileIdRef = useRef<string | undefined>(undefined);
+  activeProfileIdRef.current = activeProfile?.id;
+
   const weakTaskCount = useMemo(() => getWeakTasks(taskStats, 3, 0.3).length, [taskStats]);
 
   // Reduced motion preference — centralized in utils/animations.ts
@@ -92,9 +105,19 @@ export default function App() {
     return initReducedMotionListener();
   }, []);
 
+  // Migrate global storage → profile-keyed storage on first launch; idempotent after that
   useEffect(() => {
-    getTaskStats().then(setTaskStats);
+    migrateToProfiles().then(async (defaultProfile) => {
+      const allProfiles = await getProfiles();
+      setProfiles(allProfiles);
+      setActiveProfile(defaultProfile);
+    });
   }, []);
+
+  useEffect(() => {
+    if (!activeProfile) return;
+    getTaskStats(activeProfile.id).then(setTaskStats);
+  }, [activeProfile?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Animation values
   const cardScale = useRef(new Animated.Value(1)).current;
@@ -103,10 +126,10 @@ export default function App() {
   const menuOpacity = useRef(new Animated.Value(0)).current;
 
   // Use custom hooks
-  const preferences = usePreferences();
+  const preferences = usePreferences(activeProfile?.id);
   const theme = useTheme(preferences.themeMode, preferences.themeName);
   const sounds = useSounds(preferences.soundEnabled, preferences.soundVolume);
-  const badgeSystem = useBadges();
+  const badgeSystem = useBadges(activeProfile?.id);
   const game = useGameLogic({
     initialOperation: preferences.operation,
     initialOperations: preferences.operations,
@@ -120,9 +143,10 @@ export default function App() {
       if (record.correctTasks === record.totalTasks) {
         sounds.playSound('perfect');
       }
-      saveSessionRecord(record)
+      const pid = activeProfileIdRef.current;
+      saveSessionRecord(record, pid)
         .then(async () => {
-          const updatedStreak = await updateStreakAfterSession();
+          const updatedStreak = await updateStreakAfterSession(pid);
           setStreakData(updatedStreak);
           await badgeSystem.checkAndUnlock(record);
         })
@@ -155,7 +179,7 @@ export default function App() {
           },
         ];
       });
-      recordTaskResult(num1, num2, operation, isCorrect);
+      recordTaskResult(num1, num2, operation, isCorrect, activeProfileIdRef.current);
     },
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
@@ -253,7 +277,8 @@ export default function App() {
 
   // Load streak data and show warning when appropriate
   useEffect(() => {
-    getStreakData().then((data) => {
+    if (!activeProfile) return;
+    getStreakData(activeProfile.id).then((data) => {
       setStreakData(data);
       const now = new Date();
       const isEvening = now.getHours() >= 20;
@@ -263,7 +288,7 @@ export default function App() {
         setStreakWarningVisible(true);
       }
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeProfile?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Sound + card feedback on answer check
   useEffect(() => {
@@ -392,6 +417,10 @@ export default function App() {
             setOnboardingVisible(true);
           }}
           onOpenBadges={() => setBadgesVisible(true)}
+          onOpenProfiles={() => {
+            setProfilePickerVisible(true);
+            hideMenu();
+          }}
           t={t}
         />
       )}
@@ -457,6 +486,30 @@ export default function App() {
       <ParentDashboard
         visible={parentDashboardVisible}
         onClose={() => setParentDashboardVisible(false)}
+        colors={colors}
+        t={t}
+      />
+
+      <ProfilePickerModal
+        visible={profilePickerVisible}
+        onClose={() => setProfilePickerVisible(false)}
+        profiles={profiles}
+        activeProfileId={activeProfile?.id}
+        onSwitchProfile={async (profile) => {
+          setActiveProfile(profile);
+          await setActiveProfileId(profile.id);
+          setProfilePickerVisible(false);
+        }}
+        onProfilesChange={(updated) => {
+          setProfiles(updated);
+          // If active profile was deleted, switch to first remaining
+          if (activeProfile && !updated.find((p) => p.id === activeProfile.id)) {
+            if (updated.length > 0) {
+              setActiveProfile(updated[0]);
+              setActiveProfileId(updated[0].id);
+            }
+          }
+        }}
         colors={colors}
         t={t}
       />

--- a/components/ProfilePickerModal.tsx
+++ b/components/ProfilePickerModal.tsx
@@ -1,0 +1,410 @@
+import React, { useState } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+  Alert,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { ChildProfile, ThemeColors } from '../types/game';
+import { AVATAR_COLORS } from '../utils/constants';
+import { createProfile, deleteProfileData, saveProfiles, getProfiles } from '../utils/storage';
+
+const MAX_PROFILES = 6;
+
+interface ProfilePickerModalProps {
+  visible: boolean;
+  onClose: () => void;
+  profiles: ChildProfile[];
+  activeProfileId: string | undefined;
+  onSwitchProfile: (profile: ChildProfile) => void;
+  onProfilesChange: (profiles: ChildProfile[]) => void;
+  colors: ThemeColors;
+  t: {
+    profiles: string;
+    profilesSubtitle: string;
+    addProfile: string;
+    createProfile: string;
+    profileNamePlaceholder: string;
+    saveProfile: string;
+    cancel: string;
+    deleteProfile: string;
+    deleteProfileConfirm: string;
+    maxProfilesReached: string;
+    profileActive: string;
+  };
+}
+
+export function ProfilePickerModal({
+  visible,
+  onClose,
+  profiles,
+  activeProfileId,
+  onSwitchProfile,
+  onProfilesChange,
+  colors,
+  t,
+}: ProfilePickerModalProps) {
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [selectedColor, setSelectedColor] = useState<string>(AVATAR_COLORS[0]);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleClose = () => {
+    setShowCreateForm(false);
+    setNewName('');
+    setSelectedColor(AVATAR_COLORS[0]);
+    onClose();
+  };
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    setIsSaving(true);
+    try {
+      await createProfile(trimmed, selectedColor);
+      const updated = await getProfiles();
+      onProfilesChange(updated);
+      setShowCreateForm(false);
+      setNewName('');
+      setSelectedColor(AVATAR_COLORS[0]);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = (profile: ChildProfile) => {
+    if (profiles.length <= 1) return;
+    Alert.alert(t.deleteProfile, `"${profile.name}" — ${t.deleteProfileConfirm}`, [
+      { text: t.cancel, style: 'cancel' },
+      {
+        text: t.deleteProfile,
+        style: 'destructive',
+        onPress: async () => {
+          await deleteProfileData(profile.id);
+          const remaining = profiles.filter((p) => p.id !== profile.id);
+          await saveProfiles(remaining);
+          onProfilesChange(remaining);
+        },
+      },
+    ]);
+  };
+
+  const activeColor = colors.gradientPrimary[0];
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <View style={styles.overlay}>
+        <View style={[styles.sheet, { backgroundColor: colors.settingsMenu }]}>
+          {/* Header */}
+          <LinearGradient
+            colors={colors.gradientPrimary}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.header}
+          >
+            <Text style={styles.headerTitle}>{t.profiles}</Text>
+            <TouchableOpacity style={styles.closeButton} onPress={handleClose}>
+              <Text style={styles.closeButtonText}>✕</Text>
+            </TouchableOpacity>
+          </LinearGradient>
+
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            {t.profilesSubtitle}
+          </Text>
+
+          <ScrollView bounces={false} style={styles.list}>
+            {profiles.map((profile) => {
+              const isActive = profile.id === activeProfileId;
+              return (
+                <View key={profile.id} style={[styles.profileRow, { borderColor: colors.border }]}>
+                  <TouchableOpacity
+                    style={styles.profileInfo}
+                    onPress={() => !isActive && onSwitchProfile(profile)}
+                    activeOpacity={isActive ? 1 : 0.7}
+                  >
+                    <View style={[styles.avatar, { backgroundColor: profile.avatarColor }]}>
+                      <Text style={styles.avatarText}>{profile.name.charAt(0).toUpperCase()}</Text>
+                    </View>
+                    <View style={styles.profileTextBlock}>
+                      <Text style={[styles.profileName, { color: colors.text }]}>
+                        {profile.name}
+                      </Text>
+                      {isActive && (
+                        <Text style={[styles.activeLabel, { color: activeColor }]}>
+                          {t.profileActive}
+                        </Text>
+                      )}
+                    </View>
+                  </TouchableOpacity>
+                  {profiles.length > 1 && (
+                    <TouchableOpacity
+                      style={styles.deleteButton}
+                      onPress={() => handleDelete(profile)}
+                    >
+                      <Text style={[styles.deleteButtonText, { color: colors.textSecondary }]}>
+                        🗑
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          {/* Create form or Add button */}
+          {showCreateForm ? (
+            <View style={[styles.createForm, { borderTopColor: colors.border }]}>
+              <Text style={[styles.createTitle, { color: colors.text }]}>{t.createProfile}</Text>
+              <TextInput
+                style={[
+                  styles.nameInput,
+                  { color: colors.text, borderColor: colors.border, backgroundColor: colors.card },
+                ]}
+                placeholder={t.profileNamePlaceholder}
+                placeholderTextColor={colors.textSecondary}
+                value={newName}
+                onChangeText={setNewName}
+                maxLength={20}
+                autoFocus
+              />
+              <View style={styles.colorRow}>
+                {AVATAR_COLORS.map((color) => (
+                  <TouchableOpacity
+                    key={color}
+                    style={[
+                      styles.colorSwatch,
+                      { backgroundColor: color },
+                      selectedColor === color && styles.colorSwatchSelected,
+                    ]}
+                    onPress={() => setSelectedColor(color)}
+                  />
+                ))}
+              </View>
+              <View style={styles.formButtons}>
+                <TouchableOpacity
+                  style={[styles.formButton, { borderColor: colors.border }]}
+                  onPress={() => {
+                    setShowCreateForm(false);
+                    setNewName('');
+                    setSelectedColor(AVATAR_COLORS[0]);
+                  }}
+                >
+                  <Text style={[styles.formButtonText, { color: colors.textSecondary }]}>
+                    {t.cancel}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.formButton,
+                    styles.saveButton,
+                    { backgroundColor: activeColor },
+                    (!newName.trim() || isSaving) && styles.disabledButton,
+                  ]}
+                  onPress={handleCreate}
+                  disabled={!newName.trim() || isSaving}
+                >
+                  <Text style={styles.saveButtonText}>{t.saveProfile}</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ) : (
+            <View style={[styles.addButtonWrapper, { borderTopColor: colors.border }]}>
+              {profiles.length < MAX_PROFILES ? (
+                <TouchableOpacity
+                  style={[styles.addButton, { borderColor: activeColor }]}
+                  onPress={() => setShowCreateForm(true)}
+                >
+                  <Text style={[styles.addButtonText, { color: activeColor }]}>
+                    + {t.addProfile}
+                  </Text>
+                </TouchableOpacity>
+              ) : (
+                <Text style={[styles.maxReachedText, { color: colors.textSecondary }]}>
+                  {t.maxProfilesReached}
+                </Text>
+              )}
+            </View>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    maxHeight: '80%',
+    paddingBottom: 24,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  headerTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  closeButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  subtitle: {
+    fontSize: 13,
+    textAlign: 'center',
+    marginVertical: 10,
+    paddingHorizontal: 20,
+  },
+  list: {
+    flexGrow: 0,
+    maxHeight: 320,
+    paddingHorizontal: 16,
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    paddingVertical: 12,
+  },
+  profileInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  profileTextBlock: {
+    gap: 2,
+  },
+  profileName: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  activeLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  deleteButton: {
+    padding: 8,
+  },
+  deleteButtonText: {
+    fontSize: 18,
+  },
+  createForm: {
+    borderTopWidth: 1,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    gap: 12,
+  },
+  createTitle: {
+    fontSize: 15,
+    fontWeight: 'bold',
+  },
+  nameInput: {
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 15,
+  },
+  colorRow: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  colorSwatch: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+  },
+  colorSwatchSelected: {
+    borderWidth: 3,
+    borderColor: '#fff',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  formButtons: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  formButton: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 11,
+    alignItems: 'center',
+  },
+  formButtonText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  saveButton: {
+    borderColor: 'transparent',
+  },
+  saveButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  disabledButton: {
+    opacity: 0.45,
+  },
+  addButtonWrapper: {
+    borderTopWidth: 1,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    alignItems: 'center',
+  },
+  addButton: {
+    borderWidth: 1.5,
+    borderRadius: 14,
+    paddingVertical: 11,
+    paddingHorizontal: 28,
+  },
+  addButtonText: {
+    fontSize: 15,
+    fontWeight: 'bold',
+  },
+  maxReachedText: {
+    fontSize: 13,
+    textAlign: 'center',
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -34,6 +34,7 @@ interface SettingsMenuProps {
   onOpenParentDashboard: () => void;
   onResetOnboarding: () => void;
   onOpenBadges: () => void;
+  onOpenProfiles: () => void;
   // Translations
   t: {
     operation: string;
@@ -59,6 +60,7 @@ interface SettingsMenuProps {
     parentDashboard: string;
     parentDashboardMenu: string;
     badgesMenu: string;
+    profilesMenu: string;
     feedback: string;
     support: string;
     about: string;
@@ -84,6 +86,7 @@ export function SettingsMenu({
   onOpenParentDashboard,
   onResetOnboarding,
   onOpenBadges,
+  onOpenProfiles,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -153,6 +156,14 @@ export function SettingsMenu({
             >
               <Text style={[styles.personalizeButtonText, { color: activeColor }]}>
                 {t.badgesMenu}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.personalizeButton, { borderColor: activeColor }]}
+              onPress={onOpenProfiles}
+            >
+              <Text style={[styles.personalizeButtonText, { color: activeColor }]}>
+                {t.profilesMenu}
               </Text>
             </TouchableOpacity>
           </View>

--- a/hooks/useBadges.ts
+++ b/hooks/useBadges.ts
@@ -125,44 +125,53 @@ export function advanceStreak(current: StreakData): StreakData {
 
 // --- hook ---
 
-export function useBadges() {
+export function useBadges(profileId?: string) {
   const [badges, setBadges] = useState<BadgeStore>({});
   const [isLoaded, setIsLoaded] = useState(false);
   const [newlyUnlocked, setNewlyUnlocked] = useState<string[]>([]);
 
   useEffect(() => {
-    getBadges().then((b) => {
-      setBadges(b);
-      setIsLoaded(true);
+    let cancelled = false;
+    getBadges(profileId).then((b) => {
+      if (!cancelled) {
+        setBadges(b);
+        setIsLoaded(true);
+      }
     });
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId]);
 
-  const checkAndUnlock = useCallback(async (record: SessionRecord) => {
-    const [existing, allRecords, challengeHighScore, streakData] = await Promise.all([
-      getBadges(),
-      getSessionRecords(),
-      getChallengeHighScore(),
-      getStreakData(),
-    ]);
+  const checkAndUnlock = useCallback(
+    async (record: SessionRecord) => {
+      const [existing, allRecords, challengeHighScore, streakData] = await Promise.all([
+        getBadges(profileId),
+        getSessionRecords(profileId),
+        getChallengeHighScore(profileId),
+        getStreakData(profileId),
+      ]);
 
-    const newIds = computeNewlyUnlocked(
-      record,
-      allRecords,
-      challengeHighScore,
-      existing,
-      streakData.currentStreak
-    );
-    if (newIds.length === 0) return;
+      const newIds = computeNewlyUnlocked(
+        record,
+        allRecords,
+        challengeHighScore,
+        existing,
+        streakData.currentStreak
+      );
+      if (newIds.length === 0) return;
 
-    const now = Date.now();
-    const updated: BadgeStore = { ...existing };
-    for (const id of newIds) {
-      updated[id] = now;
-    }
-    await saveBadges(updated);
-    setBadges(updated);
-    setNewlyUnlocked(newIds);
-  }, []);
+      const now = Date.now();
+      const updated: BadgeStore = { ...existing };
+      for (const id of newIds) {
+        updated[id] = now;
+      }
+      await saveBadges(updated, profileId);
+      setBadges(updated);
+      setNewlyUnlocked(newIds);
+    },
+    [profileId]
+  );
 
   const clearNewlyUnlocked = useCallback(() => {
     setNewlyUnlocked([]);

--- a/hooks/usePreferences.test.tsx
+++ b/hooks/usePreferences.test.tsx
@@ -157,7 +157,7 @@ describe('usePreferences Hook', () => {
       });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to load preferences:',
+        'Failed to load global preferences:',
         expect.any(Error)
       );
 
@@ -450,7 +450,7 @@ describe('usePreferences Hook', () => {
       });
 
       await waitFor(() => {
-        expect(mockSaveOperations).toHaveBeenCalledWith(newOperations);
+        expect(mockSaveOperations).toHaveBeenCalledWith(newOperations, undefined);
       });
     });
 
@@ -604,7 +604,7 @@ describe('usePreferences Hook', () => {
       });
 
       await waitFor(() => {
-        expect(mockSaveNumberRange).toHaveBeenCalledWith(NumberRange.RANGE_10);
+        expect(mockSaveNumberRange).toHaveBeenCalledWith(NumberRange.RANGE_10, undefined);
       });
     });
 
@@ -677,7 +677,7 @@ describe('usePreferences Hook', () => {
       });
 
       await waitFor(() => {
-        expect(mockSaveTotalTasks).toHaveBeenCalledWith(100);
+        expect(mockSaveTotalTasks).toHaveBeenCalledWith(100, undefined);
       });
     });
 
@@ -782,7 +782,7 @@ describe('usePreferences Hook', () => {
       });
 
       await waitFor(() => {
-        expect(mockSaveNumberRange).toHaveBeenCalledWith(NumberRange.RANGE_10);
+        expect(mockSaveNumberRange).toHaveBeenCalledWith(NumberRange.RANGE_10, undefined);
       });
     });
 
@@ -800,7 +800,7 @@ describe('usePreferences Hook', () => {
       });
 
       await waitFor(() => {
-        expect(mockSaveTotalTasks).toHaveBeenCalledWith(15);
+        expect(mockSaveTotalTasks).toHaveBeenCalledWith(15, undefined);
       });
     });
 
@@ -843,7 +843,7 @@ describe('usePreferences Hook', () => {
       });
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to load preferences:',
+        'Failed to load global preferences:',
         expect.any(Error)
       );
 

--- a/hooks/usePreferences.ts
+++ b/hooks/usePreferences.ts
@@ -3,7 +3,7 @@
  * Manages user preferences with auto-save and auto-load
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Language, ThemeMode, ThemeName, Operation, NumberRange } from '../types/game';
 import {
   getLanguage,
@@ -27,7 +27,11 @@ import {
 } from '../utils/storage';
 import { getDeviceLanguage } from '../utils/language';
 
-export function usePreferences() {
+export function usePreferences(profileId?: string) {
+  // Track current profileId in a ref so auto-save closures always use the latest value
+  const profileIdRef = useRef(profileId);
+  profileIdRef.current = profileId;
+
   const [language, setLanguage] = useState<Language>('en');
   const [themeMode, setThemeMode] = useState<ThemeMode>('light');
   const [themeName, setThemeName] = useState<ThemeName>('sunset');
@@ -39,129 +43,79 @@ export function usePreferences() {
   const [soundVolume, setSoundVolume] = useState(75);
   const [isLoaded, setIsLoaded] = useState(false);
 
-  // Load preferences on mount
+  // Load global preferences once on mount (language, theme, sounds are not per-profile)
   useEffect(() => {
-    const loadPreferences = async () => {
+    const loadGlobalPreferences = async () => {
       try {
-        // Load language
         const savedLanguage = await getLanguage();
         if (savedLanguage) {
           setLanguage(savedLanguage);
         } else {
-          // Auto-detect device language
           const detectedLang = getDeviceLanguage();
           setLanguage(detectedLang);
-          // Language will be saved by the auto-save effect once isLoaded is true
         }
-
-        // Load theme
         const savedTheme = await getTheme();
-        if (savedTheme) {
-          setThemeMode(savedTheme);
-        }
-
-        // Load theme name
+        if (savedTheme) setThemeMode(savedTheme);
         const savedThemeName = await getThemeName();
-        if (savedThemeName) {
-          setThemeName(savedThemeName);
-        }
-
-        // Load operations
-        const savedOperations = await getOperations();
-        setOperations(savedOperations);
-
-        // Load total solved tasks
-        const savedTotalTasks = await getTotalTasks();
-        if (savedTotalTasks !== null) {
-          setTotalSolvedTasks(savedTotalTasks);
-        }
-
-        // Load number range (always returns a value, with migration)
-        const savedNumberRange = await getNumberRange();
-        setNumberRange(savedNumberRange);
-
-        // Load challenge high score
-        const savedHighScore = await getChallengeHighScore();
-        setChallengeHighScore(savedHighScore);
-
-        // Load sound preferences
+        if (savedThemeName) setThemeName(savedThemeName);
         const savedSoundsEnabled = await getSoundsEnabled();
         if (savedSoundsEnabled !== null) setSoundEnabled(savedSoundsEnabled);
         const savedSoundsVolume = await getSoundsVolume();
         if (savedSoundsVolume !== null) setSoundVolume(savedSoundsVolume);
-
-        setIsLoaded(true);
       } catch (error) {
-        console.error('Failed to load preferences:', error);
-        setIsLoaded(true);
+        console.error('Failed to load global preferences:', error);
+      }
+    };
+    loadGlobalPreferences();
+  }, []);
+
+  // Load per-profile preferences when profileId changes (also runs on mount)
+  useEffect(() => {
+    let cancelled = false;
+    const pid = profileId;
+
+    setIsLoaded(false);
+
+    const loadProfilePreferences = async () => {
+      try {
+        const savedOperations = await getOperations(pid);
+        if (!cancelled) setOperations(savedOperations);
+
+        const savedTotalTasks = await getTotalTasks(pid);
+        if (!cancelled && savedTotalTasks !== null) setTotalSolvedTasks(savedTotalTasks);
+        else if (!cancelled) setTotalSolvedTasks(0);
+
+        const savedNumberRange = await getNumberRange(pid);
+        if (!cancelled) setNumberRange(savedNumberRange);
+
+        const savedHighScore = await getChallengeHighScore(pid);
+        if (!cancelled) setChallengeHighScore(savedHighScore);
+      } catch (error) {
+        console.error('Failed to load profile preferences:', error);
+      } finally {
+        if (!cancelled) setIsLoaded(true);
       }
     };
 
-    loadPreferences();
-  }, []);
+    loadProfilePreferences();
+    return () => {
+      cancelled = true;
+    };
+  }, [profileId]);
 
-  // Auto-save language
+  // Auto-save global preferences (not per-profile)
   useEffect(() => {
-    if (isLoaded) {
-      saveLanguage(language);
-    }
+    if (isLoaded) saveLanguage(language);
   }, [language, isLoaded]);
 
-  // Auto-save theme
   useEffect(() => {
-    if (isLoaded) {
-      saveTheme(themeMode);
-    }
+    if (isLoaded) saveTheme(themeMode);
   }, [themeMode, isLoaded]);
 
-  // Auto-save theme name
   useEffect(() => {
-    if (isLoaded) {
-      saveThemeName(themeName);
-    }
+    if (isLoaded) saveThemeName(themeName);
   }, [themeName, isLoaded]);
 
-  // Auto-save operations
-  useEffect(() => {
-    if (isLoaded) {
-      saveOperations(operations);
-    }
-  }, [operations, isLoaded]);
-
-  // Toggle operation in multi-select
-  const toggleOperation = (op: Operation) => {
-    setOperations((prev) => {
-      const newOps = prev.includes(op) ? prev.filter((o) => o !== op) : [...prev, op];
-
-      // Ensure at least one operation is always enabled
-      if (newOps.length === 0) return prev;
-
-      return newOps;
-    });
-  };
-
-  // Auto-save total solved tasks
-  useEffect(() => {
-    if (isLoaded) {
-      saveTotalTasks(totalSolvedTasks);
-    }
-  }, [totalSolvedTasks, isLoaded]);
-
-  // Auto-save number range
-  useEffect(() => {
-    if (isLoaded) {
-      saveNumberRange(numberRange);
-    }
-  }, [numberRange, isLoaded]);
-
-  // Auto-save challenge high score
-  useEffect(() => {
-    if (isLoaded) {
-      saveChallengeHighScore(challengeHighScore);
-    }
-  }, [challengeHighScore, isLoaded]);
-
-  // Auto-save sound preferences
   useEffect(() => {
     if (isLoaded) saveSoundsEnabled(soundEnabled);
   }, [soundEnabled, isLoaded]);
@@ -170,6 +124,32 @@ export function usePreferences() {
     if (isLoaded) saveSoundsVolume(soundVolume);
   }, [soundVolume, isLoaded]);
 
+  // Auto-save per-profile preferences (use ref so closures always write to active profile)
+  useEffect(() => {
+    if (isLoaded) saveOperations(operations, profileIdRef.current);
+  }, [operations, isLoaded]);
+
+  // Toggle operation in multi-select
+  const toggleOperation = (op: Operation) => {
+    setOperations((prev) => {
+      const newOps = prev.includes(op) ? prev.filter((o) => o !== op) : [...prev, op];
+      if (newOps.length === 0) return prev;
+      return newOps;
+    });
+  };
+
+  useEffect(() => {
+    if (isLoaded) saveTotalTasks(totalSolvedTasks, profileIdRef.current);
+  }, [totalSolvedTasks, isLoaded]);
+
+  useEffect(() => {
+    if (isLoaded) saveNumberRange(numberRange, profileIdRef.current);
+  }, [numberRange, isLoaded]);
+
+  useEffect(() => {
+    if (isLoaded) saveChallengeHighScore(challengeHighScore, profileIdRef.current);
+  }, [challengeHighScore, isLoaded]);
+
   return {
     language,
     setLanguage,
@@ -177,7 +157,7 @@ export function usePreferences() {
     setThemeMode,
     themeName,
     setThemeName,
-    operation: operations.length > 0 ? operations[0] : Operation.MULTIPLICATION, // First selected operation as primary
+    operation: operations.length > 0 ? operations[0] : Operation.MULTIPLICATION,
     operations,
     setOperations,
     toggleOperation,

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -150,6 +150,19 @@ export interface TranslationStrings {
   badgeRange100Desc: string;
   badgeCreativeModeDesc: string;
   badgeNewUnlocked: string;
+  // Profiles
+  profiles: string;
+  profilesMenu: string;
+  profilesSubtitle: string;
+  addProfile: string;
+  createProfile: string;
+  profileNamePlaceholder: string;
+  saveProfile: string;
+  cancel: string;
+  deleteProfile: string;
+  deleteProfileConfirm: string;
+  maxProfilesReached: string;
+  profileActive: string;
   // Onboarding
   onboardingWelcomeTitle: string;
   onboardingWelcomeBody: string;
@@ -331,6 +344,19 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingStart: 'Start',
     onboardingSkip: 'Skip',
     resetOnboarding: 'Restart tutorial',
+    // Profiles
+    profiles: 'Profiles',
+    profilesMenu: 'Profiles',
+    profilesSubtitle: 'Tap to switch active profile',
+    addProfile: 'Add Profile',
+    createProfile: 'New Profile',
+    profileNamePlaceholder: "Child's name",
+    saveProfile: 'Save',
+    cancel: 'Cancel',
+    deleteProfile: 'Delete Profile',
+    deleteProfileConfirm: 'This will permanently delete all data for this profile.',
+    maxProfilesReached: 'Maximum of 6 profiles reached',
+    profileActive: 'Active',
   },
   de: {
     // Settings Menu
@@ -495,5 +521,18 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingStart: 'Loslegen',
     onboardingSkip: 'Überspringen',
     resetOnboarding: 'Tutorial zurücksetzen',
+    // Profiles
+    profiles: 'Profile',
+    profilesMenu: 'Profile',
+    profilesSubtitle: 'Tippe zum Profilwechsel',
+    addProfile: 'Profil hinzufügen',
+    createProfile: 'Neues Profil',
+    profileNamePlaceholder: 'Name des Kindes',
+    saveProfile: 'Speichern',
+    cancel: 'Abbrechen',
+    deleteProfile: 'Profil löschen',
+    deleteProfileConfirm: 'Damit werden alle Daten dieses Profils dauerhaft gelöscht.',
+    maxProfilesReached: 'Maximal 6 Profile möglich',
+    profileActive: 'Aktiv',
   },
 };

--- a/types/game.ts
+++ b/types/game.ts
@@ -101,6 +101,13 @@ export interface StreakData {
   longestStreak: number;
 }
 
+export interface ChildProfile {
+  id: string;
+  name: string;
+  avatarColor: string;
+  createdAt: string; // ISO date
+}
+
 export interface ThemeColors {
   background: string;
   text: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -30,7 +30,18 @@ export const STORAGE_KEYS = {
   STREAK: 'app-streak',
   SOUNDS_ENABLED: 'app-sounds-enabled',
   SOUNDS_VOLUME: 'app-sounds-volume',
+  PROFILES: 'app-profiles',
+  ACTIVE_PROFILE_ID: 'app-active-profile-id',
 } as const;
+
+export const AVATAR_COLORS = [
+  '#FF6B6B',
+  '#4ECDC4',
+  '#45B7D1',
+  '#96CEB4',
+  '#FFEAA7',
+  '#DDA0DD',
+] as const;
 
 export type BadgeCategory = 'streak' | 'performance' | 'challenge' | 'explorer';
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -5,7 +5,7 @@
 
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { STORAGE_KEYS } from './constants';
+import { STORAGE_KEYS, AVATAR_COLORS } from './constants';
 import {
   ThemeMode,
   ThemeName,
@@ -16,6 +16,7 @@ import {
   SessionRecord,
   TaskStat,
   StreakData,
+  ChildProfile,
 } from '../types/game';
 
 /**
@@ -64,7 +65,117 @@ export const removeStorageItem = async (key: string): Promise<void> => {
   }
 };
 
+// ============================================================================
+// Profile management
+// ============================================================================
+
+function generateId(): string {
+  const s4 = () =>
+    Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .slice(1);
+  return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
+}
+
+export function profileKey(baseKey: string, profileId: string): string {
+  return `${baseKey}-${profileId}`;
+}
+
+function resolveKey(baseKey: string, profileId?: string): string {
+  return profileId ? profileKey(baseKey, profileId) : baseKey;
+}
+
+export const getProfiles = async (): Promise<ChildProfile[]> => {
+  const value = await getStorageItem(STORAGE_KEYS.PROFILES);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) return parsed as ChildProfile[];
+  } catch {
+    /* ignore */
+  }
+  return [];
+};
+
+export const saveProfiles = async (profiles: ChildProfile[]): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.PROFILES, JSON.stringify(profiles));
+};
+
+export const getActiveProfileId = async (): Promise<string | null> => {
+  return getStorageItem(STORAGE_KEYS.ACTIVE_PROFILE_ID);
+};
+
+export const setActiveProfileId = async (id: string): Promise<void> => {
+  await setStorageItem(STORAGE_KEYS.ACTIVE_PROFILE_ID, id);
+};
+
+export const createProfile = async (name: string, avatarColor: string): Promise<ChildProfile> => {
+  const profile: ChildProfile = {
+    id: generateId(),
+    name: name.trim(),
+    avatarColor,
+    createdAt: new Date().toISOString(),
+  };
+  const profiles = await getProfiles();
+  profiles.push(profile);
+  await saveProfiles(profiles);
+  return profile;
+};
+
+export const deleteProfileData = async (profileId: string): Promise<void> => {
+  const keysToDelete = [
+    STORAGE_KEYS.STREAK,
+    STORAGE_KEYS.TASK_STATS,
+    STORAGE_KEYS.PARENT_STATS,
+    STORAGE_KEYS.BADGES,
+    STORAGE_KEYS.TOTAL_TASKS,
+    STORAGE_KEYS.CHALLENGE_HIGHSCORE,
+    STORAGE_KEYS.OPERATIONS,
+    STORAGE_KEYS.NUMBER_RANGE,
+  ];
+  await Promise.all(keysToDelete.map((k) => removeStorageItem(profileKey(k, profileId))));
+};
+
+// Run once on first launch with profiles: copies existing global data into a default profile.
+export const migrateToProfiles = async (): Promise<ChildProfile> => {
+  const existing = await getProfiles();
+  if (existing.length > 0) return existing[0];
+
+  const defaultProfile: ChildProfile = {
+    id: generateId(),
+    name: 'Kind 1',
+    avatarColor: AVATAR_COLORS[0],
+    createdAt: new Date().toISOString(),
+  };
+
+  // Copy all per-profile global keys to profile-keyed keys
+  const keysToCopy = [
+    STORAGE_KEYS.STREAK,
+    STORAGE_KEYS.TASK_STATS,
+    STORAGE_KEYS.PARENT_STATS,
+    STORAGE_KEYS.BADGES,
+    STORAGE_KEYS.TOTAL_TASKS,
+    STORAGE_KEYS.CHALLENGE_HIGHSCORE,
+    STORAGE_KEYS.OPERATIONS,
+    STORAGE_KEYS.NUMBER_RANGE,
+  ];
+  await Promise.all(
+    keysToCopy.map(async (k) => {
+      const value = await getStorageItem(k);
+      if (value !== null) {
+        await setStorageItem(profileKey(k, defaultProfile.id), value);
+      }
+    })
+  );
+
+  await saveProfiles([defaultProfile]);
+  await setActiveProfileId(defaultProfile.id);
+  return defaultProfile;
+};
+
+// ============================================================================
 // Typed storage helpers
+// ============================================================================
 
 export const saveLanguage = async (language: Language): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.LANGUAGE, language);
@@ -108,12 +219,16 @@ export const getThemeName = async (): Promise<ThemeName | null> => {
   return null;
 };
 
-export const saveOperations = async (operations: Operation[]): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.OPERATIONS, JSON.stringify(operations));
+export const saveOperations = async (
+  operations: Operation[],
+  profileId?: string
+): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.OPERATIONS, profileId), JSON.stringify(operations));
 };
 
-export const getOperations = async (): Promise<Operation[]> => {
-  const value = await getStorageItem(STORAGE_KEYS.OPERATIONS);
+export const getOperations = async (profileId?: string): Promise<Operation[]> => {
+  const key = resolveKey(STORAGE_KEYS.OPERATIONS, profileId);
+  const value = await getStorageItem(key);
   if (value) {
     try {
       const parsed = JSON.parse(value);
@@ -128,12 +243,14 @@ export const getOperations = async (): Promise<Operation[]> => {
     }
   }
 
-  // Migration: try old single-operation storage
-  const oldValue = await getStorageItem(STORAGE_KEYS.OPERATION);
-  if (oldValue === 'ADDITION' || oldValue === 'SUBTRACTION' || oldValue === 'MULTIPLICATION') {
-    const migratedOps = [oldValue as Operation];
-    await saveOperations(migratedOps);
-    return migratedOps;
+  // Migration: try old single-operation storage (global key only)
+  if (!profileId) {
+    const oldValue = await getStorageItem(STORAGE_KEYS.OPERATION);
+    if (oldValue === 'ADDITION' || oldValue === 'SUBTRACTION' || oldValue === 'MULTIPLICATION') {
+      const migratedOps = [oldValue as Operation];
+      await saveOperations(migratedOps);
+      return migratedOps;
+    }
   }
 
   // Default: multiplication only
@@ -153,12 +270,12 @@ export const getOperation = async (): Promise<Operation | null> => {
   return null;
 };
 
-export const saveTotalTasks = async (total: number): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.TOTAL_TASKS, total.toString());
+export const saveTotalTasks = async (total: number, profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.TOTAL_TASKS, profileId), total.toString());
 };
 
-export const getTotalTasks = async (): Promise<number | null> => {
-  const value = await getStorageItem(STORAGE_KEYS.TOTAL_TASKS);
+export const getTotalTasks = async (profileId?: string): Promise<number | null> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.TOTAL_TASKS, profileId));
   if (value) {
     const parsed = parseInt(value, 10);
     return isNaN(parsed) ? null : parsed;
@@ -166,12 +283,12 @@ export const getTotalTasks = async (): Promise<number | null> => {
   return null;
 };
 
-export const saveChallengeHighScore = async (score: number): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.CHALLENGE_HIGHSCORE, score.toString());
+export const saveChallengeHighScore = async (score: number, profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.CHALLENGE_HIGHSCORE, profileId), score.toString());
 };
 
-export const getChallengeHighScore = async (): Promise<number> => {
-  const value = await getStorageItem(STORAGE_KEYS.CHALLENGE_HIGHSCORE);
+export const getChallengeHighScore = async (profileId?: string): Promise<number> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.CHALLENGE_HIGHSCORE, profileId));
   if (value) {
     const parsed = parseInt(value, 10);
     return isNaN(parsed) ? 0 : parsed;
@@ -208,8 +325,9 @@ function pruneOldRecords(records: SessionRecord[], now: number): SessionRecord[]
   return records.filter((r) => now - r.timestamp < FOUR_WEEKS_MS);
 }
 
-export const getSessionRecords = async (): Promise<SessionRecord[]> => {
-  const value = await getStorageItem(STORAGE_KEYS.PARENT_STATS);
+export const getSessionRecords = async (profileId?: string): Promise<SessionRecord[]> => {
+  const key = resolveKey(STORAGE_KEYS.PARENT_STATS, profileId);
+  const value = await getStorageItem(key);
   if (!value) return [];
   try {
     const parsed = JSON.parse(value);
@@ -217,7 +335,7 @@ export const getSessionRecords = async (): Promise<SessionRecord[]> => {
     const valid = parsed.filter(isValidSessionRecord);
     const pruned = pruneOldRecords(valid, Date.now());
     if (pruned.length < valid.length) {
-      await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(pruned));
+      await setStorageItem(key, JSON.stringify(pruned));
     }
     return pruned;
   } catch {
@@ -225,10 +343,13 @@ export const getSessionRecords = async (): Promise<SessionRecord[]> => {
   }
 };
 
-export const saveSessionRecord = async (record: SessionRecord): Promise<void> => {
-  const records = await getSessionRecords();
+export const saveSessionRecord = async (
+  record: SessionRecord,
+  profileId?: string
+): Promise<void> => {
+  const records = await getSessionRecords(profileId);
   records.push(record);
-  await setStorageItem(STORAGE_KEYS.PARENT_STATS, JSON.stringify(records));
+  await setStorageItem(resolveKey(STORAGE_KEYS.PARENT_STATS, profileId), JSON.stringify(records));
 };
 
 // Returns true when onboarding is done (value = 'true').
@@ -260,8 +381,8 @@ function isValidTaskStat(r: unknown): r is TaskStat {
   );
 }
 
-export const getTaskStats = async (): Promise<TaskStat[]> => {
-  const value = await getStorageItem(STORAGE_KEYS.TASK_STATS);
+export const getTaskStats = async (profileId?: string): Promise<TaskStat[]> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.TASK_STATS, profileId));
   if (!value) return [];
   try {
     const parsed = JSON.parse(value);
@@ -272,8 +393,8 @@ export const getTaskStats = async (): Promise<TaskStat[]> => {
   }
 };
 
-export const saveTaskStats = async (stats: TaskStat[]): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.TASK_STATS, JSON.stringify(stats));
+export const saveTaskStats = async (stats: TaskStat[], profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.TASK_STATS, profileId), JSON.stringify(stats));
 };
 
 let taskStatsQueue: Promise<void> = Promise.resolve();
@@ -282,10 +403,11 @@ export const recordTaskResult = async (
   num1: number,
   num2: number,
   operation: Operation,
-  isCorrect: boolean
+  isCorrect: boolean,
+  profileId?: string
 ): Promise<void> => {
   taskStatsQueue = taskStatsQueue.then(async () => {
-    const stats = await getTaskStats();
+    const stats = await getTaskStats(profileId);
     const existing = stats.find(
       (s) => s.num1 === num1 && s.num2 === num2 && s.operation === operation
     );
@@ -303,7 +425,7 @@ export const recordTaskResult = async (
         lastSeen: new Date().toISOString(),
       });
     }
-    await saveTaskStats(stats);
+    await saveTaskStats(stats, profileId);
   });
   return taskStatsQueue;
 };
@@ -329,8 +451,8 @@ export const getWeakTasks = (
 // Badge storage – maps badgeId → unlock timestamp
 export type BadgeStore = Record<string, number>;
 
-export const getBadges = async (): Promise<BadgeStore> => {
-  const value = await getStorageItem(STORAGE_KEYS.BADGES);
+export const getBadges = async (profileId?: string): Promise<BadgeStore> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.BADGES, profileId));
   if (!value) return {};
   try {
     const parsed = JSON.parse(value);
@@ -349,8 +471,8 @@ export const getBadges = async (): Promise<BadgeStore> => {
   return {};
 };
 
-export const saveBadges = async (badges: BadgeStore): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.BADGES, JSON.stringify(badges));
+export const saveBadges = async (badges: BadgeStore, profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.BADGES, profileId), JSON.stringify(badges));
 };
 
 // Streak storage helpers
@@ -373,8 +495,8 @@ function isLocalDateString(v: unknown): v is string {
   return typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v);
 }
 
-export const getStreakData = async (): Promise<StreakData> => {
-  const value = await getStorageItem(STORAGE_KEYS.STREAK);
+export const getStreakData = async (profileId?: string): Promise<StreakData> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.STREAK, profileId));
   if (!value) return STREAK_DEFAULT;
   try {
     const parsed = JSON.parse(value);
@@ -391,13 +513,13 @@ export const getStreakData = async (): Promise<StreakData> => {
   return STREAK_DEFAULT;
 };
 
-export const saveStreakData = async (data: StreakData): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.STREAK, JSON.stringify(data));
+export const saveStreakData = async (data: StreakData, profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.STREAK, profileId), JSON.stringify(data));
 };
 
-export const updateStreakAfterSession = async (): Promise<StreakData> => {
+export const updateStreakAfterSession = async (profileId?: string): Promise<StreakData> => {
   const today = getLocalDateString();
-  const data = await getStreakData();
+  const data = await getStreakData(profileId);
 
   if (data.lastPlayedDate === today) {
     return data;
@@ -415,16 +537,17 @@ export const updateStreakAfterSession = async (): Promise<StreakData> => {
     longestStreak: Math.max(newStreak, data.longestStreak),
   };
 
-  await saveStreakData(updated);
+  await saveStreakData(updated, profileId);
   return updated;
 };
 
-export const saveNumberRange = async (range: NumberRange): Promise<void> => {
-  await setStorageItem(STORAGE_KEYS.NUMBER_RANGE, range);
+export const saveNumberRange = async (range: NumberRange, profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.NUMBER_RANGE, profileId), range);
 };
 
-export const getNumberRange = async (): Promise<NumberRange> => {
-  const value = await getStorageItem(STORAGE_KEYS.NUMBER_RANGE);
+export const getNumberRange = async (profileId?: string): Promise<NumberRange> => {
+  const key = resolveKey(STORAGE_KEYS.NUMBER_RANGE, profileId);
+  const value = await getStorageItem(key);
 
   // Handle new format
   if (
@@ -436,21 +559,23 @@ export const getNumberRange = async (): Promise<NumberRange> => {
     return value as NumberRange;
   }
 
-  // Migration: handle old format
-  if (value === 'SMALL') {
-    const migratedValue = NumberRange.RANGE_10;
-    await saveNumberRange(migratedValue);
-    return migratedValue;
-  }
-  if (value === 'MEDIUM') {
-    const migratedValue = NumberRange.RANGE_20;
-    await saveNumberRange(migratedValue);
-    return migratedValue;
-  }
-  if (value === 'LARGE') {
-    const migratedValue = NumberRange.RANGE_100;
-    await saveNumberRange(migratedValue);
-    return migratedValue;
+  // Migration: handle old format (global key only)
+  if (!profileId) {
+    if (value === 'SMALL') {
+      const migratedValue = NumberRange.RANGE_10;
+      await saveNumberRange(migratedValue);
+      return migratedValue;
+    }
+    if (value === 'MEDIUM') {
+      const migratedValue = NumberRange.RANGE_20;
+      await saveNumberRange(migratedValue);
+      return migratedValue;
+    }
+    if (value === 'LARGE') {
+      const migratedValue = NumberRange.RANGE_100;
+      await saveNumberRange(migratedValue);
+      return migratedValue;
+    }
   }
 
   // Default: 1-100 for existing users


### PR DESCRIPTION
## Summary

Implements Issue #187 — multiple child profiles per device.

- **Storage layer**: `migrateToProfiles()` copies existing global data into a "Kind 1" default profile on first run (idempotent). All per-profile storage functions (`getOperations`, `getNumberRange`, `getTotalTasks`, `getChallengeHighScore`, `getStreakData`/`saveStreakData`/`updateStreakAfterSession`, `getTaskStats`/`recordTaskResult`, `getSessionRecords`/`saveSessionRecord`, `getBadges`/`saveBadges`) accept an optional `profileId?: string` — when provided, data is stored under `{key}-{profileId}` suffix; when omitted, falls back to global key for backward compatibility.
- **Hooks**: `usePreferences(profileId?)` reloads per-profile preferences (operations, number range, total tasks, challenge high score) when the profile switches; global prefs (language, theme, sounds) are shared. `useBadges(profileId?)` scopes badge storage to the active profile.
- **UI**: New `ProfilePickerModal` (bottom sheet) — lists all profiles with avatar circles, tap to switch, create new profile (name + color picker, max 6), delete with confirmation. Profiles button added to the Settings menu top row.
- **App.tsx**: Runs `migrateToProfiles()` on mount, holds `activeProfile` state, passes `profileId` to hooks and storage callbacks via a ref to avoid stale closures.
- **i18n**: 12 new strings in DE + EN for profile management.

## Test plan

- [ ] Fresh install: migration creates "Kind 1" profile automatically, all existing data is preserved
- [ ] Settings → Profiles opens the modal
- [ ] Tap a non-active profile → switches immediately, game data reloads for that profile
- [ ] Add Profile → enter name, pick color, Save → appears in list
- [ ] Delete Profile (trash icon) → confirmation dialog, data removed, switches to first remaining profile
- [ ] Cannot delete the last profile (trash icon hidden when only 1 profile exists)
- [ ] Max 6 profiles: Add Profile button replaced by "Maximum of 6 profiles reached" message
- [ ] Each profile has independent: streak, badges, task stats, high score, operations, number range
- [ ] Language / theme / sounds remain shared across profiles
- [ ] All 497 Jest tests pass; Prettier format check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Naa7DJwMMdpowiuci5eg9

---
_Generated by [Claude Code](https://claude.ai/code/session_017Naa7DJwMMdpowiuci5eg9)_