### PR TITLE
ci: google-services.json als Secret injizieren (Issue #231)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -114,6 +114,22 @@ jobs:
           EXPO_NO_TELEMETRY: 1
 
       # -----------------------------------------------------------------------
+      # Inject google-services.json for Firebase Crashlytics (Issue #231)
+      # Must run after prebuild because --clean wipes /android
+      # -----------------------------------------------------------------------
+      - name: Write google-services.json
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON" ]; then
+            echo "❌ ERROR: GOOGLE_SERVICES_JSON secret is not set."
+            echo "Run: base64 -i google-services.json | gh secret set GOOGLE_SERVICES_JSON --repo S540d/1x1_Trainer"
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON" | base64 --decode > android/app/google-services.json
+          echo "✅ google-services.json written"
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+
+      # -----------------------------------------------------------------------
       # Validate and Decode Keystore from GitHub Secret
       # -----------------------------------------------------------------------
       - name: Decode Keystore


### PR DESCRIPTION
## Summary
- Neuer Step `Write google-services.json` in `build-android.yml` nach Expo Prebuild
- Dekodiert `GOOGLE_SERVICES_JSON` (Base64) nach `android/app/google-services.json`
- Muss nach `--clean` Prebuild laufen, da Prebuild `/android` komplett neu generiert
- Fehlt das Secret, bricht der Build mit klarer Fehlermeldung ab

## Secret bereits gesetzt
`GOOGLE_SERVICES_JSON` wurde via `gh secret set` in den Repo-Secrets hinterlegt.

## Test plan
- [ ] Android Build workflow manuell triggern (production oder preview)
- [ ] Step `Write google-services.json` läuft ohne Fehler
- [ ] Firebase Crashlytics ist im AAB initialisiert

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)