### PR TITLE
fix: Operationsauswahl zuverlässig persistieren und wiederherstellen (#251, #252)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -360,10 +360,17 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [preferences.isLoaded]);
 
-  // Sync operation changes to preferences
+  // Sync operation changes to preferences.
+  // Deliberately NOT keyed on preferences.isLoaded: on the load commit the game
+  // still holds the pre-load defaults, and saving those would clobber the stored
+  // selection before useGameLogic adopts it.
   useEffect(() => {
-    if (preferences.isLoaded && !preferences.operations.includes(game.gameState.operation)) {
-      const newOps = Array.from(game.gameState.selectedOperations);
+    if (!preferences.isLoaded) return;
+    const newOps = Array.from(game.gameState.selectedOperations);
+    const unchanged =
+      newOps.length === preferences.operations.length &&
+      newOps.every((op) => preferences.operations.includes(op));
+    if (!unchanged) {
       preferences.setOperations(newOps);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/hooks/useGameLogic.test.tsx
+++ b/hooks/useGameLogic.test.tsx
@@ -774,6 +774,47 @@ describe('useGameLogic Hook', () => {
       expect(result.current.gameState.selectedOperations.has(Operation.MULTIPLICATION)).toBe(true);
       expect(result.current.gameState.selectedOperations.size).toBe(1);
     });
+
+    // Regression: #252 — preferences load asynchronously, so the useState
+    // initializer only ever sees the defaults; the saved selection must be
+    // adopted when initialOperations changes.
+    it('should adopt initialOperations arriving after mount (async preference load)', () => {
+      const { result, rerender } = renderHook((props) => useGameLogic(props), {
+        initialProps: defaultProps as Parameters<typeof useGameLogic>[0],
+      });
+
+      expect(result.current.gameState.selectedOperations).toEqual(
+        new Set([Operation.MULTIPLICATION])
+      );
+
+      rerender({
+        ...defaultProps,
+        initialOperations: [Operation.ADDITION, Operation.DIVISION],
+      });
+
+      expect(result.current.gameState.selectedOperations).toEqual(
+        new Set([Operation.ADDITION, Operation.DIVISION])
+      );
+
+      // The pending question is regenerated with the adopted operations
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect([Operation.ADDITION, Operation.DIVISION]).toContain(
+        result.current.gameState.operation
+      );
+    });
+
+    it('should not reset state when initialOperations matches the current selection', () => {
+      const { result, rerender } = renderHook((props) => useGameLogic(props), {
+        initialProps: defaultProps as Parameters<typeof useGameLogic>[0],
+      });
+
+      const stateBefore = result.current.gameState;
+      rerender({ ...defaultProps, initialOperations: [Operation.MULTIPLICATION] });
+
+      expect(result.current.gameState).toBe(stateBefore);
+    });
   });
 
   describe('getCorrectAnswer', () => {

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -423,6 +423,30 @@ export function useGameLogic({
     }));
   };
 
+  // Adopt persisted operations when they arrive (async preference load or
+  // profile switch). The useState initializer above only sees the pre-load
+  // defaults, so without this the saved selection never reaches the game.
+  const selectedOpsKey = selectedOps.join(',');
+  useEffect(() => {
+    setGameState((prev) => {
+      const same =
+        prev.selectedOperations.size === selectedOps.length &&
+        selectedOps.every((op) => prev.selectedOperations.has(op));
+      if (same || prev.difficultyMode === DifficultyMode.CHALLENGE) return prev;
+      const newSet = new Set(selectedOps);
+      setTimeout(() => generateQuestion(prev.gameMode, newSet), 0);
+      return {
+        ...prev,
+        selectedOperations: newSet,
+        operation: selectedOps[0],
+        currentTask: 1,
+        score: 0,
+        showResult: false,
+      };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedOpsKey]);
+
   // Handle user input (for input mode)
   const onUserInput = (input: string) => {
     if (!gameState.isAnswerChecked) {

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -252,6 +252,27 @@ describe('storage.ts - Typed Storage Helpers', () => {
       expect(operations).toEqual(ops);
     });
 
+    // Regression: #251 — DIVISION was missing from the validation whitelist,
+    // so any stored selection containing it fell back to [MULTIPLICATION].
+    it('should save and retrieve DIVISION (survives restart)', async () => {
+      await saveOperations([Operation.DIVISION]);
+      const operations = await getOperations();
+      expect(operations).toEqual([Operation.DIVISION]);
+    });
+
+    it('should retrieve a mixed selection including DIVISION without dropping it', async () => {
+      const ops = [Operation.ADDITION, Operation.DIVISION];
+      await saveOperations(ops);
+      const operations = await getOperations();
+      expect(operations).toEqual(ops);
+    });
+
+    it('should fall back to default for an empty stored array', async () => {
+      mockLocalStorage['app-operations'] = JSON.stringify([]);
+      const operations = await getOperations();
+      expect(operations).toEqual([Operation.MULTIPLICATION]);
+    });
+
     it('should return default (MULTIPLICATION) if no operations stored', async () => {
       const operations = await getOperations();
       expect(operations).toEqual([Operation.MULTIPLICATION]);
@@ -266,6 +287,12 @@ describe('storage.ts - Typed Storage Helpers', () => {
 
       // Verify migration saved new format
       expect(mockLocalStorage['app-operations']).toBe(JSON.stringify([Operation.ADDITION]));
+    });
+
+    it('should migrate legacy DIVISION value', async () => {
+      mockLocalStorage['app-operation'] = Operation.DIVISION;
+      const operations = await getOperations();
+      expect(operations).toEqual([Operation.DIVISION]);
     });
 
     it('should handle corrupted JSON gracefully', async () => {
@@ -292,6 +319,12 @@ describe('storage.ts - Typed Storage Helpers', () => {
       mockLocalStorage['app-operation'] = Operation.SUBTRACTION;
       const operation = await getOperation();
       expect(operation).toBe(Operation.SUBTRACTION);
+    });
+
+    it('should retrieve legacy DIVISION operation', async () => {
+      mockLocalStorage['app-operation'] = Operation.DIVISION;
+      const operation = await getOperation();
+      expect(operation).toBe(Operation.DIVISION);
     });
 
     it('should return null if no legacy operation stored', async () => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -177,6 +177,8 @@ export const migrateToProfiles = async (): Promise<ChildProfile> => {
 // Typed storage helpers
 // ============================================================================
 
+const VALID_OPERATIONS = new Set<string>(Object.values(Operation));
+
 export const saveLanguage = async (language: Language): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.LANGUAGE, language);
 };
@@ -234,7 +236,8 @@ export const getOperations = async (profileId?: string): Promise<Operation[]> =>
       const parsed = JSON.parse(value);
       if (
         Array.isArray(parsed) &&
-        parsed.every((op) => ['ADDITION', 'SUBTRACTION', 'MULTIPLICATION'].includes(op))
+        parsed.length > 0 &&
+        parsed.every((op) => typeof op === 'string' && VALID_OPERATIONS.has(op))
       ) {
         return parsed as Operation[];
       }
@@ -246,7 +249,7 @@ export const getOperations = async (profileId?: string): Promise<Operation[]> =>
   // Migration: try old single-operation storage (global key only)
   if (!profileId) {
     const oldValue = await getStorageItem(STORAGE_KEYS.OPERATION);
-    if (oldValue === 'ADDITION' || oldValue === 'SUBTRACTION' || oldValue === 'MULTIPLICATION') {
+    if (oldValue !== null && VALID_OPERATIONS.has(oldValue)) {
       const migratedOps = [oldValue as Operation];
       await saveOperations(migratedOps);
       return migratedOps;
@@ -264,7 +267,7 @@ export const saveOperation = async (operation: Operation): Promise<void> => {
 
 export const getOperation = async (): Promise<Operation | null> => {
   const value = await getStorageItem(STORAGE_KEYS.OPERATION);
-  if (value === 'ADDITION' || value === 'SUBTRACTION' || value === 'MULTIPLICATION') {
+  if (value !== null && VALID_OPERATIONS.has(value)) {
     return value as Operation;
   }
   return null;
@@ -298,7 +301,6 @@ export const getChallengeHighScore = async (profileId?: string): Promise<number>
 
 export const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
 
-const VALID_OPERATIONS = new Set<string>(Object.values(Operation));
 const VALID_DIFFICULTY_MODES = new Set<string>(Object.values(DifficultyMode));
 const VALID_NUMBER_RANGES = new Set<string>(Object.values(NumberRange));
 


### PR DESCRIPTION
## Problem

Die App „vergisst" die gewählten Rechenarten — zwei Ursachen plus ein beim Fixen entdeckter dritter Defekt:

1. **#251**: `getOperations()`/`getOperation()` validierten ohne `DIVISION` → jede Auswahl mit Division fiel beim Laden komplett auf `[MULTIPLICATION]` zurück.
2. **#252**: Der Sync-Effekt in `App.tsx` speicherte nur, wenn die *gerade angezeigte* Operation nicht in den Prefs lag — Hinzufügen/Entfernen von Rechenarten wurde dadurch meist nie persistiert.
3. **Neu entdeckt**: Selbst korrekt gespeicherte Operationen erreichten das Spiel nie — der `useState`-Initializer in `useGameLogic` läuft vor dem asynchronen Preferences-Load und sah immer nur die Defaults.

## Änderungen

- `utils/storage.ts`: Validierung gegen `Object.values(Operation)` (Set `VALID_OPERATIONS`), auch für die Legacy-Migration; leeres Array fällt auf Default zurück
- `App.tsx`: Sync-Effekt vergleicht jetzt die komplette Auswahl (Set-Vergleich) und speichert bei jeder echten Änderung; bewusst nicht auf `isLoaded` gekeyt, damit der Load-Commit die gespeicherte Auswahl nicht überschreibt
- `hooks/useGameLogic.ts`: neuer Adopt-Effekt übernimmt `initialOperations` nach dem Preferences-Load bzw. Profilwechsel ins laufende Spiel und regeneriert die Aufgabe (Muster von `toggleOperation`); im Challenge-Modus deaktiviert

## Tests

- Regressionstests: DIVISION-Roundtrip, gemischte Auswahl mit Division, Legacy-DIVISION-Migration, leeres Array, Adopt-Effekt (Übernahme + No-Op bei identischer Auswahl)
- `npm test`: 15/15 Suiten, 503 passed / 3 skipped

Fixes #251, Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4)_