### PR TITLE
fix: kein Doppel-Modal am Rundenende (#254)

### DIFF
--- a/hooks/useGameLogic.test.tsx
+++ b/hooks/useGameLogic.test.tsx
@@ -1357,11 +1357,14 @@ describe('useGameLogic Hook', () => {
       expect(secondNum2).toBeLessThanOrEqual(10);
     });
 
-    it('should call onMotivationShow after every 10 tasks', () => {
-      const { result } = renderHook(() => useGameLogic(defaultProps));
+    it('should call onMotivationShow when the 10-task boundary falls mid-round', () => {
+      // totalSolvedTasks starts at 5, so the boundary (10) is reached at task 5
+      // of the round — not the last task.
+      const { result } = renderHook(() =>
+        useGameLogic({ ...defaultProps, initialTotalSolvedTasks: 5 })
+      );
 
-      // Move through 9 tasks (totalSolvedTasks goes from 0 to 9)
-      for (let i = 1; i <= 9; i++) {
+      for (let i = 1; i <= 4; i++) {
         act(() => {
           result.current.nextQuestion();
           jest.runAllTimers();
@@ -1370,7 +1373,7 @@ describe('useGameLogic Hook', () => {
 
       expect(mockOnMotivationShow).not.toHaveBeenCalled();
 
-      // The 10th call to nextQuestion makes totalSolvedTasks = 10
+      // The 5th call makes totalSolvedTasks = 10 (mid-round)
       act(() => {
         result.current.nextQuestion();
         jest.runAllTimers();
@@ -1378,6 +1381,23 @@ describe('useGameLogic Hook', () => {
 
       expect(mockOnMotivationShow).toHaveBeenCalledTimes(1);
       expect(mockOnMotivationShow).toHaveBeenCalledWith(result.current.gameState.score);
+    });
+
+    // Regression: #254 — when the boundary coincides with the last task, the
+    // result modal opens; the motivation modal must not stack on top of it.
+    it('should NOT call onMotivationShow at round end (result modal opens instead)', () => {
+      const { result } = renderHook(() => useGameLogic(defaultProps));
+
+      // Complete the full 10-task round (totalSolvedTasks 0 → 10)
+      for (let i = 1; i <= 10; i++) {
+        act(() => {
+          result.current.nextQuestion();
+          jest.runAllTimers();
+        });
+      }
+
+      expect(result.current.gameState.showResult).toBe(true);
+      expect(mockOnMotivationShow).not.toHaveBeenCalled();
     });
   });
 

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -568,14 +568,15 @@ export function useGameLogic({
 
     if (isLastTask) {
       fireSessionComplete(gameState.score, gameState.totalTasks, gameState.selectedOperations);
+    } else if (newTotalSolvedTasks > 0 && newTotalSolvedTasks % 10 === 0) {
+      // Show motivation message after every 10 tasks — but never at round end,
+      // where the result modal already opens; two stacked modals would collide (#254).
+      // Called outside the setState updater: side effects in updaters run twice
+      // in StrictMode.
+      onMotivationShow(gameState.score);
     }
 
     setGameState((prev) => {
-      // Show motivation message after every 10 tasks
-      if (newTotalSolvedTasks > 0 && newTotalSolvedTasks % 10 === 0) {
-        onMotivationShow(prev.score);
-      }
-
       if (isLastTask) {
         return {
           ...prev,


### PR DESCRIPTION
## Problem

Fällt die kumulierte 10-Aufgaben-Grenze aufs Rundenende (bei neuen Nutzern: jede Runde), öffneten sich MotivationModal und ResultModal gleichzeitig übereinander. Zusätzlich wurde `onMotivationShow` innerhalb des setState-Updaters aufgerufen (Side-Effect im Updater → doppelte Ausführung im StrictMode).

## Änderungen

- `hooks/useGameLogic.ts` (`nextQuestion`): Motivation wird nur noch gezeigt, wenn die 10er-Grenze **mitten in der Runde** erreicht wird; am Rundenende öffnet ausschließlich das ResultModal
- Aufruf aus dem setState-Updater herausgezogen

## Tests

- Neuer Test: Motivation erscheint bei 10er-Grenze mid-round (`initialTotalSolvedTasks: 5`)
- Neuer Regressionstest: am Rundenende `showResult === true` und **kein** `onMotivationShow`
- `npm test`: 15/15 Suiten grün

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4)_