### PR TITLE
fix: gebrochenen Streak nicht mehr als aktiv anzeigen (#255)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,7 +43,7 @@ import {
   saveSessionRecord,
   getStreakData,
   updateStreakAfterSession,
-  getLocalDateString,
+  getYesterdayDateString,
   recordTaskResult,
   getTaskStats,
   getWeakTasks,
@@ -282,9 +282,12 @@ export default function App() {
       setStreakData(data);
       const now = new Date();
       const isEvening = now.getHours() >= 20;
-      const hasStreakToProtect = data.currentStreak > 0;
-      const hasNotPlayedToday = data.lastPlayedDate !== getLocalDateString();
-      if (isEvening && hasStreakToProtect && hasNotPlayedToday) {
+      // Warn only while the streak is actually still savable: last play was
+      // exactly yesterday. For older dates the streak is already broken and
+      // the warning would promise something the user can no longer save (#255).
+      const streakStillSavable =
+        data.currentStreak > 0 && data.lastPlayedDate === getYesterdayDateString();
+      if (isEvening && streakStillSavable) {
         setStreakWarningVisible(true);
       }
     });

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -781,11 +781,45 @@ describe('Streak Storage', () => {
     expect(result).toEqual({ currentStreak: 0, lastPlayedDate: '', longestStreak: 0 });
   });
 
-  it('returns saved streak data', async () => {
-    const data: StreakData = { currentStreak: 5, lastPlayedDate: '2024-06-15', longestStreak: 10 };
+  it('returns saved streak data when played today', async () => {
+    const data: StreakData = {
+      currentStreak: 5,
+      lastPlayedDate: getLocalDateString(),
+      longestStreak: 10,
+    };
     await saveStreakData(data);
     const result = await getStreakData();
     expect(result).toEqual(data);
+  });
+
+  it('returns saved streak data when played yesterday (streak still savable)', async () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const data: StreakData = {
+      currentStreak: 5,
+      lastPlayedDate: getLocalDateString(yesterday),
+      longestStreak: 10,
+    };
+    await saveStreakData(data);
+    const result = await getStreakData();
+    expect(result).toEqual(data);
+  });
+
+  // Regression: #255 — a streak whose last play is older than yesterday is
+  // broken; it must not be displayed as active anymore.
+  it('reports currentStreak 0 for a broken streak (last play older than yesterday)', async () => {
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+    const data: StreakData = {
+      currentStreak: 12,
+      lastPlayedDate: getLocalDateString(threeDaysAgo),
+      longestStreak: 12,
+    };
+    await saveStreakData(data);
+    const result = await getStreakData();
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(12);
+    expect(result.lastPlayedDate).toBe(getLocalDateString(threeDaysAgo));
   });
 
   it('returns default for corrupted JSON', async () => {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -485,6 +485,12 @@ export function getLocalDateString(date?: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+export function getYesterdayDateString(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return getLocalDateString(d);
+}
+
 const STREAK_DEFAULT: StreakData = { currentStreak: 0, lastPlayedDate: '', longestStreak: 0 };
 
 function isNonNegInt(v: unknown): v is number {
@@ -505,7 +511,18 @@ export const getStreakData = async (profileId?: string): Promise<StreakData> => 
       isLocalDateString(parsed.lastPlayedDate) &&
       isNonNegInt(parsed.longestStreak)
     ) {
-      return parsed as StreakData;
+      const data = parsed as StreakData;
+      // A streak is only alive if the last play was today or yesterday.
+      // Report 0 for older dates so the UI never shows an already-broken
+      // streak (#255); longestStreak is preserved and the stored record is
+      // normalized on the next session via updateStreakAfterSession.
+      if (
+        data.lastPlayedDate === getLocalDateString() ||
+        data.lastPlayedDate === getYesterdayDateString()
+      ) {
+        return data;
+      }
+      return { ...data, currentStreak: 0 };
     }
   } catch {
     // fall through
@@ -525,11 +542,7 @@ export const updateStreakAfterSession = async (profileId?: string): Promise<Stre
     return data;
   }
 
-  const yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  const yesterdayStr = getLocalDateString(yesterday);
-
-  const newStreak = data.lastPlayedDate === yesterdayStr ? data.currentStreak + 1 : 1;
+  const newStreak = data.lastPlayedDate === getYesterdayDateString() ? data.currentStreak + 1 : 1;
 
   const updated: StreakData = {
     currentStreak: newStreak,


### PR DESCRIPTION
## Problem

Nach einer Spielpause zeigte der Header weiter den alten Streak (z. B. 🔥 12), obwohl er längst gebrochen war. Die Abend-Warnung „Schütze deinen Streak!" erschien auch dann, wenn der Streak gar nicht mehr zu retten war. Nach der nächsten Runde sprang die Anzeige dann von 🔥 12 auf 🔥 1 — ein unnötig demotivierender Moment.

## Änderungen

- `utils/storage.ts` (`getStreakData`): Ein Streak gilt nur als aktiv, wenn der letzte Spieltag heute oder gestern war; ältere Daten liefern `currentStreak: 0` (`longestStreak` bleibt erhalten, der gespeicherte Datensatz wird bei der nächsten Session regulär von `updateStreakAfterSession` fortgeschrieben)
- Neuer Helper `getYesterdayDateString()`, auch in `updateStreakAfterSession` wiederverwendet
- `App.tsx`: Abend-Warnung nur noch, wenn der Streak tatsächlich rettbar ist (letzter Spieltag == gestern)

## Tests

- Neue Tests: heute/gestern → Daten unverändert; drei Tage alt → `currentStreak 0`, `longestStreak` bleibt
- `npm test`: 15/15 Suiten grün

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4)_