### PR TITLE
feat: physische Tastatureingabe in der Web-Version (#258)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -56,7 +56,15 @@ import {
   setActiveProfileId,
 } from './utils/storage';
 import { useSounds } from './hooks/useSounds';
-import { ChildProfile, SessionRecord, StreakData, TaskStat, Operation } from './types/game';
+import { useKeyboardInput } from './hooks/useKeyboardInput';
+import {
+  AnswerMode,
+  ChildProfile,
+  SessionRecord,
+  StreakData,
+  TaskStat,
+  Operation,
+} from './types/game';
 import { useBadges } from './hooks/useBadges';
 import {
   ANIMATION_DURATIONS,
@@ -184,6 +192,44 @@ export default function App() {
     numberRange: preferences.numberRange,
     challengeHighScore: preferences.challengeHighScore,
     onChallengeHighScoreChange: preferences.setChallengeHighScore,
+  });
+
+  // Physical keyboard on web (#258) — inactive while any overlay is open
+  const overlayOpen =
+    menuRendered ||
+    aboutVisible ||
+    personalizeVisible ||
+    parentDashboardVisible ||
+    badgesVisible ||
+    profilePickerVisible ||
+    showMotivation ||
+    streakWarningVisible ||
+    onboardingVisible ||
+    game.gameState.showResult;
+  useKeyboardInput({
+    enabled: !overlayOpen,
+    onDigit: (digit) => {
+      if (game.gameState.answerMode === AnswerMode.INPUT) {
+        game.handleNumberClick(digit);
+      }
+    },
+    onBackspace: () => {
+      if (game.gameState.answerMode === AnswerMode.INPUT) {
+        game.handleNumberClick(-1);
+      }
+    },
+    onClear: () => {
+      if (game.gameState.answerMode === AnswerMode.INPUT) {
+        game.handleNumberClick(-2);
+      }
+    },
+    onSubmit: () => {
+      if (game.gameState.isAnswerChecked) {
+        game.nextQuestion();
+      } else {
+        game.checkAnswer();
+      }
+    },
   });
 
   const t = translations[preferences.language];

--- a/hooks/useKeyboardInput.test.ts
+++ b/hooks/useKeyboardInput.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for useKeyboardInput Hook (#258)
+ * Jest runs with Platform.OS === 'web' (react-native-web), so the listener
+ * is active and can be driven with synthetic KeyboardEvents.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useKeyboardInput, KeyboardInputHandlers } from './useKeyboardInput';
+
+function pressKey(key: string, target?: EventTarget) {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true });
+  (target ?? window).dispatchEvent(event);
+}
+
+function makeHandlers(overrides: Partial<KeyboardInputHandlers> = {}): KeyboardInputHandlers {
+  return {
+    enabled: true,
+    onDigit: jest.fn(),
+    onBackspace: jest.fn(),
+    onClear: jest.fn(),
+    onSubmit: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe('useKeyboardInput', () => {
+  it('forwards digit keys 0-9', () => {
+    const handlers = makeHandlers();
+    renderHook(() => useKeyboardInput(handlers));
+
+    pressKey('7');
+    pressKey('0');
+
+    expect(handlers.onDigit).toHaveBeenCalledTimes(2);
+    expect(handlers.onDigit).toHaveBeenNthCalledWith(1, 7);
+    expect(handlers.onDigit).toHaveBeenNthCalledWith(2, 0);
+  });
+
+  it('forwards Backspace, Escape and Enter', () => {
+    const handlers = makeHandlers();
+    renderHook(() => useKeyboardInput(handlers));
+
+    pressKey('Backspace');
+    pressKey('Escape');
+    pressKey('Enter');
+
+    expect(handlers.onBackspace).toHaveBeenCalledTimes(1);
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    expect(handlers.onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores unrelated keys', () => {
+    const handlers = makeHandlers();
+    renderHook(() => useKeyboardInput(handlers));
+
+    pressKey('a');
+    pressKey('ArrowUp');
+    pressKey(' ');
+
+    expect(handlers.onDigit).not.toHaveBeenCalled();
+    expect(handlers.onBackspace).not.toHaveBeenCalled();
+    expect(handlers.onClear).not.toHaveBeenCalled();
+    expect(handlers.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does nothing while disabled (e.g. a modal is open)', () => {
+    const handlers = makeHandlers({ enabled: false });
+    renderHook(() => useKeyboardInput(handlers));
+
+    pressKey('5');
+    pressKey('Enter');
+
+    expect(handlers.onDigit).not.toHaveBeenCalled();
+    expect(handlers.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('re-enables without re-registering when the enabled prop flips', () => {
+    let handlers = makeHandlers({ enabled: false });
+    const { rerender } = renderHook((props: KeyboardInputHandlers) => useKeyboardInput(props), {
+      initialProps: handlers,
+    });
+
+    pressKey('5');
+    expect(handlers.onDigit).not.toHaveBeenCalled();
+
+    handlers = makeHandlers({ enabled: true });
+    rerender(handlers);
+
+    pressKey('5');
+    expect(handlers.onDigit).toHaveBeenCalledWith(5);
+  });
+
+  it('does not steal keystrokes from text inputs', () => {
+    const handlers = makeHandlers();
+    renderHook(() => useKeyboardInput(handlers));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    pressKey('5', input);
+    input.remove();
+
+    expect(handlers.onDigit).not.toHaveBeenCalled();
+  });
+
+  it('removes the listener on unmount', () => {
+    const handlers = makeHandlers();
+    const { unmount } = renderHook(() => useKeyboardInput(handlers));
+
+    unmount();
+    pressKey('5');
+
+    expect(handlers.onDigit).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useKeyboardInput.ts
+++ b/hooks/useKeyboardInput.ts
@@ -1,0 +1,55 @@
+/**
+ * useKeyboardInput Hook
+ * Physical-keyboard support for the web build (#258): digits 0-9, Enter,
+ * Backspace and Escape drive the game without clicking the on-screen numpad.
+ * No-op on native platforms.
+ */
+
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+export interface KeyboardInputHandlers {
+  /** Master switch — pass false while any modal or menu is open. */
+  enabled: boolean;
+  /** Digit 0-9 typed. Only forwarded while digit input makes sense (caller decides). */
+  onDigit: (digit: number) => void;
+  /** Backspace: remove the last digit. */
+  onBackspace: () => void;
+  /** Escape: clear the current input. */
+  onClear: () => void;
+  /** Enter: check the answer, or advance to the next question once checked. */
+  onSubmit: () => void;
+}
+
+export function useKeyboardInput(handlers: KeyboardInputHandlers): void {
+  // Ref keeps the listener stable while always seeing the latest handlers/state
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return; // platform-safe
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const h = handlersRef.current;
+      if (!h.enabled) return;
+      // Don't steal keystrokes from real form fields (e.g. profile name input)
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA')) return;
+
+      if (event.key >= '0' && event.key <= '9') {
+        h.onDigit(parseInt(event.key, 10));
+      } else if (event.key === 'Backspace') {
+        event.preventDefault();
+        h.onBackspace();
+      } else if (event.key === 'Escape') {
+        h.onClear();
+      } else if (event.key === 'Enter') {
+        event.preventDefault();
+        h.onSubmit();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown); // platform-safe
+    return () => window.removeEventListener('keydown', onKeyDown); // platform-safe
+  }, []);
+}


### PR DESCRIPTION
## Problem

In der Web-Version (GitHub-Pages-PWA) mussten Antworten ausschließlich per Klick auf das Bildschirm-Numpad eingegeben werden — am Desktop unnötig zäh.

## Änderungen

- Neuer Hook `hooks/useKeyboardInput.ts` (nur `Platform.OS === 'web'`, platform-safe mit CI-Lint-Kommentaren):
  - **0–9** → Ziffer eingeben
  - **Backspace** → letzte Ziffer löschen
  - **Escape** → Eingabe leeren
  - **Enter** → Prüfen bzw. „Weiter" (funktioniert auch in Multiple-Choice/Zahlenreihe, sobald eine Auswahl getroffen ist)
- In `App.tsx` verdrahtet; deaktiviert, solange ein Modal/Menü offen ist (Settings, Result, Onboarding, Profil-Picker …)
- Eingaben in echten Textfeldern (z. B. Profilname) werden nicht abgefangen
- Ziffern/Backspace/Escape greifen nur im INPUT-Antwortmodus

## Tests

- 7 neue Tests für den Hook (Tasten-Weiterleitung, Disabled-Zustand, Enable-Flip ohne Re-Registrierung, Textfeld-Schutz, Listener-Cleanup)
- `npm test`: 16/16 Suiten grün

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvTJ3jLnoP2f3i5KEraAE4)_