### PR TITLE
chore: bump version to 1.4.0 (versionCode 30)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "1x1 Trainer",
     "slug": "1x1-trainer",
-    "version": "1.3.9",
+    "version": "1.4.0",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -20,7 +20,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "versionCode": 29,
+      "versionCode": 30,
       "jsEngine": "hermes",
       "googleServicesFile": "./google-services.json",
       "edgeToEdgeEnabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "1x1_trainer",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "1x1_trainer",
-      "version": "1.3.9",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@expo-google-fonts/baloo-2": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1x1_trainer",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "Cross-platform 1x1 multiplication trainer with multiple game modes",
   "main": "index.ts",
   "engines": {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -4,7 +4,7 @@
 
 import { GameMode, NumberRange, Operation, ThemeName } from '../types/game';
 
-export const APP_VERSION = '1.3.9';
+export const APP_VERSION = '1.4.0';
 export const APP_NAME = '1×1 Trainer';
 export const CONTACT_EMAIL = 'devsven@posteo.de';
 


### PR DESCRIPTION
# Pull Request

## Beschreibung

Versionsbump 1.3.9 → 1.4.0 (versionCode 29 → 30) via `./scripts/bump-version.sh minor`, als Vorbereitung für den Release-Merge testing → main. Alle drei Versionsstellen aktualisiert (`package.json`, `app.json`, `utils/constants.ts`) plus `package-lock.json`-Sync; app.json anschließend mit Prettier nachformatiert.

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update / Chore (Versionsbump)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

## Testing Checklist

- [x] `npm test --ci`: 16/16 Suites, 515 passed / 3 skipped
- [x] `npm run format:check` grün
- [x] Version-Consistency-Check (pre-commit) grün
- [x] Keine TypeScript Errors

## Screenshots / Videos

Keine UI-Änderungen.

## Zusätzliche Notizen

Nach Merge dieses PRs folgt der Release-PR testing → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RMZYrA1BEu3swAK3QmPEz

---
_Generated by [Claude Code](https://claude.ai/code/session_015RMZYrA1BEu3swAK3QmPEz)_