### PR TITLE
chore: PR-Trigger auf main beschränken + playstore-assets/ ignorieren

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, testing]
   pull_request:
-    branches: [main, testing]
+    branches: [main]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ public/screenshot*.png
 public/screenshot2.png
 public/favicon-new.png
 playstore-screenshots/
+playstore-assets/
 
 # Security – Pflicht-Einträge (Issue #7 / reusable-gitignore-audit)
 .env


### PR DESCRIPTION
## Was
- `ci-cd.yml`: `pull_request`-Trigger von `[main, testing]` auf `[main]` reduziert
- `.gitignore`: `playstore-assets/` (lokale Marketing-Bilder) ergänzt

## Warum
- Housekeeping aus dem Tagesabschluss-Cleanup
- Der PR-Trigger auf `testing` war redundant (feature→testing-PRs; die eigentlichen Gates laufen ohnehin)
- `playstore-assets/` enthält lokale Gemini-Marketing-Bilder, die nicht ins Repo gehören (Konvention wie `playstore-screenshots/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)