### PR TITLE
feat: Fortschrittsbalken in 10 Abschnitte + Durchlauf-Zähler statt Flamme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,6 +43,8 @@ import {
   getStreakData,
   updateStreakAfterSession,
   getYesterdayDateString,
+  getLocalDateString,
+  getSessionRecords,
   recordTaskResult,
   getTaskStats,
   getWeakTasks,
@@ -95,6 +97,7 @@ export default function App() {
   const [streakWarningVisible, setStreakWarningVisible] = useState(false);
   const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
+  const [roundsToday, setRoundsToday] = useState(0);
 
   // Profile state
   const [activeProfile, setActiveProfile] = useState<ChildProfile | null>(null);
@@ -149,6 +152,7 @@ export default function App() {
         .then(async () => {
           const updatedStreak = await updateStreakAfterSession(pid);
           setStreakData(updatedStreak);
+          setRoundsToday((prev) => prev + 1);
           await badgeSystem.checkAndUnlock(record);
         })
         .catch((err) => console.error('Session save / badge unlock failed:', err));
@@ -331,6 +335,18 @@ export default function App() {
     });
   }, [activeProfile?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Load today's completed rounds count (replaces the streak flame badge in the header)
+  useEffect(() => {
+    if (!activeProfile) return;
+    const today = getLocalDateString();
+    getSessionRecords(activeProfile.id).then((records) => {
+      const count = records.filter(
+        (r) => getLocalDateString(new Date(r.timestamp)) === today
+      ).length;
+      setRoundsToday(count);
+    });
+  }, [activeProfile?.id]);
+
   // Sound + card feedback on answer check
   useEffect(() => {
     if (!game.gameState.isAnswerChecked) return;
@@ -431,9 +447,8 @@ export default function App() {
         difficultyMode={game.gameState.difficultyMode}
         challengeState={game.gameState.challengeState}
         score={game.gameState.score}
-        currentTask={game.gameState.currentTask}
-        totalTasks={game.gameState.totalTasks}
-        currentStreak={streakData.currentStreak}
+        answerHistory={game.gameState.answerHistory}
+        roundsToday={roundsToday}
         onShowMenu={showMenu}
         t={t}
       />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,27 +83,28 @@ npm run test:coverage # Coverage
 
 ---
 
-## Aktueller Stand (2026-06-20)
+## Aktueller Stand (2026-07-07)
 
-- Version: **1.3.8** / versionCode 28
-- Branches: `testing` vorn (inkl. #242, #243, #246, #247); `main` auf `91cf92d` (sync v1.3.8)
-- Offene PRs: #245 (CLAUDE.md docs), gegen `testing`
+- Version: **1.4.0** / versionCode 30
+- Branches: `testing` vorn; `main` auf `91cf92d` (sync v1.3.8)
+- Offene PRs: #272 (Fortschrittsbalken-Segmente + Durchlauf-Zähler), #245 (CLAUDE.md docs), gegen `testing`
 - Offene Issues: #156, #231, #96
 - APK v1.3.8 via CI
 
 ### Zuletzt gemergt / gepusht
 
-| PR / Commit  | Was                                                                         |
-| ------------ | --------------------------------------------------------------------------- |
-| #247 ✅      | feat: Mehrere Kinderprofile (Issue #187 ✅ geschlossen)                     |
-| #246 ✅      | chore: Prettier + pre-push Hook (Issue #220 ✅ geschlossen)                 |
-| #245 (offen) | docs: CLAUDE.md 2026-06-18                                                  |
-| #244 ✅      | build: app.config.js für APP_PACKAGE env-var (Issue #233 ✅ geschlossen)    |
-| #243 ✅      | feat: Orientation "default" für Tablet/Foldable (Issue #235 ✅ geschlossen) |
-| #242 ✅      | fix: Sounds sofort stoppen wenn deaktiviert (Issue #241 ✅ geschlossen)     |
-| #240 ✅      | ci: Cache-Cleanup-Workflow                                                  |
-| #239 ✅      | chore: Review-Modell v2                                                     |
-| #234 ✅      | sync: testing → main (v1.3.8 + googleServicesFile fix)                      |
+| PR / Commit  | Was                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------- |
+| #272 (offen) | feat: Fortschrittsbalken in 10 Segmente (grün/rot pro Aufgabe) + Durchlauf-Zähler statt Flamme |
+| #247 ✅      | feat: Mehrere Kinderprofile (Issue #187 ✅ geschlossen)                                        |
+| #246 ✅      | chore: Prettier + pre-push Hook (Issue #220 ✅ geschlossen)                                    |
+| #245 (offen) | docs: CLAUDE.md 2026-06-18                                                                     |
+| #244 ✅      | build: app.config.js für APP_PACKAGE env-var (Issue #233 ✅ geschlossen)                       |
+| #243 ✅      | feat: Orientation "default" für Tablet/Foldable (Issue #235 ✅ geschlossen)                    |
+| #242 ✅      | fix: Sounds sofort stoppen wenn deaktiviert (Issue #241 ✅ geschlossen)                        |
+| #240 ✅      | ci: Cache-Cleanup-Workflow                                                                     |
+| #239 ✅      | chore: Review-Modell v2                                                                        |
+| #234 ✅      | sync: testing → main (v1.3.8 + googleServicesFile fix)                                         |
 
 ---
 
@@ -115,7 +116,7 @@ npm run test:coverage # Coverage
 | `utils/theme.ts`                    | `getThemeColors(isDarkMode, themeName?)` — themeName optional, Default `'sunset'`                                                                                                                                                                                                                     |
 | `utils/storage.ts`                  | Storage-Helfer + Profile-Management (`migrateToProfiles`, `createProfile`, `deleteProfileData`, `getProfiles`/`saveProfiles`, `setActiveProfileId`). Alle per-Profil-Funktionen haben optionalen `profileId?`-Parameter (Suffix-Pattern `{key}-{profileId}`). `profileKey()` / `resolveKey()` intern. |
 | `utils/animations.ts`               | `prefersReducedMotion()` — liest Accessibility-Einstellung                                                                                                                                                                                                                                            |
-| `types/game.ts`                     | ThemeColors (inkl. `gradientPrimary`), GameState, Enums, SessionRecord, `ThemeName`, `ChildProfile`                                                                                                                                                                                                   |
+| `types/game.ts`                     | ThemeColors (inkl. `gradientPrimary`), GameState (inkl. `answerHistory`), Enums, SessionRecord, `ThemeName`, `ChildProfile`                                                                                                                                                                           |
 | `i18n/translations.ts`              | DE/EN Übersetzungen, `TranslationStrings`-Interface (inkl. 12 Profil-Strings)                                                                                                                                                                                                                         |
 | `hooks/useGameLogic.ts`             | Gesamte Spiellogik, `onSessionComplete`-Callback                                                                                                                                                                                                                                                      |
 | `hooks/usePreferences.ts`           | `usePreferences(profileId?)` — globale Prefs (Sprache, Theme, Sounds) + per-Profil-Prefs (Operations, NumberRange, TotalTasks, HighScore); lädt per-Profil-Daten neu bei Profilwechsel                                                                                                                |
@@ -127,6 +128,8 @@ npm run test:coverage # Coverage
 | `components/ParentDashboard.tsx`    | Eltern-Dashboard Modal (Beta)                                                                                                                                                                                                                                                                         |
 | `components/ProfilePickerModal.tsx` | Bottom-Sheet-Modal für Profilauswahl/-erstellung/-löschung (max. 6 Profile, Farbauswahl, Bestätigungs-Alert bei Löschen)                                                                                                                                                                              |
 | `components/GameCard.tsx`           | Hauptspielansicht (alle 3 Antwortmodi)                                                                                                                                                                                                                                                                |
+| `components/Header.tsx`             | Score/Level/Lives, segmentierte `ProgressBar`, Durchlauf-Zähler (`roundsToday`, ersetzt seit PR #272 die Streak-Flamme)                                                                                                                                                                               |
+| `components/ProgressBar.tsx`        | 10 Segmente statt Gradient-Fill; `history: (boolean \| null)[]` → grün/rot/grau pro Aufgabe                                                                                                                                                                                                           |
 | `styles/modalStyles.ts`             | Gemeinsame Modal-Styles                                                                                                                                                                                                                                                                               |
 | `app.config.js`                     | Dynamische Expo-Konfiguration: überschreibt `android.package` via `APP_PACKAGE` env-var (Issue #233)                                                                                                                                                                                                  |
 | `jest.config.js`                    | Jest-Konfiguration                                                                                                                                                                                                                                                                                    |
@@ -166,10 +169,19 @@ npm run test:coverage # Coverage
 - `updateStreakAfterSession()` in `utils/storage.ts`: DST-sicherer Vergleich via `getLocalDateString()` — kein UTC-Offset-Problem
 - Streak-Logik: gleicher Tag → kein Update; Folgetag → +1; Lücke → Reset auf 1 (longestStreak bleibt)
 - `isNonNegInt` / `isLocalDateString`: Validatoren in storage.ts verhindern korrupte Werte (NaN, negativ, falsches Format)
-- Header zeigt 🔥 {n} Badge wenn `currentStreak > 0` (via `currentStreak`-Prop in Header.tsx)
+- **Seit PR #272 kein 🔥-Badge mehr im Header** — dort steht jetzt der Durchlauf-Zähler (`roundsToday`), siehe eigener Abschnitt unten. Die Streak-Daten selbst laufen unverändert weiter und werden nur noch im ParentDashboard + der Abend-Warnung angezeigt
 - Abend-Warnung: Modal bei App-Öffnung wenn `hour >= 20` + Streak aktiv + heute noch nicht gespielt
 - ParentDashboard: currentStreak + longestStreak im Summary-Bar (inkl. korrekter Divider-Logik)
 - `streakWarningMessage` enthält `{days}` Platzhalter → wird via `.replace('{days}', ...)` in App.tsx ersetzt
+
+## Fortschrittsbalken / Durchlauf-Zähler — Hinweise (PR #272)
+
+- `GameState.answerHistory: (boolean | null)[]` (`types/game.ts`) — Ergebnis pro Aufgabe der aktuellen Runde, Länge `TOTAL_TASKS` (10); `null` = noch nicht beantwortet
+- `useGameLogic.checkAnswer()` schreibt `isCorrect` an Index `currentTask - 1`; `emptyAnswerHistory()` setzt bei jedem Rundenstart zurück (`restartGame`, `continueGame`, `changeGameMode`, `toggleOperation`, `changeAnswerMode`, `changeDifficultyMode`, Operationswechsel-Effect)
+- `components/ProgressBar.tsx`: kein animierter Gradient-Fill mehr, sondern 10 einzelne Segmente (`history`-Prop); grün `#10B981` = richtig, rot `#EF4444` = falsch, grau `#E2E8F0` = offen
+- Im Challenge-Modus wird statt der ProgressBar weiterhin die Lives-Anzeige gerendert (unverändert)
+- `App.tsx`: neuer `roundsToday`-State — beim Profilwechsel aus `getSessionRecords()` (gefiltert auf `getLocalDateString()` == heute) geladen, bei jedem `onSessionComplete` hochgezählt; **kein eigener Storage-Key**, reine Ableitung aus SessionRecords, setzt sich also automatisch täglich zurück
+- `i18n/translations.ts`: `roundsInfoTitle` / `roundsInfoBody` (DE/EN) ersetzen die entfernten `streakInfoTitle` / `streakInfoBody`
 
 ## Adaptives Lernen / Übungsmodus (PRACTICE) — Hinweise
 

--- a/components/GameCard.test.tsx
+++ b/components/GameCard.test.tsx
@@ -50,6 +50,7 @@ const baseGameState: GameState = {
   isAnswerChecked: false,
   totalSolvedTasks: 0,
   selectedChoice: null,
+  answerHistory: Array(10).fill(null),
 };
 
 const defaultProps = {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,16 +10,15 @@ interface HeaderProps {
   difficultyMode: DifficultyMode;
   challengeState?: ChallengeState;
   score: number;
-  currentTask: number;
-  totalTasks: number;
-  currentStreak?: number;
+  answerHistory: (boolean | null)[];
+  roundsToday?: number;
   onShowMenu: () => void;
   t: {
     level: string;
     task: string;
     points: string;
-    streakInfoTitle: string;
-    streakInfoBody: string;
+    roundsInfoTitle: string;
+    roundsInfoBody: string;
   };
 }
 
@@ -28,9 +27,8 @@ export function Header({
   difficultyMode,
   challengeState,
   score,
-  currentTask,
-  totalTasks,
-  currentStreak,
+  answerHistory,
+  roundsToday,
   onShowMenu,
   t,
 }: HeaderProps) {
@@ -50,21 +48,19 @@ export function Header({
           <Badge value={score} variant="default" animated />
         </>
       ) : (
-        <ProgressBar
-          current={currentTask - 1}
-          total={totalTasks}
-          gradientColors={colors.gradientPrimary}
-        />
+        <ProgressBar history={answerHistory} />
       )}
-      {!!currentStreak && currentStreak > 0 && (
+      {!!roundsToday && roundsToday > 0 && (
         <TouchableOpacity
-          onPress={() => Alert.alert(t.streakInfoTitle, `${currentStreak} ${t.streakInfoBody}`)}
+          onPress={() => Alert.alert(t.roundsInfoTitle, `${roundsToday} ${t.roundsInfoBody}`)}
           activeOpacity={0.7}
-          style={styles.streakBadge}
+          style={[styles.roundsBadge, { backgroundColor: colors.buttonInactive }]}
           accessibilityRole="button"
-          accessibilityLabel={`${t.streakInfoTitle}: ${currentStreak}`}
+          accessibilityLabel={`${t.roundsInfoTitle}: ${roundsToday}`}
         >
-          <Text style={styles.streakText}>🔥 {currentStreak}</Text>
+          <Text style={[styles.roundsText, { color: colors.buttonInactiveText }]}>
+            {roundsToday}
+          </Text>
         </TouchableOpacity>
       )}
       <TouchableOpacity onPress={onShowMenu} style={styles.settingsButton} aria-label="Settings">
@@ -97,17 +93,16 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'normal',
   },
-  streakBadge: {
+  roundsBadge: {
+    minWidth: 28,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 14,
-    backgroundColor: 'rgba(249,212,35,0.15)',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  streakText: {
+  roundsText: {
     fontSize: 14,
     fontWeight: 'bold',
-    color: '#F59E0B',
   },
 });

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -1,46 +1,33 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
-import { DESIGN_TOKENS } from '../utils/constants';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 
 interface ProgressBarProps {
-  current: number;
-  total: number;
-  gradientColors?: readonly [string, string];
+  history: (boolean | null)[];
 }
 
-export function ProgressBar({ current, total, gradientColors }: ProgressBarProps) {
-  const widthAnim = useRef(new Animated.Value(0)).current;
+const CORRECT_COLOR = '#10B981';
+const INCORRECT_COLOR = '#EF4444';
+const NEUTRAL_COLOR = '#E2E8F0';
 
-  useEffect(() => {
-    const pct = total > 0 ? Math.min(current / total, 1) : 0;
-    Animated.timing(widthAnim, {
-      toValue: pct,
-      duration: 300,
-      useNativeDriver: false,
-    }).start();
-  }, [current, total, widthAnim]);
-
+export function ProgressBar({ history }: ProgressBarProps) {
   return (
     <View style={styles.track}>
-      <Animated.View
-        style={[
-          styles.fill,
-          {
-            width: widthAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: ['0%', '100%'],
-            }),
-          },
-        ]}
-      >
-        <LinearGradient
-          colors={gradientColors ?? DESIGN_TOKENS.GRADIENT_PRIMARY}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 0 }}
-          style={StyleSheet.absoluteFill}
+      {history.map((result, index) => (
+        <View
+          key={index}
+          style={[
+            styles.segment,
+            {
+              backgroundColor:
+                result === true
+                  ? CORRECT_COLOR
+                  : result === false
+                    ? INCORRECT_COLOR
+                    : NEUTRAL_COLOR,
+            },
+          ]}
         />
-      </Animated.View>
+      ))}
     </View>
   );
 }
@@ -48,14 +35,13 @@ export function ProgressBar({ current, total, gradientColors }: ProgressBarProps
 const styles = StyleSheet.create({
   track: {
     flex: 1,
+    flexDirection: 'row',
     height: 10,
-    backgroundColor: '#E2E8F0',
-    borderRadius: 5,
-    overflow: 'hidden',
+    gap: 3,
   },
-  fill: {
+  segment: {
+    flex: 1,
     height: '100%',
-    borderRadius: 5,
-    overflow: 'hidden',
+    borderRadius: 3,
   },
 });

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -188,6 +188,8 @@ export function useGameLogic({
       ? initialOperations
       : [initialOperation || Operation.MULTIPLICATION];
 
+  const emptyAnswerHistory = (): (boolean | null)[] => Array(TOTAL_TASKS).fill(null);
+
   const [gameState, setGameState] = useState<GameState>({
     num1: 1,
     num2: 1,
@@ -206,6 +208,7 @@ export function useGameLogic({
     isAnswerChecked: false,
     totalSolvedTasks: initialTotalSolvedTasks,
     selectedChoice: null,
+    answerHistory: emptyAnswerHistory(),
   });
 
   const fireSessionComplete = (
@@ -443,6 +446,7 @@ export function useGameLogic({
         currentTask: 1,
         score: 0,
         showResult: false,
+        answerHistory: emptyAnswerHistory(),
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -532,11 +536,18 @@ export function useGameLogic({
     }
 
     setGameState((prev) => {
+      const answerIndex = prev.currentTask - 1;
+      const newHistory = [...prev.answerHistory];
+      if (answerIndex >= 0 && answerIndex < newHistory.length) {
+        newHistory[answerIndex] = isCorrect;
+      }
+
       const newState: GameState = {
         ...prev,
         lastAnswerCorrect: isCorrect,
         score: newScore,
         isAnswerChecked: true,
+        answerHistory: newHistory,
       };
 
       // Challenge mode: update lives on wrong answer
@@ -656,6 +667,7 @@ export function useGameLogic({
         currentTask: 1,
         showResult: false,
         challengeState: newChallengeState,
+        answerHistory: emptyAnswerHistory(),
       }));
 
       const level1Ops = new Set([Operation.MULTIPLICATION]);
@@ -668,6 +680,7 @@ export function useGameLogic({
       score: 0,
       currentTask: 1,
       showResult: false,
+      answerHistory: emptyAnswerHistory(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -678,6 +691,7 @@ export function useGameLogic({
       ...prev,
       currentTask: 1,
       showResult: false,
+      answerHistory: emptyAnswerHistory(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -690,6 +704,7 @@ export function useGameLogic({
       currentTask: 1,
       score: 0,
       showResult: false,
+      answerHistory: emptyAnswerHistory(),
     }));
     setTimeout(() => generateQuestion(newMode), 0);
   };
@@ -715,6 +730,7 @@ export function useGameLogic({
         currentTask: 1,
         score: 0,
         showResult: false,
+        answerHistory: emptyAnswerHistory(),
       };
 
       // Generate a new question with the updated operations
@@ -734,6 +750,7 @@ export function useGameLogic({
       showResult: false,
       userAnswer: '',
       selectedChoice: null,
+      answerHistory: emptyAnswerHistory(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -767,6 +784,7 @@ export function useGameLogic({
         userAnswer: '',
         selectedChoice: null,
         challengeState: initialChallengeState,
+        answerHistory: emptyAnswerHistory(),
       }));
 
       // Level 1 starts with multiplication only, range 10
@@ -799,6 +817,7 @@ export function useGameLogic({
       userAnswer: '',
       selectedChoice: null,
       challengeState: undefined,
+      answerHistory: emptyAnswerHistory(),
     }));
     setTimeout(() => generateQuestion(newGameMode, undefined, undefined, newMode), 0);
   };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -97,8 +97,8 @@ export interface TranslationStrings {
   streakWarningTitle: string;
   streakWarningMessage: string;
   streakWarningButton: string;
-  streakInfoTitle: string;
-  streakInfoBody: string;
+  roundsInfoTitle: string;
+  roundsInfoBody: string;
   parentWeakTasks: string;
   parentWeakTasksEmpty: string;
   chartSessions: string;
@@ -267,8 +267,8 @@ export const translations: Record<Language, TranslationStrings> = {
     streakWarningTitle: "Don't break your streak!",
     streakWarningMessage: 'Play a quick round today to keep your {days}-day streak going!',
     streakWarningButton: "Let's go!",
-    streakInfoTitle: 'Streak',
-    streakInfoBody: 'days played in a row. Keep it up!',
+    roundsInfoTitle: 'Rounds today',
+    roundsInfoBody: 'rounds completed today. Keep it up!',
     parentWeakTasks: 'Weak Areas (Top 5)',
     parentWeakTasksEmpty: 'No weak areas identified yet.',
     chartSessions: 'Sessions · 14 days',
@@ -436,8 +436,8 @@ export const translations: Record<Language, TranslationStrings> = {
     streakWarningTitle: 'Brich deine Serie nicht!',
     streakWarningMessage: 'Spiel heute eine Runde, um deine {days}-Tage-Serie zu halten!',
     streakWarningButton: "Los geht's!",
-    streakInfoTitle: 'Serie',
-    streakInfoBody: 'Tage in Folge gespielt. Weiter so!',
+    roundsInfoTitle: 'Durchläufe heute',
+    roundsInfoBody: 'Durchläufe heute abgeschlossen. Weiter so!',
     parentWeakTasks: 'Schwachstellen (Top 5)',
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
     chartSessions: 'Einheiten · 14 Tage',

--- a/types/game.ts
+++ b/types/game.ts
@@ -70,6 +70,9 @@ export interface GameState {
   totalSolvedTasks: number; // Track total tasks solved for motivation message
   selectedChoice: number | null; // For multiple choice and number sequence modes
   challengeState?: ChallengeState; // Challenge mode state
+  // Per-task result of the current round, indexed by task position (0-based).
+  // null = not answered yet. Drives the segmented progress bar.
+  answerHistory: (boolean | null)[];
 }
 
 export interface TaskStat {


### PR DESCRIPTION
## Beschreibung

- Der Fortschrittsbalken im Header ist jetzt in 10 Abschnitte (einer pro Aufgabe) unterteilt. Wird eine Aufgabe richtig beantwortet, färbt sich der entsprechende Abschnitt grün; bei einer falschen Antwort rot. Noch nicht beantwortete Abschnitte bleiben neutral-grau.
- Das Flammen-Symbol (`🔥 {streak}`) im Header wurde entfernt und durch einen Zähler der heute abgeschlossenen Durchläufe ersetzt (z. B. „2" nach 2 abgeschlossenen Runden). Die zugrunde liegenden Streak-Daten (Tage in Folge gespielt) bleiben unverändert erhalten und werden weiterhin im Eltern-Dashboard sowie für die Abend-Warnung genutzt.

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [x] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [ ] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

Keine neuen `window.*`/`document`/Storage-Zugriffe; reine React-Native-Komponenten (`View`, `Text`) und bestehende Storage-Helfer (`getSessionRecords`, `getLocalDateString`) wiederverwendet.

## Testing Checklist

- [x] Lokaler Build erfolgreich (`npx tsc --noEmit`)
- [x] Keine TypeScript Errors
- [x] `npm test` — 515 Tests grün (16 Suiten)
- [x] App startet ohne Crashes (im Browser getestet, siehe Screenshots)
- [x] Geänderte Features funktionieren wie erwartet (10 Segmente, grün/rot pro Aufgabe, Durchlauf-Zähler nach Rundenabschluss)

## Screenshots / Videos

**Web:**

Leerer Balken (10 neutrale Segmente) zu Rundenbeginn, danach gemischt grün/rot nach mehreren beantworteten Aufgaben, und alle 10 Segmente grün mit Durchlauf-Zähler „1" nach einer perfekten Runde.

**Mobile:**

Nicht separat getestet (reine RN-Komponenten, identisches Verhalten zu Web erwartet).

## Zusätzliche Notizen

Implementierung:
- `types/game.ts`: `GameState.answerHistory: (boolean | null)[]` — pro-Aufgabe-Ergebnis der aktuellen Runde
- `hooks/useGameLogic.ts`: `answerHistory` wird in `checkAnswer()` befüllt und bei jedem Rundenstart (`restartGame`, `continueGame`, `changeGameMode`, `toggleOperation`, `changeAnswerMode`, `changeDifficultyMode`, Operationswechsel) zurückgesetzt
- `components/ProgressBar.tsx`: von animiertem Gradient-Fill auf 10 einzelne Segmente umgebaut
- `App.tsx`: neuer `roundsToday`-State, initial aus `getSessionRecords()` (gefiltert auf heutiges lokales Datum) geladen, wird bei jedem `onSessionComplete` hochgezählt
- `i18n/translations.ts`: `streakInfoTitle`/`streakInfoBody` entfernt (nicht mehr referenziert), `roundsInfoTitle`/`roundsInfoBody` (DE/EN) ergänzt
- Streak-System selbst (Storage, Eltern-Dashboard, Abend-Warnung) unverändert

Getestet per Playwright gegen `expo start --web`: leerer Balken, gemischter grün/rot-Zustand und der Durchlauf-Zähler nach einer abgeschlossenen 10er-Runde.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAcX4VYeLwXrFjJbV9E2Rp)_