### PR TITLE
feat: Wochenrückblick im Eltern-Dashboard + freundlicher Empty-State (Issue #277 1d/2d)

### DIFF
--- a/components/ParentDashboard.test.tsx
+++ b/components/ParentDashboard.test.tsx
@@ -32,6 +32,16 @@ const t = {
   parentStreakDays: 'Tage',
   chartSessions: 'Einheiten · 14 Tage',
   chartErrorRate: 'Fehlerquote · 14 Tage',
+  parentEmptyTitle: "Los geht's!",
+  parentWeeklyReview: 'Wochenrückblick',
+  parentWeeklySessions: 'Einheiten diese Woche',
+  parentWeeklyVsLastWeek: 'vs. letzte Woche',
+  parentWeeklyMinutes: 'Übungszeit diese Woche',
+  parentWeeklyMinutesUnit: 'Min',
+  parentRowAccuracy: 'Genauigkeit pro Malreihe',
+  parentWeeklyRecommendation: 'Übungsempfehlung der Woche',
+  parentRecommendationText: 'Die {row}er-Reihe üben (Fehlerquote {rate}%)',
+  parentRecommendationEmpty: 'Keine Schwachstelle erkannt – weiter so!',
   ok: 'OK',
 };
 
@@ -58,22 +68,22 @@ describe('ParentDashboard', () => {
     mockGetTaskStats.mockResolvedValue([]);
   });
 
-  it('shows empty state when no records', async () => {
+  it('shows friendly empty state illustration when no records', async () => {
     const { getByText } = render(
       <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
     );
     await waitFor(() => {
+      expect(getByText(t.parentEmptyTitle)).toBeTruthy();
       expect(getByText(t.parentNoData)).toBeTruthy();
     });
   });
 
-  it('shows title and beta badge', async () => {
+  it('shows title', async () => {
     const { getByText } = render(
       <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
     );
     await waitFor(() => {
       expect(getByText(t.parentDashboard)).toBeTruthy();
-      expect(getByText('BETA')).toBeTruthy();
     });
   });
 
@@ -190,6 +200,71 @@ describe('ParentDashboard', () => {
     await waitFor(() => {
       expect(getByText(t.chartSessions)).toBeTruthy();
       expect(getByText(t.chartErrorRate)).toBeTruthy();
+    });
+  });
+
+  it('shows weekly session count in the weekly review section', async () => {
+    mockGetSessionRecords.mockResolvedValue([
+      makeRecord({ timestamp: Date.now() }),
+      makeRecord({ timestamp: Date.now() - 2 * 24 * 60 * 60 * 1000 }),
+    ]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(t.parentWeeklyReview)).toBeTruthy();
+      expect(getByText(`${t.parentWeeklySessions}: 2`)).toBeTruthy();
+    });
+  });
+
+  it('shows practiced minutes when session durations are recorded', async () => {
+    mockGetSessionRecords.mockResolvedValue([
+      makeRecord({ timestamp: Date.now(), durationMs: 90000 }),
+    ]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(`${t.parentWeeklyMinutes}: 2 ${t.parentWeeklyMinutesUnit}`)).toBeTruthy();
+    });
+  });
+
+  it('recommends the weakest times-table row when one is clearly weak', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    mockGetTaskStats.mockResolvedValue([
+      {
+        num1: 6,
+        num2: 7,
+        operation: 'MULTIPLICATION',
+        correctCount: 1,
+        errorCount: 5,
+        lastSeen: new Date().toISOString(),
+      },
+      {
+        num1: 6,
+        num2: 8,
+        operation: 'MULTIPLICATION',
+        correctCount: 0,
+        errorCount: 3,
+        lastSeen: new Date().toISOString(),
+      },
+    ]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText('Die 6er-Reihe üben (Fehlerquote 89%)')).toBeTruthy();
+    });
+  });
+
+  it('shows the empty recommendation message when no row is weak', async () => {
+    mockGetSessionRecords.mockResolvedValue([makeRecord()]);
+    mockGetTaskStats.mockResolvedValue([]);
+    const { getByText } = render(
+      <ParentDashboard visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(t.parentRecommendationEmpty)).toBeTruthy();
     });
   });
 

--- a/components/ParentDashboard.tsx
+++ b/components/ParentDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -54,6 +54,16 @@ interface ParentDashboardProps {
     parentWeakTasksEmpty: string;
     chartSessions: string;
     chartErrorRate: string;
+    parentEmptyTitle: string;
+    parentWeeklyReview: string;
+    parentWeeklySessions: string;
+    parentWeeklyVsLastWeek: string;
+    parentWeeklyMinutes: string;
+    parentWeeklyMinutesUnit: string;
+    parentRowAccuracy: string;
+    parentWeeklyRecommendation: string;
+    parentRecommendationText: string;
+    parentRecommendationEmpty: string;
     ok: string;
   };
 }
@@ -210,6 +220,77 @@ function errorRateColor(rate: number): string {
   return '#EF4444';
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TIMES_TABLE_ROWS = Array.from({ length: 10 }, (_, i) => i + 1);
+
+// Rolling window ending `offsetDays` ago (0 = up to now), matching the
+// rolling-14-days convention used by getLast14Days rather than calendar weeks.
+function recordsInLastNDays(
+  records: SessionRecord[],
+  days: number,
+  offsetDays = 0
+): SessionRecord[] {
+  const now = Date.now();
+  const windowEnd = now - offsetDays * DAY_MS;
+  const windowStart = windowEnd - days * DAY_MS;
+  return records.filter((r) => r.timestamp >= windowStart && r.timestamp < windowEnd);
+}
+
+function computeTrend(current: number, previous: number): 'up' | 'down' | 'flat' | null {
+  if (current === 0 && previous === 0) return null;
+  if (current > previous) return 'up';
+  if (current < previous) return 'down';
+  return 'flat';
+}
+
+function practicedMinutes(records: SessionRecord[]): number | null {
+  const withDuration = records.filter((r) => typeof r.durationMs === 'number');
+  if (withDuration.length === 0) return null;
+  const totalMs = withDuration.reduce((sum, r) => sum + (r.durationMs ?? 0), 0);
+  return Math.round(totalMs / 60000);
+}
+
+interface RowAccuracy {
+  row: number;
+  correct: number;
+  total: number;
+}
+
+// All-time accuracy per times-table row, derived from TaskStat (no per-attempt
+// timestamps exist, so this can't be windowed to "this week" like the rest of
+// the review).
+function computeRowAccuracy(stats: TaskStat[]): RowAccuracy[] {
+  const byRow = new Map<number, RowAccuracy>(
+    TIMES_TABLE_ROWS.map((row) => [row, { row, correct: 0, total: 0 }])
+  );
+  for (const s of stats) {
+    if (s.operation !== Operation.MULTIPLICATION) continue;
+    const total = s.correctCount + s.errorCount;
+    for (const row of new Set([s.num1, s.num2])) {
+      const entry = byRow.get(row);
+      if (entry) {
+        entry.correct += s.correctCount;
+        entry.total += total;
+      }
+    }
+  }
+  return TIMES_TABLE_ROWS.map((row) => byRow.get(row)!);
+}
+
+function recommendWeakestRow(
+  rows: RowAccuracy[],
+  minAttempts = 5,
+  minErrorRate = 0.2
+): RowAccuracy | null {
+  const candidates = rows.filter((r) => r.total >= minAttempts);
+  if (candidates.length === 0) return null;
+  const worst = [...candidates].sort(
+    (a, b) => (b.total - b.correct) / b.total - (a.total - a.correct) / a.total
+  )[0];
+  const rate = (worst.total - worst.correct) / worst.total;
+  return rate > minErrorRate ? worst : null;
+}
+
 export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboardProps) {
   const [records, setRecords] = useState<SessionRecord[]>([]);
   const [streak, setStreak] = useState<StreakData>({
@@ -217,7 +298,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
     lastPlayedDate: '',
     longestStreak: 0,
   });
-  const [weakTasks, setWeakTasks] = useState<TaskStat[]>([]);
+  const [taskStats, setTaskStats] = useState<TaskStat[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -227,12 +308,14 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
         ([data, streakData, stats]) => {
           setRecords(data);
           setStreak(streakData);
-          setWeakTasks(getWeakTasks(stats).slice(0, 5));
+          setTaskStats(stats);
           setLoading(false);
         }
       );
     }
   }, [visible]);
+
+  const weakTasks = useMemo(() => getWeakTasks(taskStats).slice(0, 5), [taskStats]);
 
   const grouped = groupByDay(records);
   const chartData = getLast14Days(records);
@@ -244,6 +327,13 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
     recentRecords.length > 0
       ? recentRecords.reduce((sum, r) => sum + r.errorRate, 0) / recentRecords.length
       : null;
+
+  const thisWeekRecords = recordsInLastNDays(records, 7, 0);
+  const lastWeekRecords = recordsInLastNDays(records, 7, 7);
+  const sessionsTrend = computeTrend(thisWeekRecords.length, lastWeekRecords.length);
+  const weeklyMinutes = practicedMinutes(thisWeekRecords);
+  const rowAccuracy = useMemo(() => computeRowAccuracy(taskStats), [taskStats]);
+  const recommendation = useMemo(() => recommendWeakestRow(rowAccuracy), [rowAccuracy]);
 
   const getDayLabel = (key: string) => {
     if (key === '__today__') return t.parentToday;
@@ -258,12 +348,7 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           {/* Header */}
           <View style={styles.header}>
             <View>
-              <View style={styles.titleRow}>
-                <Text style={[styles.title, { color: colors.text }]}>{t.parentDashboard}</Text>
-                <View style={styles.betaBadge}>
-                  <Text style={styles.betaText}>BETA</Text>
-                </View>
-              </View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.parentDashboard}</Text>
               <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
                 {t.parentDashboardSubtitle}
               </Text>
@@ -332,11 +417,110 @@ export function ParentDashboard({ visible, onClose, colors, t }: ParentDashboard
           {loading ? (
             <ActivityIndicator style={styles.loader} color={colors.gradientPrimary[0]} />
           ) : records.length === 0 ? (
-            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-              {t.parentNoData}
-            </Text>
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyEmoji}>📊</Text>
+              <Text style={[styles.emptyTitle, { color: colors.text }]}>{t.parentEmptyTitle}</Text>
+              <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+                {t.parentNoData}
+              </Text>
+            </View>
           ) : (
             <ScrollView style={styles.list} showsVerticalScrollIndicator={false}>
+              {/* Weekly review */}
+              <View style={[styles.weeklySection, { borderColor: colors.border }]}>
+                <Text style={[styles.weeklyTitle, { color: colors.textSecondary }]}>
+                  {t.parentWeeklyReview}
+                </Text>
+                <View style={styles.weeklyRow}>
+                  <Text style={[styles.weeklyLabel, { color: colors.text }]}>
+                    {t.parentWeeklySessions}: {thisWeekRecords.length}
+                  </Text>
+                  {sessionsTrend && (
+                    <Text
+                      style={[
+                        styles.weeklyTrend,
+                        {
+                          color:
+                            sessionsTrend === 'up'
+                              ? '#10B981'
+                              : sessionsTrend === 'down'
+                                ? '#F59E0B'
+                                : colors.textSecondary,
+                        },
+                      ]}
+                    >
+                      {sessionsTrend === 'up' ? '▲' : sessionsTrend === 'down' ? '▼' : '→'}{' '}
+                      {t.parentWeeklyVsLastWeek}
+                    </Text>
+                  )}
+                </View>
+                {weeklyMinutes !== null && (
+                  <Text style={[styles.weeklyLabel, { color: colors.text }]}>
+                    {t.parentWeeklyMinutes}: {weeklyMinutes} {t.parentWeeklyMinutesUnit}
+                  </Text>
+                )}
+
+                <Text
+                  style={[
+                    styles.weeklySubtitle,
+                    styles.weeklySubtitleSpaced,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  {t.parentRowAccuracy}
+                </Text>
+                <View style={styles.rowAccuracyRow}>
+                  {rowAccuracy.map(({ row, correct, total }) => {
+                    const rate = total > 0 ? (total - correct) / total : null;
+                    return (
+                      <View
+                        key={row}
+                        style={[
+                          styles.rowChip,
+                          {
+                            backgroundColor:
+                              rate !== null ? errorRateColor(rate) + '33' : colors.buttonInactive,
+                          },
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.rowChipText,
+                            { color: rate !== null ? errorRateColor(rate) : colors.textSecondary },
+                          ]}
+                        >
+                          {row}
+                        </Text>
+                      </View>
+                    );
+                  })}
+                </View>
+
+                <Text
+                  style={[
+                    styles.weeklySubtitle,
+                    styles.weeklySubtitleSpaced,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  {t.parentWeeklyRecommendation}
+                </Text>
+                <Text style={[styles.weeklyLabel, { color: colors.text }]}>
+                  {recommendation
+                    ? t.parentRecommendationText
+                        .replace('{row}', recommendation.row.toString())
+                        .replace(
+                          '{rate}',
+                          Math.round(
+                            ((recommendation.total - recommendation.correct) /
+                              recommendation.total) *
+                              100
+                          ).toString()
+                        )
+                    : t.parentRecommendationEmpty}
+                </Text>
+              </View>
+
               {/* Charts */}
               {hasChartData && (
                 <View style={[styles.chartsSection, { borderColor: colors.border }]}>
@@ -475,26 +659,9 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     marginBottom: 14,
   },
-  titleRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
   title: {
     fontSize: 18,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-  },
-  betaBadge: {
-    backgroundColor: '#F59E0B22',
-    borderRadius: 6,
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-  },
-  betaText: {
-    fontSize: 10,
-    fontFamily: DESIGN_TOKENS.FONT_UI,
-    color: '#F59E0B',
-    letterSpacing: 0.5,
   },
   subtitle: {
     fontSize: 11,
@@ -540,15 +707,83 @@ const styles = StyleSheet.create({
   loader: {
     marginVertical: 32,
   },
+  emptyState: {
+    alignItems: 'center',
+    marginVertical: 32,
+    gap: 6,
+  },
+  emptyEmoji: {
+    fontSize: 40,
+    marginBottom: 4,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
   emptyText: {
     textAlign: 'center',
     fontSize: 14,
     fontFamily: DESIGN_TOKENS.FONT_UI,
-    marginVertical: 32,
   },
   list: {
     flex: 1,
     marginBottom: 12,
+  },
+  weeklySection: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 12,
+    gap: 4,
+  },
+  weeklyTitle: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  weeklyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  weeklyLabel: {
+    fontSize: 13,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  weeklyTrend: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  weeklySubtitle: {
+    fontSize: 10,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  weeklySubtitleSpaced: {
+    marginTop: 8,
+  },
+  rowAccuracyRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 4,
+  },
+  rowChip: {
+    width: 28,
+    height: 28,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowChipText: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
   },
   chartsSection: {
     borderWidth: 1,

--- a/hooks/useGameLogic.ts
+++ b/hooks/useGameLogic.ts
@@ -190,6 +190,13 @@ export function useGameLogic({
 
   const emptyAnswerHistory = (): (boolean | null)[] => Array(TOTAL_TASKS).fill(null);
 
+  const sessionStartRef = useRef<number>(Date.now());
+  // Resets the round timer alongside the answer history; call at every round start
+  const beginNewRound = (): (boolean | null)[] => {
+    sessionStartRef.current = Date.now();
+    return emptyAnswerHistory();
+  };
+
   const [gameState, setGameState] = useState<GameState>({
     num1: 1,
     num2: 1,
@@ -232,6 +239,7 @@ export function useGameLogic({
       errorRate: totalTasks > 0 ? errors / totalTasks : 0,
       difficultyMode: gameState.difficultyMode,
       numberRange: effectiveRange,
+      durationMs: Math.max(0, Date.now() - sessionStartRef.current),
     };
     if (gameState.difficultyMode === DifficultyMode.CHALLENGE) {
       record.challengeFlawlessLevel3 = gameState.challengeState?.flawlessLevel3 === true;
@@ -446,7 +454,7 @@ export function useGameLogic({
         currentTask: 1,
         score: 0,
         showResult: false,
-        answerHistory: emptyAnswerHistory(),
+        answerHistory: beginNewRound(),
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -667,7 +675,7 @@ export function useGameLogic({
         currentTask: 1,
         showResult: false,
         challengeState: newChallengeState,
-        answerHistory: emptyAnswerHistory(),
+        answerHistory: beginNewRound(),
       }));
 
       const level1Ops = new Set([Operation.MULTIPLICATION]);
@@ -680,7 +688,7 @@ export function useGameLogic({
       score: 0,
       currentTask: 1,
       showResult: false,
-      answerHistory: emptyAnswerHistory(),
+      answerHistory: beginNewRound(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -691,7 +699,7 @@ export function useGameLogic({
       ...prev,
       currentTask: 1,
       showResult: false,
-      answerHistory: emptyAnswerHistory(),
+      answerHistory: beginNewRound(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -704,7 +712,7 @@ export function useGameLogic({
       currentTask: 1,
       score: 0,
       showResult: false,
-      answerHistory: emptyAnswerHistory(),
+      answerHistory: beginNewRound(),
     }));
     setTimeout(() => generateQuestion(newMode), 0);
   };
@@ -730,7 +738,7 @@ export function useGameLogic({
         currentTask: 1,
         score: 0,
         showResult: false,
-        answerHistory: emptyAnswerHistory(),
+        answerHistory: beginNewRound(),
       };
 
       // Generate a new question with the updated operations
@@ -750,7 +758,7 @@ export function useGameLogic({
       showResult: false,
       userAnswer: '',
       selectedChoice: null,
-      answerHistory: emptyAnswerHistory(),
+      answerHistory: beginNewRound(),
     }));
     setTimeout(() => generateQuestion(), 0);
   };
@@ -784,7 +792,7 @@ export function useGameLogic({
         userAnswer: '',
         selectedChoice: null,
         challengeState: initialChallengeState,
-        answerHistory: emptyAnswerHistory(),
+        answerHistory: beginNewRound(),
       }));
 
       // Level 1 starts with multiplication only, range 10
@@ -817,7 +825,7 @@ export function useGameLogic({
       userAnswer: '',
       selectedChoice: null,
       challengeState: undefined,
-      answerHistory: emptyAnswerHistory(),
+      answerHistory: beginNewRound(),
     }));
     setTimeout(() => generateQuestion(newGameMode, undefined, undefined, newMode), 0);
   };

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -101,6 +101,16 @@ export interface TranslationStrings {
   parentWeakTasksEmpty: string;
   chartSessions: string;
   chartErrorRate: string;
+  parentEmptyTitle: string;
+  parentWeeklyReview: string;
+  parentWeeklySessions: string;
+  parentWeeklyVsLastWeek: string;
+  parentWeeklyMinutes: string;
+  parentWeeklyMinutesUnit: string;
+  parentRowAccuracy: string;
+  parentWeeklyRecommendation: string;
+  parentRecommendationText: string;
+  parentRecommendationEmpty: string;
   colorTheme: string;
   // Sounds
   sounds: string;
@@ -248,7 +258,7 @@ export const translations: Record<Language, TranslationStrings> = {
     ok: 'OK',
     // Parent Dashboard
     parentDashboard: 'Parent Dashboard',
-    parentDashboardMenu: 'Parent Dashboard (Beta)',
+    parentDashboardMenu: 'Parent Dashboard',
     parentDashboardSubtitle: 'Last 4 weeks · tap ✕ to close',
     parentNoData: 'No sessions recorded yet. Play a few rounds first!',
     parentSessions: 'Sessions (4 weeks)',
@@ -269,6 +279,16 @@ export const translations: Record<Language, TranslationStrings> = {
     parentWeakTasksEmpty: 'No weak areas identified yet.',
     chartSessions: 'Sessions · 14 days',
     chartErrorRate: 'Error rate · 14 days',
+    parentEmptyTitle: "Let's get started!",
+    parentWeeklyReview: 'Weekly Review',
+    parentWeeklySessions: 'Sessions this week',
+    parentWeeklyVsLastWeek: 'vs. last week',
+    parentWeeklyMinutes: 'Practice time this week',
+    parentWeeklyMinutesUnit: 'min',
+    parentRowAccuracy: 'Accuracy by times table',
+    parentWeeklyRecommendation: "This week's practice tip",
+    parentRecommendationText: 'Practice the {row} times table (error rate {rate}%)',
+    parentRecommendationEmpty: 'No weak spot found — keep it up!',
     colorTheme: 'COLOR THEME',
     sounds: 'SOUNDS',
     soundsOn: 'On',
@@ -415,7 +435,7 @@ export const translations: Record<Language, TranslationStrings> = {
     ok: 'OK',
     // Parent Dashboard
     parentDashboard: 'Eltern-Dashboard',
-    parentDashboardMenu: 'Eltern-Dashboard (Beta)',
+    parentDashboardMenu: 'Eltern-Dashboard',
     parentDashboardSubtitle: 'Letzte 4 Wochen · ✕ zum Schließen',
     parentNoData: 'Noch keine Einheiten gespeichert. Spielt zuerst ein paar Runden!',
     parentSessions: 'Einheiten (4 Wochen)',
@@ -436,6 +456,16 @@ export const translations: Record<Language, TranslationStrings> = {
     parentWeakTasksEmpty: 'Noch keine Schwächen erkannt.',
     chartSessions: 'Einheiten · 14 Tage',
     chartErrorRate: 'Fehlerquote · 14 Tage',
+    parentEmptyTitle: "Los geht's!",
+    parentWeeklyReview: 'Wochenrückblick',
+    parentWeeklySessions: 'Einheiten diese Woche',
+    parentWeeklyVsLastWeek: 'vs. letzte Woche',
+    parentWeeklyMinutes: 'Übungszeit diese Woche',
+    parentWeeklyMinutesUnit: 'Min',
+    parentRowAccuracy: 'Genauigkeit pro Malreihe',
+    parentWeeklyRecommendation: 'Übungsempfehlung der Woche',
+    parentRecommendationText: 'Die {row}er-Reihe üben (Fehlerquote {rate}%)',
+    parentRecommendationEmpty: 'Keine Schwachstelle erkannt – weiter so!',
     colorTheme: 'FARBTHEMA',
     sounds: 'TÖNE',
     soundsOn: 'An',

--- a/types/game.ts
+++ b/types/game.ts
@@ -96,6 +96,8 @@ export interface SessionRecord {
   numberRange: NumberRange;
   // Challenge only: level 3 was reached with all lives intact (#253)
   challengeFlawlessLevel3?: boolean;
+  // Wall-clock time spent on the round; absent on sessions recorded before #277
+  durationMs?: number;
 }
 
 export interface AchievementBadge {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -319,7 +319,8 @@ function isValidSessionRecord(r: unknown): r is SessionRecord {
     typeof obj.difficultyMode === 'string' &&
     VALID_DIFFICULTY_MODES.has(obj.difficultyMode) &&
     typeof obj.numberRange === 'string' &&
-    VALID_NUMBER_RANGES.has(obj.numberRange)
+    VALID_NUMBER_RANGES.has(obj.numberRange) &&
+    (obj.durationMs === undefined || typeof obj.durationMs === 'number')
   );
 }
 


### PR DESCRIPTION
## Beschreibung

Setzt Punkt **1d** (Eltern-Dashboard aus der Beta führen) und **2d** (Empty States) aus Issue #277 um:

- **Wochenrückblick**-Sektion im Eltern-Dashboard: Einheiten diese Woche mit Trend-Pfeil vs. Vorwoche, Übungszeit diese Woche (neues optionales Feld `SessionRecord.durationMs`, das `useGameLogic` pro Runde erfasst; ältere Sessions ohne Dauer werden bei der Anzeige übersprungen statt falsche Werte zu zeigen)
- **Genauigkeit pro Malreihe** (1–10): kompakte Farbchips, aggregiert aus den vorhandenen `TaskStat`-Daten
- **Übungsempfehlung der Woche**: automatische Empfehlung der schwächsten Malreihe (analog zur bestehenden `getWeakTasks()`-Logik), mit freundlichem Fallback-Text wenn keine Schwachstelle erkannt wurde
- **"(Beta)"-Label entfernt** — Titel und Menüeintrag heißen jetzt schlicht "Eltern-Dashboard"
- **Freundlicher Empty-State**: Statt reinem Fließtext zeigt das Dashboard ohne Daten jetzt ein Emoji + Titel + Text

Bewusst nicht angefasst: der "Meister-Status aus 1a"-Punkt aus dem Issue, da die Lernreise/Malreihen-Meisterschaft (1a) noch nicht existiert. Das 3-Screen-Onboarding aus 2d war bereits vorhanden (`OnboardingModal`) und wurde nicht verändert.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reine React-Native-Komponenten- und State-Logik, keine `window.*`/Storage-Sonderfälle.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit`)
- [x] `npm test` — alle 16 Suiten / 516 Tests grün (inkl. neuer Tests für Wochenrückblick, Empfehlung, Empty-State)
- [x] `npm run format:check` grün
- [ ] Manuell auf Android/iOS getestet (nicht in dieser Umgebung möglich)

## Zusätzliche Notizen

`isValidSessionRecord` in `utils/storage.ts` akzeptiert `durationMs` optional, damit bereits gespeicherte Sessions ohne dieses Feld weiterhin gültig bleiben.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y34hibR6cFgEy2QNjbjbo9)_