### PR TITLE
fix: android:resizeableActivity="true" via Config-Plugin (Issue #275)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -7,5 +7,6 @@ module.exports = {
       ...base.expo.android,
       package: process.env.APP_PACKAGE || base.expo.android.package,
     },
+    plugins: [...base.expo.plugins, './plugins/withResizeableActivity'],
   },
 };

--- a/plugins/withResizeableActivity.js
+++ b/plugins/withResizeableActivity.js
@@ -1,0 +1,16 @@
+const { withAndroidManifest } = require('expo/config-plugins');
+
+// Play Store Warnung (Android 16, Issue #275): ohne resizeableActivity="true"
+// stuft der Play Store die App als größenänderungs-/orientierungsbeschränkt ein.
+// android/ wird per prebuild generiert (nicht versioniert) - der Fix muss daher
+// hier als Config-Plugin leben statt direkt im Manifest.
+module.exports = function withResizeableActivity(config) {
+  return withAndroidManifest(config, (config) => {
+    const application = config.modResults.manifest.application?.[0];
+    const activities = application?.activity ?? [];
+    for (const activity of activities) {
+      activity.$['android:resizeableActivity'] = 'true';
+    }
+    return config;
+  });
+};


### PR DESCRIPTION
## Beschreibung

Setzt Issue #275 um (Play-Store-Warnung 3 — Größenänderungs-/Ausrichtungsbeschränkungen, Android 16).

- `android/` wird nicht versioniert, sondern per `expo prebuild` generiert — daher kann `android:resizeableActivity="true"` nicht direkt im Manifest gepflegt werden
- Neues lokales Expo-Config-Plugin `plugins/withResizeableActivity.js` (nutzt `withAndroidManifest` aus `expo/config-plugins`) setzt das Attribut auf jeder `<activity>` im generierten Manifest
- In `app.config.js` an die bestehende Plugin-Liste angehängt
- `orientation` bleibt unverändert `"default"` (unspecified) — keine Rückkehr zu portrait

Damit sind beide offenen To-Dos aus dem Issue erledigt:
- [x] `android:resizeableActivity="true"` ergänzt
- [x] `orientation` bleibt `default`/unspecified
- [ ] Neubuild + AAB-Upload an den Play Store (manueller Release-Schritt, nicht Teil dieses PRs)

## Art der Änderung

- [x] Bugfix (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Ja — Android-Build-Konfiguration (Expo Config Plugin), kein Laufzeitcode. Kein Einfluss auf Web/iOS.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit`)
- [x] `npm test` — alle 16 Suiten / 516 Tests grün
- [x] `npm run format:check` grün
- [x] Verifiziert per `npx expo prebuild --platform android --clean`: generiertes `AndroidManifest.xml` enthält anschließend `android:screenOrientation="unspecified" android:resizeableActivity="true"` auf `MainActivity` (lokal getestet, `android/`-Ordner danach wieder entfernt, da gitignored)
- [ ] Play-Store-Warnung nach nächstem AAB-Upload manuell verifizieren

## Zusätzliche Notizen

Für den lokalen Prebuild-Test wurde vorübergehend eine Platzhalter-`google-services.json` angelegt (gitignored, nicht Teil dieses PRs) — ohne die Datei bricht `expo prebuild` an anderer Stelle ab (Firebase-Plugin-Kopierschritt), unabhängig von dieser Änderung.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y34hibR6cFgEy2QNjbjbo9)_