### PR TITLE
feat: Lernreise / Reihen-Meisterschaft mit Bronze/Silber/Gold (Issue #277 1a)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import { BadgesModal } from './components/BadgesModal';
 import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
 import { ProfilePickerModal } from './components/ProfilePickerModal';
+import { LernreiseModal } from './components/LernreiseModal';
 import {
   saveSessionRecord,
   getStreakData,
@@ -89,6 +90,7 @@ export default function App() {
   const [parentDashboardVisible, setParentDashboardVisible] = useState(false);
   const [badgesVisible, setBadgesVisible] = useState(false);
   const [profilePickerVisible, setProfilePickerVisible] = useState(false);
+  const [lernreiseVisible, setLernreiseVisible] = useState(false);
   const [streakData, setStreakData] = useState<StreakData>({
     currentStreak: 0,
     lastPlayedDate: '',
@@ -199,6 +201,7 @@ export default function App() {
     parentDashboardVisible ||
     badgesVisible ||
     profilePickerVisible ||
+    lernreiseVisible ||
     streakWarningVisible ||
     onboardingVisible ||
     game.gameState.showResult;
@@ -484,6 +487,7 @@ export default function App() {
             setProfilePickerVisible(true);
             hideMenu();
           }}
+          onOpenLernreise={() => setLernreiseVisible(true)}
           t={t}
         />
       )}
@@ -616,6 +620,14 @@ export default function App() {
         badgeIds={badgeSystem.newlyUnlocked}
         onDone={badgeSystem.clearNewlyUnlocked}
         badgeNewUnlockedLabel={t.badgeNewUnlocked}
+      />
+
+      <LernreiseModal
+        visible={lernreiseVisible}
+        onClose={() => setLernreiseVisible(false)}
+        colors={colors}
+        profileId={activeProfile?.id}
+        t={t}
       />
     </SafeAreaView>
   );

--- a/components/LernreiseModal.test.tsx
+++ b/components/LernreiseModal.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { LernreiseModal } from './LernreiseModal';
+import { getThemeColors } from '../utils/theme';
+import { RowMastery } from '../types/game';
+
+jest.mock('../utils/storage', () => ({
+  ...jest.requireActual('../utils/storage'),
+  getRowMastery: jest.fn(),
+  recordRowTestResult: jest.fn(),
+  recordTaskResult: jest.fn(),
+}));
+
+import { getRowMastery, recordRowTestResult } from '../utils/storage';
+const mockGetRowMastery = getRowMastery as jest.Mock;
+const mockRecordRowTestResult = recordRowTestResult as jest.Mock;
+
+const t = {
+  lernreiseTitle: 'Lernreise',
+  lernreiseSubtitle: 'Meistere jede Malreihe – Bronze, Silber, Gold',
+  lernreiseRowLabel: '{row}er-Reihe',
+  lernreiseResultScore: '{score}/10 richtig',
+  lernreiseResultGold: 'Gold! Perfekt gemeistert!',
+  lernreiseResultSilver: 'Silber! Toll gemacht!',
+  lernreiseResultBronze: 'Bronze! Gut gemacht!',
+  lernreiseResultRetry: 'Noch nicht ganz – versuch es nochmal!',
+  lernreiseBackToMap: 'Zurück zur Lernreise',
+  check: 'Prüfen',
+  nextQuestion: 'Weiter →',
+  ok: 'OK',
+};
+
+function emptyMastery(): RowMastery[] {
+  return Array.from({ length: 12 }, (_, i) => ({ row: i + 1, bestScore: 0, status: null }));
+}
+
+// Clicks the digit's Numpad button. When a digit is already echoed in the
+// answer box, getAllByText returns both; the Numpad button is always the
+// last DOM match since it renders after the question row.
+function clickDigit(getAllByText: (text: string) => HTMLElement[], digit: string) {
+  const matches = getAllByText(digit);
+  fireEvent.click(matches[matches.length - 1]);
+}
+
+describe('LernreiseModal', () => {
+  const colors = getThemeColors(false);
+
+  beforeEach(() => {
+    mockGetRowMastery.mockReset();
+    mockGetRowMastery.mockResolvedValue(emptyMastery());
+    mockRecordRowTestResult.mockReset();
+  });
+
+  it('shows the title and subtitle', async () => {
+    const { getByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      expect(getByText(t.lernreiseTitle)).toBeTruthy();
+      expect(getByText(t.lernreiseSubtitle)).toBeTruthy();
+    });
+  });
+
+  it('does not fetch mastery when not visible', () => {
+    render(<LernreiseModal visible={false} onClose={jest.fn()} colors={colors} t={t} />);
+    expect(mockGetRowMastery).not.toHaveBeenCalled();
+  });
+
+  it('shows row 1 as playable and row 2 as locked initially', async () => {
+    const { getByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(getByText('1er-Reihe')).toBeTruthy());
+    const row1Icon = getByText('1er-Reihe').parentElement!.firstChild as HTMLElement;
+    const row2Icon = getByText('2er-Reihe').parentElement!.firstChild as HTMLElement;
+    expect(row1Icon.textContent).toBe('▶');
+    expect(row2Icon.textContent).toBe('🔒');
+  });
+
+  it('shows the earned badge on an already-mastered row and unlocks the next one', async () => {
+    const mastery = emptyMastery();
+    mastery[0] = { row: 1, bestScore: 9, status: 'silver' };
+    mockGetRowMastery.mockResolvedValue(mastery);
+    const { getByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => {
+      const row1Icon = getByText('1er-Reihe').parentElement!.firstChild as HTMLElement;
+      expect(row1Icon.textContent).toBe('🥈');
+    });
+    // row 2 is now unlocked (row 1 has a status) → playable icon, no lock
+    const row2Icon = getByText('2er-Reihe').parentElement!.firstChild as HTMLElement;
+    expect(row2Icon.textContent).toBe('▶');
+  });
+
+  it('tapping a locked row does not start a test', async () => {
+    const { getByText, queryByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(getByText('2er-Reihe')).toBeTruthy());
+    fireEvent.click(getByText('2er-Reihe'));
+    expect(queryByText(t.check)).toBeNull();
+  });
+
+  it('tapping an unlocked row starts the test view', async () => {
+    const { getByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(getByText('1er-Reihe')).toBeTruthy());
+    fireEvent.click(getByText('1er-Reihe'));
+    expect(getByText(t.check)).toBeTruthy();
+  });
+
+  it('completes a perfect row test, awards gold, and unlocks the next row', async () => {
+    mockRecordRowTestResult.mockImplementation(async (row: number, score: number) => {
+      const result = emptyMastery();
+      result[row - 1] = { row, bestScore: score, status: 'gold' };
+      return result;
+    });
+
+    const { getByText, getAllByText } = render(
+      <LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    await waitFor(() => expect(getByText('1er-Reihe')).toBeTruthy());
+    fireEvent.click(getByText('1er-Reihe'));
+
+    for (let i = 0; i < 10; i++) {
+      const equation = getAllByText(/^1 × \d+ =$/)[0].textContent!;
+      const factor = parseInt(equation.match(/× (\d+) =/)![1], 10);
+      for (const digit of (1 * factor).toString()) {
+        clickDigit(getAllByText, digit);
+      }
+      fireEvent.click(getByText(t.check));
+      fireEvent.click(getByText(t.nextQuestion));
+    }
+
+    await waitFor(() => {
+      expect(getByText('10/10 richtig')).toBeTruthy();
+      expect(getByText(t.lernreiseResultGold)).toBeTruthy();
+    });
+    expect(mockRecordRowTestResult).toHaveBeenCalledWith(1, 10, 10, undefined);
+
+    fireEvent.click(getByText(t.lernreiseBackToMap));
+    await waitFor(() => {
+      expect(getByText('🥇')).toBeTruthy();
+      expect(getByText('▶')).toBeTruthy(); // row 2 unlocked
+    });
+  });
+
+  it('passes profileId through to storage calls', async () => {
+    render(<LernreiseModal visible onClose={jest.fn()} colors={colors} t={t} profileId="abc" />);
+    await waitFor(() => expect(mockGetRowMastery).toHaveBeenCalledWith('abc'));
+  });
+});

--- a/components/LernreiseModal.tsx
+++ b/components/LernreiseModal.tsx
@@ -1,0 +1,366 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, Modal, ScrollView } from 'react-native';
+import { ThemeColors, Operation, RowMastery, RowMasteryStatus } from '../types/game';
+import { TOTAL_TASKS, DESIGN_TOKENS } from '../utils/constants';
+import {
+  getRowMastery,
+  isRowUnlocked,
+  recordRowTestResult,
+  recordTaskResult,
+  statusForRowScore,
+} from '../utils/storage';
+import { modalStyles } from '../styles/modalStyles';
+import { Numpad } from './Numpad';
+import { ProgressBar } from './ProgressBar';
+
+interface LernreiseModalProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  profileId?: string;
+  t: {
+    lernreiseTitle: string;
+    lernreiseSubtitle: string;
+    lernreiseRowLabel: string;
+    lernreiseResultScore: string;
+    lernreiseResultGold: string;
+    lernreiseResultSilver: string;
+    lernreiseResultBronze: string;
+    lernreiseResultRetry: string;
+    lernreiseBackToMap: string;
+    check: string;
+    nextQuestion: string;
+    ok: string;
+  };
+}
+
+type ViewState = 'map' | 'test' | 'result';
+
+const STATUS_EMOJI: Record<RowMasteryStatus, string> = {
+  bronze: '🥉',
+  silver: '🥈',
+  gold: '🥇',
+};
+
+function shuffledFactors(): number[] {
+  const factors = Array.from({ length: 10 }, (_, i) => i + 1);
+  for (let i = factors.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [factors[i], factors[j]] = [factors[j], factors[i]];
+  }
+  return factors;
+}
+
+export function LernreiseModal({ visible, onClose, colors, profileId, t }: LernreiseModalProps) {
+  const [mastery, setMastery] = useState<RowMastery[]>([]);
+  const [view, setView] = useState<ViewState>('map');
+  const [activeRow, setActiveRow] = useState<number | null>(null);
+  const [factors, setFactors] = useState<number[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [userAnswer, setUserAnswer] = useState('');
+  const [isAnswerChecked, setIsAnswerChecked] = useState(false);
+  const [score, setScore] = useState(0);
+  const [answerHistory, setAnswerHistory] = useState<(boolean | null)[]>([]);
+
+  useEffect(() => {
+    if (visible) {
+      getRowMastery(profileId).then(setMastery);
+      setView('map');
+    }
+  }, [visible, profileId]);
+
+  const startTest = (row: number) => {
+    setActiveRow(row);
+    setFactors(shuffledFactors());
+    setCurrentIndex(0);
+    setUserAnswer('');
+    setIsAnswerChecked(false);
+    setScore(0);
+    setAnswerHistory(Array(TOTAL_TASKS).fill(null));
+    setView('test');
+  };
+
+  const handleNumberClick = (num: number) => {
+    if (isAnswerChecked) return;
+    if (num === -1) {
+      setUserAnswer((prev) => prev.slice(0, -1));
+    } else {
+      setUserAnswer((prev) => prev + num.toString());
+    }
+  };
+
+  const handleCheck = () => {
+    if (userAnswer === '' || activeRow === null) return;
+    const num2 = factors[currentIndex];
+    const isCorrect = parseInt(userAnswer, 10) === activeRow * num2;
+    recordTaskResult(activeRow, num2, Operation.MULTIPLICATION, isCorrect, profileId);
+    setScore((prev) => (isCorrect ? prev + 1 : prev));
+    setIsAnswerChecked(true);
+    setAnswerHistory((prev) => {
+      const next = [...prev];
+      next[currentIndex] = isCorrect;
+      return next;
+    });
+  };
+
+  const handleNext = () => {
+    if (activeRow === null) return;
+    if (currentIndex + 1 >= TOTAL_TASKS) {
+      recordRowTestResult(activeRow, score, TOTAL_TASKS, profileId).then((updated) => {
+        setMastery(updated);
+        setView('result');
+      });
+      return;
+    }
+    setCurrentIndex((prev) => prev + 1);
+    setUserAnswer('');
+    setIsAnswerChecked(false);
+  };
+
+  const roundStatus = view === 'result' ? statusForRowScore(score, TOTAL_TASKS) : null;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View style={[styles.container, { backgroundColor: colors.settingsMenu }]}>
+          <View style={styles.header}>
+            <View>
+              <Text style={[styles.title, { color: colors.text }]}>{t.lernreiseTitle}</Text>
+              <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+                {t.lernreiseSubtitle}
+              </Text>
+            </View>
+            <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+              <Text style={[styles.closeText, { color: colors.text }]}>✕</Text>
+            </TouchableOpacity>
+          </View>
+
+          {view === 'map' && (
+            <ScrollView style={styles.mapScroll} showsVerticalScrollIndicator={false}>
+              <View style={styles.mapGrid}>
+                {mastery.map((m) => {
+                  const unlocked = isRowUnlocked(mastery, m.row);
+                  const icon = !unlocked ? '🔒' : m.status ? STATUS_EMOJI[m.status] : '▶';
+                  return (
+                    <TouchableOpacity
+                      key={m.row}
+                      disabled={!unlocked}
+                      onPress={() => startTest(m.row)}
+                      style={[
+                        styles.rowNode,
+                        { borderColor: colors.border, backgroundColor: colors.card },
+                        !unlocked && styles.rowNodeLocked,
+                      ]}
+                    >
+                      <Text style={styles.rowNodeIcon}>{icon}</Text>
+                      <Text
+                        style={[
+                          styles.rowNodeLabel,
+                          { color: unlocked ? colors.text : colors.textSecondary },
+                        ]}
+                      >
+                        {t.lernreiseRowLabel.replace('{row}', m.row.toString())}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </ScrollView>
+          )}
+
+          {view === 'test' && activeRow !== null && (
+            <View style={styles.testContainer}>
+              <Text style={[styles.testRowLabel, { color: colors.textSecondary }]}>
+                {t.lernreiseRowLabel.replace('{row}', activeRow.toString())}
+              </Text>
+              <ProgressBar history={answerHistory} />
+              <View style={styles.questionRow}>
+                <Text style={[styles.questionText, { color: colors.text }]}>
+                  {activeRow} × {factors[currentIndex]} =
+                </Text>
+                <View style={[styles.answerBox, { backgroundColor: colors.buttonInactive }]}>
+                  <Text style={[styles.answerText, { color: colors.text }]}>
+                    {userAnswer || '?'}
+                  </Text>
+                </View>
+              </View>
+              <Numpad
+                onNumberClick={handleNumberClick}
+                onCheck={isAnswerChecked ? handleNext : handleCheck}
+                userAnswer={userAnswer}
+                isAnswerChecked={isAnswerChecked}
+                checkLabel={t.check}
+                nextLabel={t.nextQuestion}
+                gradientPrimary={colors.gradientPrimary}
+              />
+            </View>
+          )}
+
+          {view === 'result' && (
+            <View style={styles.resultContainer}>
+              <Text style={styles.resultEmoji}>
+                {roundStatus ? STATUS_EMOJI[roundStatus] : '💪'}
+              </Text>
+              <Text style={[styles.resultScore, { color: colors.text }]}>
+                {t.lernreiseResultScore.replace('{score}', score.toString())}
+              </Text>
+              <Text style={[styles.resultMessage, { color: colors.textSecondary }]}>
+                {roundStatus === 'gold'
+                  ? t.lernreiseResultGold
+                  : roundStatus === 'silver'
+                    ? t.lernreiseResultSilver
+                    : roundStatus === 'bronze'
+                      ? t.lernreiseResultBronze
+                      : t.lernreiseResultRetry}
+              </Text>
+              <TouchableOpacity
+                style={[styles.closeBtn, { backgroundColor: colors.gradientPrimary[0] }]}
+                onPress={() => setView('map')}
+              >
+                <Text style={styles.closeBtnText}>{t.lernreiseBackToMap}</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {view === 'map' && (
+            <TouchableOpacity
+              style={[styles.closeBtn, { backgroundColor: colors.gradientPrimary[0] }]}
+              onPress={onClose}
+            >
+              <Text style={styles.closeBtnText}>{t.ok}</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 24,
+    padding: 20,
+    width: '90%',
+    maxWidth: 420,
+    maxHeight: '88%',
+    elevation: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.15,
+    shadowRadius: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 14,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  subtitle: {
+    fontSize: 11,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    marginTop: 2,
+  },
+  closeButton: {
+    padding: 6,
+    minWidth: 36,
+    minHeight: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeText: {
+    fontSize: 18,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  mapScroll: {
+    maxHeight: 440,
+    marginBottom: 12,
+  },
+  mapGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  rowNode: {
+    width: '31%',
+    borderWidth: 1.5,
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+    gap: 4,
+  },
+  rowNodeLocked: {
+    opacity: 0.5,
+  },
+  rowNodeIcon: {
+    fontSize: 24,
+  },
+  rowNodeLabel: {
+    fontSize: 12,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+  testContainer: {
+    alignItems: 'center',
+    gap: 16,
+    marginBottom: 12,
+  },
+  testRowLabel: {
+    fontSize: 13,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  questionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  questionText: {
+    fontSize: 32,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+  },
+  answerBox: {
+    minWidth: 72,
+    height: 52,
+    borderRadius: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+  },
+  answerText: {
+    fontSize: 26,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+  },
+  resultContainer: {
+    alignItems: 'center',
+    gap: 8,
+    marginVertical: 24,
+  },
+  resultEmoji: {
+    fontSize: 56,
+  },
+  resultScore: {
+    fontSize: 20,
+    fontFamily: DESIGN_TOKENS.FONT_NUMBER,
+  },
+  resultMessage: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  closeBtn: {
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  closeBtnText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/components/SettingsMenu.tsx
+++ b/components/SettingsMenu.tsx
@@ -35,6 +35,7 @@ interface SettingsMenuProps {
   onResetOnboarding: () => void;
   onOpenBadges: () => void;
   onOpenProfiles: () => void;
+  onOpenLernreise: () => void;
   // Translations
   t: {
     operation: string;
@@ -61,6 +62,7 @@ interface SettingsMenuProps {
     parentDashboardMenu: string;
     badgesMenu: string;
     profilesMenu: string;
+    lernreiseMenu: string;
     feedback: string;
     support: string;
     about: string;
@@ -87,6 +89,7 @@ export function SettingsMenu({
   onResetOnboarding,
   onOpenBadges,
   onOpenProfiles,
+  onOpenLernreise,
   t,
 }: SettingsMenuProps) {
   const buttonBg = colors.buttonInactive;
@@ -164,6 +167,17 @@ export function SettingsMenu({
             >
               <Text style={[styles.personalizeButtonText, { color: activeColor }]}>
                 {t.profilesMenu}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.personalizeButton, { borderColor: activeColor }]}
+              onPress={() => {
+                onOpenLernreise();
+                onHideMenu();
+              }}
+            >
+              <Text style={[styles.personalizeButtonText, { color: activeColor }]}>
+                {t.lernreiseMenu}
               </Text>
             </TouchableOpacity>
           </View>

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -178,6 +178,17 @@ export interface TranslationStrings {
   onboardingStart: string;
   onboardingSkip: string;
   resetOnboarding: string;
+  // Lernreise / Reihen-Meisterschaft
+  lernreiseMenu: string;
+  lernreiseTitle: string;
+  lernreiseSubtitle: string;
+  lernreiseRowLabel: string;
+  lernreiseResultScore: string;
+  lernreiseResultGold: string;
+  lernreiseResultSilver: string;
+  lernreiseResultBronze: string;
+  lernreiseResultRetry: string;
+  lernreiseBackToMap: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -344,6 +355,17 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingStart: 'Start',
     onboardingSkip: 'Skip',
     resetOnboarding: 'Restart tutorial',
+    // Lernreise / Times-Table Mastery
+    lernreiseMenu: 'Learning Journey',
+    lernreiseTitle: 'Learning Journey',
+    lernreiseSubtitle: 'Master every times table — Bronze, Silver, Gold',
+    lernreiseRowLabel: '{row} Times Table',
+    lernreiseResultScore: '{score}/10 correct',
+    lernreiseResultGold: 'Gold! Perfectly mastered!',
+    lernreiseResultSilver: 'Silver! Great job!',
+    lernreiseResultBronze: 'Bronze! Well done!',
+    lernreiseResultRetry: 'Not quite yet — give it another try!',
+    lernreiseBackToMap: 'Back to Learning Journey',
     // Profiles
     profiles: 'Profiles',
     profilesMenu: 'Profiles',
@@ -521,6 +543,17 @@ export const translations: Record<Language, TranslationStrings> = {
     onboardingStart: 'Loslegen',
     onboardingSkip: 'Überspringen',
     resetOnboarding: 'Tutorial zurücksetzen',
+    // Lernreise / Reihen-Meisterschaft
+    lernreiseMenu: 'Lernreise',
+    lernreiseTitle: 'Lernreise',
+    lernreiseSubtitle: 'Meistere jede Malreihe – Bronze, Silber, Gold',
+    lernreiseRowLabel: '{row}er-Reihe',
+    lernreiseResultScore: '{score}/10 richtig',
+    lernreiseResultGold: 'Gold! Perfekt gemeistert!',
+    lernreiseResultSilver: 'Silber! Toll gemacht!',
+    lernreiseResultBronze: 'Bronze! Gut gemacht!',
+    lernreiseResultRetry: 'Noch nicht ganz – versuch es nochmal!',
+    lernreiseBackToMap: 'Zurück zur Lernreise',
     // Profiles
     profiles: 'Profile',
     profilesMenu: 'Profile',

--- a/types/game.ts
+++ b/types/game.ts
@@ -84,6 +84,15 @@ export interface TaskStat {
   lastSeen: string; // ISO date
 }
 
+// Lernreise / Reihen-Meisterschaft (Issue #277 1a)
+export type RowMasteryStatus = 'bronze' | 'silver' | 'gold';
+
+export interface RowMastery {
+  row: number;
+  bestScore: number;
+  status: RowMasteryStatus | null;
+}
+
 export interface SessionRecord {
   id: string;
   timestamp: number;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -32,7 +32,11 @@ export const STORAGE_KEYS = {
   SOUNDS_VOLUME: 'app-sounds-volume',
   PROFILES: 'app-profiles',
   ACTIVE_PROFILE_ID: 'app-active-profile-id',
+  ROW_MASTERY: 'app-row-mastery',
 } as const;
+
+// Lernreise / Reihen-Meisterschaft (Issue #277 1a): one node per times table
+export const LERNREISE_ROW_COUNT = 12;
 
 export const AVATAR_COLORS = [
   '#FF6B6B',

--- a/utils/storage.test.ts
+++ b/utils/storage.test.ts
@@ -34,6 +34,11 @@ import {
   saveTaskStats,
   recordTaskResult,
   getWeakTasks,
+  getRowMastery,
+  saveRowMastery,
+  recordRowTestResult,
+  isRowUnlocked,
+  statusForRowScore,
 } from './storage';
 import {
   Operation,
@@ -44,6 +49,7 @@ import {
   SessionRecord,
   StreakData,
   TaskStat,
+  RowMastery,
 } from '../types/game';
 
 // Mock react-native Platform
@@ -749,6 +755,131 @@ describe('getWeakTasks', () => {
     const stats = [makeStat(7, 8, 1, 1)];
     expect(getWeakTasks(stats, 2, 0.4)).toHaveLength(1);
     expect(getWeakTasks(stats, 3, 0.4)).toHaveLength(0);
+  });
+});
+
+describe('statusForRowScore', () => {
+  it('returns gold for a perfect score', () => {
+    expect(statusForRowScore(10, 10)).toBe('gold');
+  });
+
+  it('returns silver for >= 80%', () => {
+    expect(statusForRowScore(8, 10)).toBe('silver');
+  });
+
+  it('returns bronze for >= 60%', () => {
+    expect(statusForRowScore(6, 10)).toBe('bronze');
+  });
+
+  it('returns null below the bronze threshold', () => {
+    expect(statusForRowScore(5, 10)).toBeNull();
+  });
+
+  it('returns null when total is zero', () => {
+    expect(statusForRowScore(0, 0)).toBeNull();
+  });
+});
+
+describe('isRowUnlocked', () => {
+  const mastery = (overrides: Partial<Record<number, RowMastery['status']>>): RowMastery[] =>
+    Array.from({ length: 12 }, (_, i) => ({
+      row: i + 1,
+      bestScore: 0,
+      status: overrides[i + 1] ?? null,
+    }));
+
+  it('row 1 is always unlocked', () => {
+    expect(isRowUnlocked(mastery({}), 1)).toBe(true);
+  });
+
+  it('row N is locked when row N-1 has no status yet', () => {
+    expect(isRowUnlocked(mastery({}), 2)).toBe(false);
+  });
+
+  it('row N unlocks once row N-1 has any status', () => {
+    expect(isRowUnlocked(mastery({ 1: 'bronze' }), 2)).toBe(true);
+  });
+});
+
+describe('Row Mastery Storage', () => {
+  let mockStore: { [key: string]: string };
+
+  beforeEach(() => {
+    mockStore = {};
+    jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation((key: string) => mockStore[key] || null);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation((key: string, value: string) => {
+      mockStore[key] = value;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 12 empty rows when nothing stored', async () => {
+    const result = await getRowMastery();
+    expect(result).toHaveLength(12);
+    expect(result.every((m) => m.status === null && m.bestScore === 0)).toBe(true);
+  });
+
+  it('returns empty rows for corrupted JSON', async () => {
+    mockStore['app-row-mastery'] = '{invalid}';
+    const result = await getRowMastery();
+    expect(result).toHaveLength(12);
+  });
+
+  it('fills in missing rows from partial/corrupt stored data', async () => {
+    mockStore['app-row-mastery'] = JSON.stringify([{ row: 3, bestScore: 9, status: 'silver' }]);
+    const result = await getRowMastery();
+    expect(result).toHaveLength(12);
+    expect(result.find((m) => m.row === 3)).toEqual({ row: 3, bestScore: 9, status: 'silver' });
+    expect(result.find((m) => m.row === 1)).toEqual({ row: 1, bestScore: 0, status: null });
+  });
+
+  it('saves and retrieves row mastery', async () => {
+    const mastery = await getRowMastery();
+    mastery[0].status = 'gold';
+    mastery[0].bestScore = 10;
+    await saveRowMastery(mastery);
+    const result = await getRowMastery();
+    expect(result[0]).toEqual({ row: 1, bestScore: 10, status: 'gold' });
+  });
+
+  it('recordRowTestResult sets status on first pass', async () => {
+    const result = await recordRowTestResult(4, 8, 10);
+    const row4 = result.find((m) => m.row === 4)!;
+    expect(row4.status).toBe('silver');
+    expect(row4.bestScore).toBe(8);
+  });
+
+  it('recordRowTestResult never downgrades an existing status', async () => {
+    await recordRowTestResult(4, 10, 10); // gold
+    const result = await recordRowTestResult(4, 6, 10); // bronze-level attempt
+    const row4 = result.find((m) => m.row === 4)!;
+    expect(row4.status).toBe('gold');
+    expect(row4.bestScore).toBe(10);
+  });
+
+  it('recordRowTestResult keeps the best score even if status does not improve', async () => {
+    await recordRowTestResult(4, 6, 10);
+    const result = await recordRowTestResult(4, 7, 10);
+    const row4 = result.find((m) => m.row === 4)!;
+    expect(row4.bestScore).toBe(7);
+    expect(row4.status).toBe('bronze');
+  });
+
+  it('a failed attempt does not unlock the next row', async () => {
+    await recordRowTestResult(1, 3, 10);
+    const result = await getRowMastery();
+    expect(isRowUnlocked(result, 2)).toBe(false);
+  });
+
+  it('a passed attempt unlocks the next row', async () => {
+    await recordRowTestResult(1, 6, 10);
+    const result = await getRowMastery();
+    expect(isRowUnlocked(result, 2)).toBe(true);
   });
 });
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -5,7 +5,7 @@
 
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { STORAGE_KEYS, AVATAR_COLORS } from './constants';
+import { STORAGE_KEYS, AVATAR_COLORS, LERNREISE_ROW_COUNT } from './constants';
 import {
   ThemeMode,
   ThemeName,
@@ -17,6 +17,8 @@ import {
   TaskStat,
   StreakData,
   ChildProfile,
+  RowMastery,
+  RowMasteryStatus,
 } from '../types/game';
 
 /**
@@ -449,6 +451,89 @@ export const getWeakTasks = (
       const rateB = b.errorCount / (b.correctCount + b.errorCount);
       return rateB - rateA;
     });
+};
+
+// Lernreise / Reihen-Meisterschaft (Issue #277 1a)
+const VALID_ROW_MASTERY_STATUSES = new Set<string>(['bronze', 'silver', 'gold']);
+
+function isValidRowMastery(r: unknown): r is RowMastery {
+  if (!r || typeof r !== 'object') return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.row === 'number' &&
+    obj.row >= 1 &&
+    obj.row <= LERNREISE_ROW_COUNT &&
+    typeof obj.bestScore === 'number' &&
+    (obj.status === null ||
+      (typeof obj.status === 'string' && VALID_ROW_MASTERY_STATUSES.has(obj.status)))
+  );
+}
+
+function emptyRowMastery(): RowMastery[] {
+  return Array.from({ length: LERNREISE_ROW_COUNT }, (_, i) => ({
+    row: i + 1,
+    bestScore: 0,
+    status: null,
+  }));
+}
+
+export const getRowMastery = async (profileId?: string): Promise<RowMastery[]> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.ROW_MASTERY, profileId));
+  if (!value) return emptyRowMastery();
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return emptyRowMastery();
+    const byRow = new Map(parsed.filter(isValidRowMastery).map((m) => [m.row, m]));
+    return Array.from(
+      { length: LERNREISE_ROW_COUNT },
+      (_, i) => byRow.get(i + 1) ?? { row: i + 1, bestScore: 0, status: null }
+    );
+  } catch {
+    return emptyRowMastery();
+  }
+};
+
+export const saveRowMastery = async (mastery: RowMastery[], profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.ROW_MASTERY, profileId), JSON.stringify(mastery));
+};
+
+const ROW_MASTERY_RANK: Record<RowMasteryStatus, number> = { bronze: 1, silver: 2, gold: 3 };
+
+export function statusForRowScore(score: number, total: number): RowMasteryStatus | null {
+  if (total <= 0) return null;
+  const rate = score / total;
+  if (rate === 1) return 'gold';
+  if (rate >= 0.8) return 'silver';
+  if (rate >= 0.6) return 'bronze';
+  return null;
+}
+
+// A row unlocks once the previous row has been passed at least once (any status).
+// Row 1 is always unlocked.
+export function isRowUnlocked(mastery: RowMastery[], row: number): boolean {
+  if (row <= 1) return true;
+  const previous = mastery.find((m) => m.row === row - 1);
+  return previous?.status != null;
+}
+
+export const recordRowTestResult = async (
+  row: number,
+  score: number,
+  total: number,
+  profileId?: string
+): Promise<RowMastery[]> => {
+  const mastery = await getRowMastery(profileId);
+  const achievedStatus = statusForRowScore(score, total);
+  const updated = mastery.map((m) => {
+    if (m.row !== row) return m;
+    const bestScore = Math.max(m.bestScore, score);
+    const currentRank = m.status ? ROW_MASTERY_RANK[m.status] : 0;
+    const achievedRank = achievedStatus ? ROW_MASTERY_RANK[achievedStatus] : 0;
+    const status = achievedRank > currentRank ? achievedStatus : m.status;
+    return { ...m, bestScore, status };
+  });
+  await saveRowMastery(updated, profileId);
+  return updated;
 };
 
 // Badge storage – maps badgeId → unlock timestamp


### PR DESCRIPTION
## Beschreibung

Setzt 1a aus Issue #277 um (volle Variante inkl. Lernreise-Pfad, wie in der Rückfrage zum Scope entschieden): ein neuer Einstiegspunkt **"Lernreise"** im Einstellungsmenü.

- **Landkarte** mit 12 Knoten (1er- bis 12er-Reihe). Reihe 1 ist immer offen; jede weitere Reihe schaltet sich frei, sobald die vorherige mindestens einmal **bestanden** wurde
- **Abschlusstest pro Reihe**: 10 Aufgaben derselben Malreihe (Faktoren 1–10 gemischt), UI wiederverwendet die bestehenden `Numpad`- und `ProgressBar`-Komponenten für Konsistenz mit dem Hauptspiel
- **Meister-Status Bronze/Silber/Gold** je nach Testergebnis: Gold = 10/10, Silber ≥ 8/10, Bronze ≥ 6/10, sonst kein Status (Reihe bleibt/wird nicht freigeschaltet)
- Jede Testantwort läuft ganz normal über `recordTaskResult()` in die bestehende `TaskStat`-Infrastruktur ein → Übungsmodus und Eltern-Dashboard (Genauigkeit pro Malreihe, Wochenrückblick aus #279) profitieren automatisch mit
- Neuer Storage-Key `app-row-mastery`, per Profil getrennt (bestehendes Suffix-Pattern)

### Design-Entscheidung
Der Status (Bronze/Silber/Gold) wird bewusst pro Testversuch vergeben (nicht aus der langfristig kumulierten `TaskStat`-Fehlerquote berechnet) — das macht das Freischalten der nächsten Reihe nachvollziehbar ("bestanden oder nicht") statt von organischem Übungsverhalten außerhalb der Lernreise abhängig zu sein. Ein bereits erreichter Status kann durch einen schwächeren späteren Versuch nicht wieder verloren gehen.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein — reine React-Native-Komponenten- und Storage-Logik.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit`)
- [x] `npm test` — alle 17 Suiten / 541 Tests grün (neue Tests für `RowMastery`-Storage-Funktionen und `LernreiseModal`, inkl. vollständigem Testdurchlauf mit Freischaltung der nächsten Reihe)
- [x] `npm run format:check` grün
- [ ] Manuell auf Android/iOS getestet (nicht in dieser Umgebung möglich)

## Zusätzliche Notizen

Bewusst nicht Teil dieses PRs (siehe Issue #277 1a): das perspektivische Ersetzen/Bündeln des separaten Übungsmodus (PRACTICE) — das bleibt ein eigener, späterer Schritt.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y34hibR6cFgEy2QNjbjbo9)_