### PR TITLE
chore: project-templates sync (GLOBAL POLICY + commands)

### DIFF
--- a/.claude/commands/aufräumen.md
+++ b/.claude/commands/aufräumen.md
@@ -2,59 +2,78 @@
 
 Führe den täglichen Cleanup-Workflow durch:
 
-## 1. Repository Status prüfen
+## 0. Branch-Übersicht: testing vs. main (alle Repos)
 
+Erstelle zu Beginn eine Tabelle aller Repositories mit dem Stand von `testing` gegenüber `main`:
+
+```bash
+for repo in Eisenhauer 1x1_Trainer DrawFromMemory EnergyPriceGermany Pflanzkalender safe_my_plants CD-to-Spotify-PWA project-templates; do
+  dir="/Users/svenstrohkark/Documents/Programmierung/Projects/$repo"
+  if [ -d "$dir/.git" ]; then
+    cd "$dir"
+    git fetch --all --prune -q 2>/dev/null
+    ab=$(git rev-list --left-right --count origin/main...origin/testing 2>/dev/null)
+    main_ahead=$(echo $ab | awk '{print $1}')
+    test_ahead=$(echo $ab | awk '{print $2}')
+    echo "$repo | testing +$test_ahead | main +$main_ahead"
+  fi
+done
+```
+
+Zeige das Ergebnis als Markdown-Tabelle:
+
+| Projekt | testing ahead | main ahead | Status |
+|---|---|---|---|
+| ... | ... | ... | ✅ OK / ⚠️ Divergiert / 🔴 main voraus |
+
+**Statusregeln:**
+- ✅ OK — main_ahead = 0 (testing enthält main vollständig)
+- ⚠️ Leicht divergiert — main_ahead ≤ 3 und nur Auto-Commits (z.B. marketdata)
+- 🔴 main voraus — main_ahead > 0 mit echten Commits → Sync-PR nötig
+
+## 1. Repository Status prüfen
 - Prüfe `git status` für uncommitted changes
 - Liste alle lokalen Branches
 - Prüfe ob lokaler main Branch mit origin synchron ist
 
 ## 2. Branches aufräumen
-
 - Liste alle merged Feature Branches (lokal und remote)
 - Frage ob diese gelöscht werden sollen
 - Lösche approved Branches
 
 ## 3. GitHub Actions Status
-
 - Liste letzte 5 Workflow Runs (Deploy, Tests, etc.)
 - Zeige Failed Runs falls vorhanden
 - Prüfe wichtige automatisierte Workflows
 
 ## 4. Open Pull Requests
-
 - Liste alle offenen PRs
 - Zeige Status (Approved? Mergeable? CI passing?)
 - Weise auf alte PRs hin (>7 Tage)
 
 ## 5. Issues Management
-
 - Liste Issues mit "Priority" oder "Bug" Label
 - Zeige kürzlich geschlossene Issues (heute)
 - Weise auf Issues ohne Label hin
 
 ## 6. Dependencies & Security
-
 - Prüfe ob `package.json` Updates braucht (via npm outdated)
 - Prüfe auf Security Vulnerabilities (npm audit)
 - Zeige Warnungen falls vorhanden
 
 ## 7. Data Status (falls relevant)
-
 - Prüfe letzte Aktualisierung von kritischen Daten-Files
 - Zeige ob Daten aktuell sind
 - Manuelles Update anbieten falls nötig
 
 ## 8. Sync & Push
-
 - Zeige alle lokalen Commits, die noch nicht gepusht sind (`git log @{u}..HEAD`)
 - **Frage vor Push:** "Soll ich diese Commits jetzt pushen?" — nie automatisch pushen
 - Falls Ja: pushe und hole neueste Änderungen von origin
 - Zeige finale Status-Zusammenfassung
 
 ## 9. Zusammenfassung
-
 Erstelle eine kurze Zusammenfassung:
-
 - Anzahl gelöschter Branches
 - Anzahl gepushter Commits
 - Status der Environments (Production, Staging)

--- a/.claude/commands/cache-clean.md
+++ b/.claude/commands/cache-clean.md
@@ -1,0 +1,44 @@
+# Lokaler Cache-Cleanup
+
+Führe den lokalen Cache-Cleanup für alle Projekte aus (Festplattenplatz freigeben).
+
+Dies ist ein manueller, seltener Eingriff (kein automatischer Cron) — nur auf
+explizite Anfrage ausführen.
+
+## 1. Report erzeugen (Dry-Run)
+
+Führe im project-templates-Verzeichnis aus:
+
+```bash
+cd "$(find ~/Documents -maxdepth 4 -type d -name project-templates 2>/dev/null | head -1)"
+./scripts/clean-local-cache.sh --dry-run
+```
+
+Zeige das Ergebnis (Größen pro Projekt, geplante Löschungen) als Übersicht.
+
+## 2. Rückfrage
+
+Frage explizit: "Sollen diese Caches gelöscht werden? (node_modules, dist,
+build, .expo, android/.gradle, android/app/build)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes
+```
+
+## 3. Optional: globale Caches
+
+Frage separat: "Auch globale Caches leeren? (~/.gradle/caches ~9GB, ~/.npm
+~900MB — betrifft alle Gradle-/Node-Projekte gemeinsam)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes --global
+```
+
+## 4. Hinweis nach dem Löschen
+
+Erinnere daran, dass beim nächsten Start des jeweiligen Projekts
+`npm install` (und ggf. `npx expo prebuild` / Gradle-Sync) nötig ist.

--- a/.claude/commands/dependency-update.md
+++ b/.claude/commands/dependency-update.md
@@ -4,13 +4,11 @@ Sichere Aktualisierung von Dependencies mit Security-Checks.
 Paketmanager: npm (Standard), yarn oder pnpm – Befehle ggf. anpassen.
 
 ## Ziel
-
 Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes prüfen
 
 ## Workflow
 
 ### 1. Aktuellen Status analysieren
-
 - Zeige `npm outdated` Output
 - Gruppiere Updates nach Typ:
   - **Patch Updates** (1.2.3 → 1.2.4) - Bugfixes, sicher
@@ -20,7 +18,6 @@ Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes pr�
 - Priorisiere Security-relevante Updates
 
 ### 2. Security Vulnerabilities fixen (PRIORITÄT!)
-
 - Zeige alle Vulnerabilities mit Severity (Critical, High, Medium, Low)
 - Für jede Vulnerability:
   - Zeige betroffenes Package
@@ -29,7 +26,6 @@ Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes pr�
   - Falls Breaking Change: Manuell fixen mit `npm install package@version`
 
 ### 3. Patch & Minor Updates (meist sicher)
-
 - Frage: "Alle Patch/Minor Updates installieren? (empfohlen)"
 - Falls Ja:
   ```bash
@@ -38,7 +34,6 @@ Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes pr�
 - Falls Nein: Gehe durch einzelne Packages und frage jeweils
 
 ### 4. Major Updates (Breaking Changes möglich)
-
 - Für jedes Major Update:
   - Zeige Package-Name, alte Version, neue Version
   - Suche nach CHANGELOG oder Breaking Changes:
@@ -49,9 +44,7 @@ Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes pr�
   - Falls Ja: `npm install package@latest`
 
 ### 5. Dependencies Test-Run
-
 Nach jedem Update-Batch:
-
 - Führe `npm install` aus (um lock-file zu aktualisieren)
 - Führe Tests aus: `npm run test`
 - Führe Linting aus: `npm run lint`
@@ -65,31 +58,26 @@ Nach jedem Update-Batch:
 ### 6. Update-spezifische Fixes
 
 #### TypeScript Major Update
-
 - Prüfe `tsconfig.json` für deprecated Options
 - Aktualisiere `@types/*` Packages
 - Prüfe auf neue strict Checks
 
 #### React/React Native Major Update
-
 - Prüfe auf deprecated APIs
 - Aktualisiere React-Plugins (babel, etc.)
 - Teste App vollständig
 
 #### Expo Major Update
-
 - Folge Expo Upgrade Guide: `npx expo upgrade`
 - Prüfe `app.json` für neue Config-Optionen
 - Teste auf realen Devices
 
 #### Build Tools (Webpack, Vite, etc.)
-
 - Prüfe Config-Files für Breaking Changes
 - Teste Build-Output
 - Prüfe Bundle-Size
 
 ### 7. Lock-File aktualisieren
-
 - Stelle sicher dass `package-lock.json` committed wird
 - Prüfe auf ungewollte Dependency-Änderungen:
   ```bash
@@ -98,13 +86,10 @@ Nach jedem Update-Batch:
 - Falls zu viele Änderungen: Nutze `npm ci` statt `npm install` für sauberen State
 
 ### 8. Dokumentation
-
 - Aktualisiere CHANGELOG.md:
   ```markdown
   ## [Version] - YYYY-MM-DD
-
   ### Dependencies
-
   - Updated [package] from X.Y.Z to A.B.C
   - Fixed security vulnerability in [package]
   ```
@@ -112,7 +97,6 @@ Nach jedem Update-Batch:
 - Aktualisiere README falls Versions-Anforderungen ändern (z.B. Node.js Version)
 
 ### 9. Commit & PR erstellen
-
 - Erstelle Feature-Branch: `git checkout -b chore/dependency-update-[YYYY-MM-DD]`
 - Commit Änderungen:
   ```bash
@@ -120,7 +104,6 @@ Nach jedem Update-Batch:
   git commit -m "chore: Update dependencies and fix security vulnerabilities"
   ```
 - Erstelle PR:
-
   ```bash
   gh pr create --base testing --title "chore: Dependency Update [Date]" --body "$(cat <<EOF
   ## Dependency Updates
@@ -148,7 +131,6 @@ Nach jedem Update-Batch:
   ```
 
 ### 10. Post-Update Monitoring
-
 - Teste App gründlich (manuell und automatisiert)
 - Achte auf Performance-Regression
 - Monitore Error-Logs nach Deployment
@@ -157,14 +139,12 @@ Nach jedem Update-Batch:
 ## Sicherheitschecks
 
 **KRITISCH - Besondere Vorsicht bei:**
-
 - ❌ Major Updates von Core-Dependencies (React, TypeScript, etc.)
 - ❌ Updates die `node_modules` Struktur stark ändern
 - ❌ Dependencies mit vielen Downstream-Dependencies
 - ❌ Critical Security Fixes die Breaking Changes enthalten
 
 **Immer testen:**
-
 - ✅ Vollständiger Test-Suite Durchlauf
 - ✅ Build erfolgreich
 - ✅ App startet und funktioniert
@@ -173,7 +153,6 @@ Nach jedem Update-Batch:
 ## Rollback-Strategie
 
 Falls nach Update Probleme auftreten:
-
 ```bash
 # Rollback zu vorheriger Version
 git checkout HEAD~1 package.json package-lock.json
@@ -188,33 +167,30 @@ git commit -m "revert: Rollback dependency update due to [reason]"
 ## Automatisierung (Optional)
 
 ### Dependabot Configuration
-
 Erstelle `.github/dependabot.yml`:
-
 ```yaml
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     open-pull-requests-limit: 5
     reviewers:
-      - 'your-username'
+      - "your-username"
     labels:
-      - 'dependencies'
-      - 'automated'
+      - "dependencies"
+      - "automated"
     # Gruppiere Minor/Patch Updates
     groups:
       development-dependencies:
-        dependency-type: 'development'
+        dependency-type: "development"
         update-types:
-          - 'minor'
-          - 'patch'
+          - "minor"
+          - "patch"
 ```
 
 ### Renovate (Alternative zu Dependabot)
-
 - Mehr Konfigurationsmöglichkeiten
 - Automatische Merge für Patch-Updates möglich
 - Bessere Gruppierung von Updates
@@ -222,7 +198,6 @@ updates:
 ## Best Practices
 
 ✅ **Do:**
-
 - Regelmäßig updaten (mindestens monatlich)
 - Security-Updates sofort anwenden
 - CHANGELOG dokumentieren
@@ -230,7 +205,6 @@ updates:
 - Lock-Files committen
 
 ❌ **Don't:**
-
 - Nicht alle Updates blind installieren
 - Nicht ohne Tests updaten
 - Nicht Major Updates kurz vor Release

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -52,21 +52,27 @@ Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für
 - Falls neue Features/Breaking Changes: Schlage CHANGELOG-Eintrag vor
 - Prüfe ob README/Docs aktualisiert werden müssen
 
-### 6. Merge-Gate (review-gate) – automatischer Claude-Review + Autofix
+### 6. Merge-Gate (review-gate) + KI-Review
 
-Der Workflow `reusable-pr-review.yml` korrigiert den PR automatisch und reviewt
-den End-Stand, dann setzt er den required Status-Check **`review-gate`** und ein Label:
+**Kostenloses Gate (automatisch, keine API-Kosten):** Der Workflow
+`reusable-mergeability.yml` läuft bei jedem PR, postet einen Sticky-Kommentar
+(Zielbranch, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den required
+Status-Check **`review-gate`**:
+- **kein Merge-Konflikt → grün** → Merge möglich (sofern auch CI grün ist).
+- **Merge-Konflikt → rot** → Branch aktualisieren.
 
-1. **Autofix:** Ein Claude-Agent fixt alle umsetzbaren Findings selbst (Commit `[auto]` + Push).
-2. **Review:** bewertet den korrigierten Stand:
-   - **Keine offenen Findings → grün** + Label `ready to merge` → Merge frei.
-   - **Findings übrig → rot** + Inline-Kommentare + Label `needs human review`.
+**Tiefer KI-Review (primärer Weg, abo-basiert, ohne Pay-per-Token):** Führe das
+Slash-Command `/review` (bzw. `/code-review --comment`) aus Claude Code aus —
+lokal am PC **oder** in einer Web-Session vom Telefon. Das ist durch dein
+Pro/Max-Abo gedeckt und kostet keine metered API-Token. Mit `--comment` werden die
+Findings als PR-Kommentare gepostet, mit `--fix` direkt im Working-Tree umgesetzt.
 
-Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer Lauf.
+**Optionaler API-Fallback (kostet metered API):** Setze das Label **`ai-review`**
+am PR → `pr-review.yml` postet einen beratenden Claude-Review (Haiku). Dieser
+blockiert den Merge **nicht** — er ergänzt nur das kostenlose Gate.
 
-> ⚠️ Es gibt **kein** manuelles Quittierungs-Label mehr. Den roten Gate öffnet nur
-> ein sauberer Review (alle Findings gelöst). Solange `needs human review` gesetzt
-> ist: **nicht mergen**, bis die offenen Punkte geklärt sind.
+> ℹ️ Der KI-Review ist beratend; verbindlich für den Merge sind die kostenlosen,
+> deterministischen Checks (CI grün + `review-gate` grün + keine Konflikte).
 
 ### 7. Merge vorbereiten
 - Prüfe ob alle Checks grün sind (inkl. `review-gate`)
@@ -129,7 +135,7 @@ Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer 
 **KRITISCH - NIEMALS automatisch mergen wenn:**
 - ❌ CI/CD Tests fehlgeschlagen
 - ❌ Merge Conflicts vorhanden
-- ❌ `review-gate` ist rot bzw. Label `needs human review` gesetzt (offene Findings erst klären)
+- ❌ `review-gate` ist rot (Merge-Konflikt – erst Branch aktualisieren)
 - ❌ Target-Branch ist `main` oder `production` (extra Vorsicht, nur mit Freigabe + `--admin`)
 
 **Immer fragen vor:**

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,58 @@
+# Security Review (Cross-Project)
+
+Globaler Security-Scan über alle lokalen Projekte mit konsolidiertem Report (Issue #7).
+
+> **Ablageort:** global unter `~/.claude/commands/security-review.md`, nicht pro Projekt.
+> Begründung: scannt projektübergreifend, gehört nicht in ein einzelnes Repo.
+
+## Ziel
+Alle lokalen Projekt-Repositories auf Secrets, Fingerprints, getrackte sensible Dateien
+und Gitignore-Lücken prüfen – ein zusammengefasster Bericht statt sieben Einzelläufe.
+
+## Workflow
+
+### 1. Projekte ermitteln
+- Bestimme die zu prüfenden Repos (Standard: alle App-Projekte im Workspace).
+- Pro Repo: ist es ein Git-Repo? Aktueller Branch? Uncommitted Changes?
+
+### 2. Pro Projekt scannen
+Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
+
+- **Signing-Fingerprints** (SHA1/SHA256 Colon-Hex):
+  ```bash
+  git -C "$repo" grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock'
+  ```
+- **Hardcodierte API-Keys / Tokens:**
+  ```bash
+  git -C "$repo" grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' -- . ':!*.lock'
+  ```
+- **Getrackte sensible Dateien:** (nur konventionell-geheime .env – nicht committete `.env.<environment>`-Config)
+  ```bash
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\.[^/]*\.local$)'
+  ```
+- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.local`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`. `.env.<environment>` mit reiner Public-Config ist erlaubt.
+- **`docs/private/` nicht getrackt?**
+- **`npm audit`** (falls `package.json` vorhanden) – Vulnerabilities zählen.
+
+### 3. Befunde einordnen
+- Bekannte False Positives kennzeichnen (z.B. CrUX-Demo-Key in `@react-native/debugger-frontend`).
+- Severity zuordnen: 🔴 Secret/Fingerprint getrackt · 🟡 Gitignore-Lücke · 🟢 nur Hinweis.
+
+### 4. Konsolidierter Report
+Tabelle über alle Projekte:
+
+| Projekt | Fingerprints | Secrets | Sensible Dateien | Gitignore | npm audit |
+|---|---|---|---|---|---|
+| ... | ✅/❌ | ✅/❌ | ✅/❌ | ✅/⚠️ | 0 / N |
+
+- Anschließend priorisierte Handlungsempfehlungen (kritischste zuerst).
+- Nichts automatisch ändern – nur berichten und Fixes vorschlagen.
+
+## Sicherheitschecks
+- **Niemals** gefundene Secrets im Klartext in Commits/Issues/Logs ausgeben – nur Datei + Zeile.
+- Bei echtem Leak: sofort als kritisch markieren, Rotation + History-Bereinigung empfehlen.
+
+## Best Practices
+✅ Regelmäßig laufen lassen (z.B. wöchentlich, ergänzend zu `weekly-audit.yml`).
+✅ Public-Repos strenger behandeln (alle Workspace-Projekte sind öffentlich).
+❌ Keine destruktiven Aktionen ohne Rückfrage (kein `git filter-repo` etc. automatisch).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,3 +257,32 @@ npm run test:coverage # Coverage
 - `setCrashlyticsCollectionEnabled(!__DEV__)` — kein Dev-Traffic in Firebase Console
 - `google-services.json` liegt im Projekt-Root, ist gitignored — muss nach `prebuild --clean` nicht neu abgelegt werden (kein Expo-Native-Ordner)
 - **Paketname für Firebase**: `com.sven4321.trainer1x1` (Play-Store-Paketname, nicht `com.devsven.x1x1trainer` aus app.json!)
+
+<!-- GLOBAL POLICY:START -->
+
+## [GLOBAL POLICY]
+
+> Automatisch synchronisiert aus project-templates (Issue #7). Nicht manuell editieren –
+> Änderungen hier werden beim nächsten Sync überschrieben. Quelle anpassen statt lokal.
+
+- PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
+- Merge auf `main` nur mit expliziter schriftlicher Freigabe
+- `--delete-branch` nur für Feature-Branches (nie staging/testing)
+- **Lokales Branch-Cleanup:** `main` und `testing` NIE löschen — auch nicht beim Bulk-Delete verwaister `[gone]`-Branches. Ein fehlender `origin/main`/`origin/testing` ist ein **wiederherzustellender Defekt** (lokal behalten, nach origin zurückpushen), kein Aufräum-Signal.
+- `--no-verify` nur auf explizite Bitte
+- **Vor jedem Push: lokale Tests ausführen** (`npm test` bzw. projektspezifischer Test-Befehl) – kein Push ohne grüne lokale Tests
+- **Kein Merge bei CI-Fail** – Branch Protection erzwingt das technisch; nie mit `--admin` umgehen außer auf explizite Bitte
+
+## [ANDROID BUILD – PFLICHTREGELN]
+
+- **Git-Tag** nach jedem Play-Store-Upload setzen: `git tag vX.Y.Z && git push origin vX.Y.Z` – der Tag markiert den tatsächlich veröffentlichten Stand und dient als Changelog-Baseline für den nächsten Build
+- **EAS Local Build (DrawFromMemory):** Workingdir vor jedem Build leeren: `rm -rf ~/tmp/eas-build && mkdir -p ~/tmp/eas-build` – ein nicht-leeres Verzeichnis bricht den Build sofort ab
+- **Disk-Check vor EAS Build:** Skia-Libraries benötigen ~5–8 GB. Bei < 5 GB frei: `npm cache clean --force && rm -rf ~/.npm/_npx` (~13 GB, sicher löschbar)
+- **JAVA_HOME** für EAS/Expo-Builds explizit auf Android Studio JBR setzen: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
+- **Gradle-Lock nach Absturz:** Bei "Cannot lock file hash cache"-Fehler Daemons stoppen: `pkill -f GradleDaemon`, dann Workingdir leeren und neu starten
+- **AAB-Archiv:** Gebaute Release-AABs in einem **gitignored** `aab-archive/`-Verzeichnis im Repo-Root ablegen (in `.gitignore` aufnehmen – AABs sind 3–110 MB und gehören nie in die Git-History). Benennung: `<Projekt>-vX.Y.Z-vc<versionCode>-YYYY-MM-DD.aab`. **Retention: max. 2 Dateien** (aktuelles Release + ein Vorgänger für schnelles Rollback); ältere AABs löschen. Der Git-Tag `vX.Y.Z` ist die eigentliche Release-Baseline – ältere AABs lassen sich daraus jederzeit neu bauen.
+
+## [CI – CACHE-CLEANUP]
+
+- **Cache-Cleanup-Workflow** (`.github/workflows/cache-cleanup.yml`) in jedem Repo mit GitHub-Actions-Caches: löscht wöchentlich (So 03:00 UTC) bzw. on-demand alle Action-Caches älter als der jeweils letzte Lauf. GitHub-Limit ist 10 GB pro Repo – ohne Cleanup laufen Build-Caches (node_modules, Gradle, Expo) voll und verdrängen frische Einträge. Vorlage: `cache-cleanup.yml` in project-templates.
+<!-- GLOBAL POLICY:END -->


### PR DESCRIPTION
## Was

Synchronisiert die aus project-templates verwalteten Doku-Dateien in dieses Repo.

- **CLAUDE.md**: GLOBAL POLICY / ANDROID BUILD / CI-CACHE-CLEANUP Block ergänzt
- **.claude/commands/**: `aufräumen`, `dependency-update`, `pr-review` aktualisiert (neues review-gate-Modell + KI-Review via Abo statt Pay-per-Token); `cache-clean` + `security-review` neu

## Bewusst NICHT übernommen

`.prettierrc.json`: die project-templates-Version ist älter (`arrowParens: 'avoid'` statt Repo-Stand `'always'`) und würde 36 Produktionsdateien unnötig reformatieren. Die **Quelle in project-templates** muss stattdessen an den Repo-Stand nachgezogen werden.

## Tests

- `npm test`: 17 Suites grün, 541 passed / 3 skipped
- `npm run format:check`: sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)