### PR TITLE
Fix #284: Begrüßungsschirm für die Lernreise

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,7 @@ import { BadgeUnlockToast } from './components/BadgeUnlockToast';
 import { FloatingStars } from './components/FloatingStars';
 import { ProfilePickerModal } from './components/ProfilePickerModal';
 import { LernreiseModal } from './components/LernreiseModal';
+import { LernreiseIntroModal } from './components/LernreiseIntroModal';
 import {
   saveSessionRecord,
   getStreakData,
@@ -52,6 +53,8 @@ import {
   getOnboardingDone,
   setOnboardingDone,
   resetOnboarding,
+  getLernreiseIntroDone,
+  setLernreiseIntroDone,
   getStorageItem,
   migrateToProfiles,
   getProfiles,
@@ -91,6 +94,7 @@ export default function App() {
   const [badgesVisible, setBadgesVisible] = useState(false);
   const [profilePickerVisible, setProfilePickerVisible] = useState(false);
   const [lernreiseVisible, setLernreiseVisible] = useState(false);
+  const [lernreiseIntroVisible, setLernreiseIntroVisible] = useState(false);
   const [streakData, setStreakData] = useState<StreakData>({
     currentStreak: 0,
     lastPlayedDate: '',
@@ -202,6 +206,7 @@ export default function App() {
     badgesVisible ||
     profilePickerVisible ||
     lernreiseVisible ||
+    lernreiseIntroVisible ||
     streakWarningVisible ||
     onboardingVisible ||
     game.gameState.showResult;
@@ -487,7 +492,14 @@ export default function App() {
             setProfilePickerVisible(true);
             hideMenu();
           }}
-          onOpenLernreise={() => setLernreiseVisible(true)}
+          onOpenLernreise={async () => {
+            const introDone = await getLernreiseIntroDone(activeProfileIdRef.current);
+            if (introDone) {
+              setLernreiseVisible(true);
+            } else {
+              setLernreiseIntroVisible(true);
+            }
+          }}
           t={t}
         />
       )}
@@ -627,6 +639,17 @@ export default function App() {
         onClose={() => setLernreiseVisible(false)}
         colors={colors}
         profileId={activeProfile?.id}
+        t={t}
+      />
+
+      <LernreiseIntroModal
+        visible={lernreiseIntroVisible}
+        onClose={async () => {
+          await setLernreiseIntroDone(activeProfileIdRef.current);
+          setLernreiseIntroVisible(false);
+          setLernreiseVisible(true);
+        }}
+        colors={colors}
         t={t}
       />
     </SafeAreaView>

--- a/components/LernreiseIntroModal.test.tsx
+++ b/components/LernreiseIntroModal.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { LernreiseIntroModal } from './LernreiseIntroModal';
+import { getThemeColors } from '../utils/theme';
+
+const t = {
+  lernreiseIntroTitle: 'Willkommen zu deiner Lernreise!',
+  lernreiseIntroBody: 'Arbeite dich Malreihe für Malreihe von 1 bis 12 vor.',
+  lernreiseIntroPracticeHint: 'Tipp: Nutze danach den Übungsmodus.',
+  lernreiseIntroStart: "Los geht's!",
+};
+
+describe('LernreiseIntroModal', () => {
+  const colors = getThemeColors(false);
+
+  it('renders nothing meaningful when not visible', () => {
+    const { queryByText } = render(
+      <LernreiseIntroModal visible={false} onClose={jest.fn()} colors={colors} t={t} />
+    );
+    expect(queryByText(t.lernreiseIntroTitle)).toBeNull();
+  });
+
+  it('shows title, body and practice hint when visible', () => {
+    const { getByText } = render(
+      <LernreiseIntroModal visible onClose={jest.fn()} colors={colors} t={t} />
+    );
+    expect(getByText(t.lernreiseIntroTitle)).not.toBeNull();
+    expect(getByText(t.lernreiseIntroBody)).not.toBeNull();
+    expect(getByText(`💡 ${t.lernreiseIntroPracticeHint}`)).not.toBeNull();
+  });
+
+  it('calls onClose when the start button is pressed', () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <LernreiseIntroModal visible onClose={onClose} colors={colors} t={t} />
+    );
+    fireEvent.click(getByText(t.lernreiseIntroStart));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/components/LernreiseIntroModal.tsx
+++ b/components/LernreiseIntroModal.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, Modal } from 'react-native';
+import { ThemeColors } from '../types/game';
+import { modalStyles } from '../styles/modalStyles';
+import { DESIGN_TOKENS } from '../utils/constants';
+
+interface LernreiseIntroModalProps {
+  visible: boolean;
+  onClose: () => void;
+  colors: ThemeColors;
+  t: {
+    lernreiseIntroTitle: string;
+    lernreiseIntroBody: string;
+    lernreiseIntroPracticeHint: string;
+    lernreiseIntroStart: string;
+  };
+}
+
+export function LernreiseIntroModal({ visible, onClose, colors, t }: LernreiseIntroModalProps) {
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={modalStyles.overlay}>
+        <View
+          style={[modalStyles.content, styles.container, { backgroundColor: colors.settingsMenu }]}
+        >
+          <Text style={styles.emoji}>🗺️</Text>
+          <Text style={[styles.title, { color: colors.text }]}>{t.lernreiseIntroTitle}</Text>
+          <Text style={[styles.body, { color: colors.textSecondary }]}>{t.lernreiseIntroBody}</Text>
+          <View style={[styles.hintCard, { backgroundColor: colors.card }]}>
+            <Text style={[styles.hintText, { color: colors.textSecondary }]}>
+              💡 {t.lernreiseIntroPracticeHint}
+            </Text>
+          </View>
+          <TouchableOpacity
+            style={[styles.startButton, { backgroundColor: colors.gradientPrimary[0] }]}
+            onPress={onClose}
+          >
+            <Text style={styles.startButtonText}>{t.lernreiseIntroStart}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '88%',
+    maxWidth: 420,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 20,
+    alignItems: 'center',
+    gap: 12,
+  },
+  emoji: {
+    fontSize: 48,
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+  },
+  body: {
+    fontSize: 14,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  hintCard: {
+    borderRadius: 14,
+    padding: 14,
+    width: '100%',
+  },
+  hintText: {
+    fontSize: 13,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+  startButton: {
+    borderRadius: DESIGN_TOKENS.NUMPAD_BUTTON_RADIUS,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+    marginTop: 4,
+    width: '100%',
+  },
+  startButtonText: {
+    color: '#fff',
+    fontSize: 15,
+    fontFamily: DESIGN_TOKENS.FONT_UI,
+  },
+});

--- a/i18n/translations.ts
+++ b/i18n/translations.ts
@@ -189,6 +189,10 @@ export interface TranslationStrings {
   lernreiseResultBronze: string;
   lernreiseResultRetry: string;
   lernreiseBackToMap: string;
+  lernreiseIntroTitle: string;
+  lernreiseIntroBody: string;
+  lernreiseIntroPracticeHint: string;
+  lernreiseIntroStart: string;
 }
 
 export const translations: Record<Language, TranslationStrings> = {
@@ -366,6 +370,12 @@ export const translations: Record<Language, TranslationStrings> = {
     lernreiseResultBronze: 'Bronze! Well done!',
     lernreiseResultRetry: 'Not quite yet — give it another try!',
     lernreiseBackToMap: 'Back to Learning Journey',
+    lernreiseIntroTitle: 'Welcome to your Learning Journey!',
+    lernreiseIntroBody:
+      'Work through the times tables one by one, from 1 to 12. Pass a table’s test to unlock the next one and earn Bronze, Silver, or Gold.',
+    lernreiseIntroPracticeHint:
+      'Tip: use Practice Mode afterwards to automatically drill the tasks you find tricky.',
+    lernreiseIntroStart: "Let's go!",
     // Profiles
     profiles: 'Profiles',
     profilesMenu: 'Profiles',
@@ -554,6 +564,12 @@ export const translations: Record<Language, TranslationStrings> = {
     lernreiseResultBronze: 'Bronze! Gut gemacht!',
     lernreiseResultRetry: 'Noch nicht ganz – versuch es nochmal!',
     lernreiseBackToMap: 'Zurück zur Lernreise',
+    lernreiseIntroTitle: 'Willkommen zu deiner Lernreise!',
+    lernreiseIntroBody:
+      'Arbeite dich Malreihe für Malreihe von 1 bis 12 vor. Bestehe den Test einer Reihe, um die nächste freizuschalten und Bronze, Silber oder Gold zu verdienen.',
+    lernreiseIntroPracticeHint:
+      'Tipp: Nutze danach den Übungsmodus, um automatisch die Aufgaben zu festigen, die dir noch schwerfallen.',
+    lernreiseIntroStart: "Los geht's!",
     // Profiles
     profiles: 'Profile',
     profilesMenu: 'Profile',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -33,6 +33,7 @@ export const STORAGE_KEYS = {
   PROFILES: 'app-profiles',
   ACTIVE_PROFILE_ID: 'app-active-profile-id',
   ROW_MASTERY: 'app-row-mastery',
+  LERNREISE_INTRO_DONE: 'app-lernreise-intro-done',
 } as const;
 
 // Lernreise / Reihen-Meisterschaft (Issue #277 1a): one node per times table

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -372,6 +372,16 @@ export const resetOnboarding = async (): Promise<void> => {
   await setStorageItem(STORAGE_KEYS.ONBOARDING_DONE, 'pending');
 };
 
+// Lernreise intro is per-profile: each child profile sees it once on first entry.
+export const getLernreiseIntroDone = async (profileId?: string): Promise<boolean> => {
+  const value = await getStorageItem(resolveKey(STORAGE_KEYS.LERNREISE_INTRO_DONE, profileId));
+  return value === 'true';
+};
+
+export const setLernreiseIntroDone = async (profileId?: string): Promise<void> => {
+  await setStorageItem(resolveKey(STORAGE_KEYS.LERNREISE_INTRO_DONE, profileId), 'true');
+};
+
 function isValidTaskStat(r: unknown): r is TaskStat {
   if (!r || typeof r !== 'object') return false;
   const obj = r as Record<string, unknown>;


### PR DESCRIPTION
## Was

Neues `LernreiseIntroModal`, das beim ersten Öffnen der Lernreise (pro Kinderprofil, einmalig) erklärt, worum es geht, und auf den Übungsmodus verweist.

- Analog zum bestehenden `OnboardingModal`-Muster, eigenständige Komponente
- Storage-Flag `app-lernreise-intro-done` per Profil (Suffix-Pattern, wie bei allen anderen per-Profil-Daten)
- `onOpenLernreise` zeigt das Intro vor der Lernreise-Landkarte, solange nicht bestätigt
- Neue i18n-Keys `lernreiseIntro*` (DE/EN)

Vom User im Browser (localhost:8081) getestet und bestätigt: "Der Begrüßungstext für die Lernreise ist perfekt!"

## Test plan

- [x] `npm test`: 18 Suites grün, 544 passed
- [x] `npm run format:check`: sauber
- [x] Manuell im Browser getestet: Intro erscheint beim ersten Öffnen, danach nicht mehr

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)