### PR TITLE
feat: add Open Graph meta tags for social sharing / SEO

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,14 @@
     <meta name="description" content="Practice multiplication tables with different game modes" />
     <meta name="keywords" content="1x1, multiplication, trainer, math, learning, PWA, education" />
     <meta name="author" content="S540d" />
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="1x1 Trainer - Learn Multiplication" />
+    <meta property="og:description" content="Practice multiplication tables with different game modes" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://s540d.github.io/1x1_Trainer/" />
+    <meta property="og:image" content="https://s540d.github.io/1x1_Trainer/icon-512.png" />
+
     <link rel="manifest" href="/1x1_Trainer/manifest.json" />
     <link rel="icon" type="image/png" sizes="128x128" href="/1x1_Trainer/icon-128.png" />
     <link rel="icon" type="image/png" sizes="96x96" href="/1x1_Trainer/icon-96.png" />


### PR DESCRIPTION
## Summary
- Adds `og:title`, `og:description`, `og:type`, `og:url`, and `og:image` meta tags to `public/index.html`
- `og:title`/`og:description` reuse the existing `<title>`/meta description content
- `og:url` points to the deployed GitHub Pages URL (`https://s540d.github.io/1x1_Trainer/`)
- `og:image` uses the existing `icon-512.png` asset already served from `public/`
- No changes to `sitemap.xml`, `robots.txt`, or the existing title/meta description — those were already correct

Part of S540d/project-templates#95

## Test plan
- [x] `npm test` — 547 passed, 3 skipped, 18 suites
- [x] `npm run build:web` fails locally on Node 22 due to a pre-existing, unrelated `expo-cli` telemetry bug (`getOriginalEnvValue is not a function`) — reproduced identically on the base branch without my changes, so unrelated to this PR. CI runs Node 20 and should be unaffected.
- [x] `git push` pre-push hook (prettier format:check on ts/tsx/js/jsx/json/md) passed