### PR TITLE
chore: aab-archive/ in .gitignore aufnehmen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ expo-env.d.ts
 *.aab
 *.apk
 builds/
+aab-archive/
 
 # Metro
 .metro-health-check*


### PR DESCRIPTION
## Summary
Nimmt das lokale AAB-Archiv-Verzeichnis `aab-archive/` explizit in `.gitignore` auf.

Kontext: Beim lokalen v1.5.0-AAB-Build wird der signierte Bundle nach `aab-archive/` kopiert (Build-Workflow-Konvention: max. 2 AABs für schnelles Rollback). Die AABs selbst sind durch `*.aab` bereits ignoriert — dieser Zusatz macht die Absicht explizit und deckt auch etwaige andere Artefakte im Verzeichnis ab.

## Test plan
- [x] `git check-ignore aab-archive/foo.aab` greift (bereits via `*.aab`)
- Keine Code-Änderung, kein Testlauf nötig

🤖 Generated with [Claude Code](https://claude.com/claude-code)